### PR TITLE
set typedoc revision to main

### DIFF
--- a/apps/docs/docs/api/classes/BaseEmbedding.md
+++ b/apps/docs/docs/api/classes/BaseEmbedding.md
@@ -36,7 +36,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Embedding.ts:206](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L206)
+[Embedding.ts:206](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L206)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:205](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L205)
+[Embedding.ts:205](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L205)
 
 ___
 
@@ -78,4 +78,4 @@ ___
 
 #### Defined in
 
-[Embedding.ts:197](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L197)
+[Embedding.ts:197](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L197)

--- a/apps/docs/docs/api/classes/BaseIndex.md
+++ b/apps/docs/docs/api/classes/BaseIndex.md
@@ -43,7 +43,7 @@ they can be retrieved for our queries.
 
 #### Defined in
 
-[indices/BaseIndex.ts:122](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L122)
+[indices/BaseIndex.ts:122](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L122)
 
 ## Properties
 
@@ -53,7 +53,7 @@ they can be retrieved for our queries.
 
 #### Defined in
 
-[indices/BaseIndex.ts:117](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L117)
+[indices/BaseIndex.ts:117](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L117)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L119)
+[indices/BaseIndex.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L119)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:120](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L120)
+[indices/BaseIndex.ts:120](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L120)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L115)
+[indices/BaseIndex.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L115)
 
 ___
 
@@ -93,7 +93,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L116)
+[indices/BaseIndex.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L116)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:118](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L118)
+[indices/BaseIndex.ts:118](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L118)
 
 ## Methods
 
@@ -128,7 +128,7 @@ and response synthezier if they are not provided.
 
 #### Defined in
 
-[indices/BaseIndex.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L142)
+[indices/BaseIndex.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L142)
 
 ___
 
@@ -150,4 +150,4 @@ Create a new retriever from the index.
 
 #### Defined in
 
-[indices/BaseIndex.ts:135](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L135)
+[indices/BaseIndex.ts:135](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L135)

--- a/apps/docs/docs/api/classes/BaseNode.md
+++ b/apps/docs/docs/api/classes/BaseNode.md
@@ -28,7 +28,7 @@ Generic abstract class for retrievable nodes
 
 #### Defined in
 
-[Node.ts:48](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L48)
+[Node.ts:48](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L48)
 
 ## Properties
 
@@ -38,7 +38,7 @@ Generic abstract class for retrievable nodes
 
 #### Defined in
 
-[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L39)
+[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L39)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L43)
+[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L43)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L44)
+[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L44)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L46)
+[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L46)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L38)
+[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L38)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L42)
+[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L42)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L45)
+[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L45)
 
 ## Accessors
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L104)
+[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L104)
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 #### Defined in
 
-[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L84)
+[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L84)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L58)
+[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L58)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L94)
+[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L94)
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L72)
+[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L72)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L62)
+[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L62)
 
 ## Methods
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L124)
+[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L124)
 
 ___
 
@@ -216,7 +216,7 @@ ___
 
 #### Defined in
 
-[Node.ts:54](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L54)
+[Node.ts:54](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L54)
 
 ___
 
@@ -230,7 +230,7 @@ ___
 
 #### Defined in
 
-[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L116)
+[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L116)
 
 ___
 
@@ -250,7 +250,7 @@ ___
 
 #### Defined in
 
-[Node.ts:55](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L55)
+[Node.ts:55](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L55)
 
 ___
 
@@ -264,7 +264,7 @@ ___
 
 #### Defined in
 
-[Node.ts:52](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L52)
+[Node.ts:52](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L52)
 
 ___
 
@@ -284,4 +284,4 @@ ___
 
 #### Defined in
 
-[Node.ts:56](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L56)
+[Node.ts:56](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L56)

--- a/apps/docs/docs/api/classes/CallbackManager.md
+++ b/apps/docs/docs/api/classes/CallbackManager.md
@@ -24,7 +24,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:67](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L67)
+[callbacks/CallbackManager.ts:67](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L67)
 
 ## Properties
 
@@ -52,7 +52,7 @@ CallbackManagerMethods.onLLMStream
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:64](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L64)
+[callbacks/CallbackManager.ts:64](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L64)
 
 ___
 
@@ -80,4 +80,4 @@ CallbackManagerMethods.onRetrieve
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:65](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L65)
+[callbacks/CallbackManager.ts:65](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L65)

--- a/apps/docs/docs/api/classes/CompactAndRefine.md
+++ b/apps/docs/docs/api/classes/CompactAndRefine.md
@@ -34,7 +34,7 @@ CompactAndRefine is a slight variation of Refine that first compacts the text ch
 
 #### Defined in
 
-[ResponseSynthesizer.ts:78](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L78)
+[ResponseSynthesizer.ts:78](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L78)
 
 ## Properties
 
@@ -48,7 +48,7 @@ CompactAndRefine is a slight variation of Refine that first compacts the text ch
 
 #### Defined in
 
-[ResponseSynthesizer.ts:76](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L76)
+[ResponseSynthesizer.ts:76](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L76)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L74)
+[ResponseSynthesizer.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L74)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L75)
+[ResponseSynthesizer.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L75)
 
 ## Methods
 
@@ -103,4 +103,4 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:181](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L181)
+[ResponseSynthesizer.ts:181](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L181)

--- a/apps/docs/docs/api/classes/CondenseQuestionChatEngine.md
+++ b/apps/docs/docs/api/classes/CondenseQuestionChatEngine.md
@@ -37,7 +37,7 @@ data, or are very referential to previous context.
 
 #### Defined in
 
-[ChatEngine.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L75)
+[ChatEngine.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L75)
 
 ## Properties
 
@@ -47,7 +47,7 @@ data, or are very referential to previous context.
 
 #### Defined in
 
-[ChatEngine.ts:71](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L71)
+[ChatEngine.ts:71](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L71)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[ChatEngine.ts:73](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L73)
+[ChatEngine.ts:73](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L73)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[ChatEngine.ts:70](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L70)
+[ChatEngine.ts:70](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L70)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[ChatEngine.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L72)
+[ChatEngine.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L72)
 
 ## Methods
 
@@ -104,7 +104,7 @@ Send message along with the class's current chat history to the LLM.
 
 #### Defined in
 
-[ChatEngine.ts:100](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L100)
+[ChatEngine.ts:100](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L100)
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 #### Defined in
 
-[ChatEngine.ts:89](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L89)
+[ChatEngine.ts:89](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L89)
 
 ___
 
@@ -145,4 +145,4 @@ Resets the chat history so that it's empty.
 
 #### Defined in
 
-[ChatEngine.ts:118](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L118)
+[ChatEngine.ts:118](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L118)

--- a/apps/docs/docs/api/classes/ContextChatEngine.md
+++ b/apps/docs/docs/api/classes/ContextChatEngine.md
@@ -31,7 +31,7 @@ ideally allowing the appropriate context to be surfaced for each query.
 
 #### Defined in
 
-[ChatEngine.ts:133](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L133)
+[ChatEngine.ts:133](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L133)
 
 ## Properties
 
@@ -41,7 +41,7 @@ ideally allowing the appropriate context to be surfaced for each query.
 
 #### Defined in
 
-[ChatEngine.ts:131](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L131)
+[ChatEngine.ts:131](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L131)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[ChatEngine.ts:130](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L130)
+[ChatEngine.ts:130](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L130)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[ChatEngine.ts:129](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L129)
+[ChatEngine.ts:129](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L129)
 
 ## Methods
 
@@ -88,7 +88,7 @@ Send message along with the class's current chat history to the LLM.
 
 #### Defined in
 
-[ChatEngine.ts:144](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L144)
+[ChatEngine.ts:144](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L144)
 
 ___
 
@@ -108,4 +108,4 @@ Resets the chat history so that it's empty.
 
 #### Defined in
 
-[ChatEngine.ts:182](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L182)
+[ChatEngine.ts:182](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L182)

--- a/apps/docs/docs/api/classes/Document.md
+++ b/apps/docs/docs/api/classes/Document.md
@@ -32,7 +32,7 @@ A document is just a special text node with a docId.
 
 #### Defined in
 
-[Node.ts:216](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L216)
+[Node.ts:216](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L216)
 
 ## Properties
 
@@ -46,7 +46,7 @@ A document is just a special text node with a docId.
 
 #### Defined in
 
-[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L39)
+[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L39)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[Node.ts:139](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L139)
+[Node.ts:139](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L139)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L43)
+[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L43)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L44)
+[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L44)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L46)
+[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L46)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L38)
+[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L38)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L42)
+[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L42)
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 #### Defined in
 
-[Node.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L142)
+[Node.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L142)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L45)
+[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L45)
 
 ___
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[Node.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L138)
+[Node.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L138)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[Node.ts:137](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L137)
+[Node.ts:137](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L137)
 
 ## Accessors
 
@@ -204,7 +204,7 @@ TextNode.childNodes
 
 #### Defined in
 
-[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L104)
+[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L104)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[Node.ts:225](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L225)
+[Node.ts:225](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L225)
 
 ___
 
@@ -236,7 +236,7 @@ TextNode.nextNode
 
 #### Defined in
 
-[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L84)
+[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L84)
 
 ___
 
@@ -254,7 +254,7 @@ TextNode.nodeId
 
 #### Defined in
 
-[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L58)
+[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L58)
 
 ___
 
@@ -272,7 +272,7 @@ TextNode.parentNode
 
 #### Defined in
 
-[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L94)
+[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L94)
 
 ___
 
@@ -290,7 +290,7 @@ TextNode.prevNode
 
 #### Defined in
 
-[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L72)
+[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L72)
 
 ___
 
@@ -308,7 +308,7 @@ TextNode.sourceNode
 
 #### Defined in
 
-[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L62)
+[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L62)
 
 ## Methods
 
@@ -326,7 +326,7 @@ TextNode.sourceNode
 
 #### Defined in
 
-[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L124)
+[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L124)
 
 ___
 
@@ -344,7 +344,7 @@ ___
 
 #### Defined in
 
-[Node.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L149)
+[Node.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L149)
 
 ___
 
@@ -368,7 +368,7 @@ ___
 
 #### Defined in
 
-[Node.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L157)
+[Node.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L157)
 
 ___
 
@@ -386,7 +386,7 @@ ___
 
 #### Defined in
 
-[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L116)
+[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L116)
 
 ___
 
@@ -410,7 +410,7 @@ ___
 
 #### Defined in
 
-[Node.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L162)
+[Node.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L162)
 
 ___
 
@@ -433,7 +433,7 @@ ___
 
 #### Defined in
 
-[Node.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L187)
+[Node.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L187)
 
 ___
 
@@ -451,7 +451,7 @@ ___
 
 #### Defined in
 
-[Node.ts:191](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L191)
+[Node.ts:191](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L191)
 
 ___
 
@@ -469,7 +469,7 @@ ___
 
 #### Defined in
 
-[Node.ts:221](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L221)
+[Node.ts:221](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L221)
 
 ___
 
@@ -493,4 +493,4 @@ ___
 
 #### Defined in
 
-[Node.ts:183](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L183)
+[Node.ts:183](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L183)

--- a/apps/docs/docs/api/classes/InMemoryFileSystem.md
+++ b/apps/docs/docs/api/classes/InMemoryFileSystem.md
@@ -26,7 +26,7 @@ A filesystem implementation that stores files in memory.
 
 #### Defined in
 
-[storage/FileSystem.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L25)
+[storage/FileSystem.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L25)
 
 ## Methods
 
@@ -50,7 +50,7 @@ A filesystem implementation that stores files in memory.
 
 #### Defined in
 
-[storage/FileSystem.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L38)
+[storage/FileSystem.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L38)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L44)
+[storage/FileSystem.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L44)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L31)
+[storage/FileSystem.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L31)
 
 ___
 
@@ -126,4 +126,4 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L27)
+[storage/FileSystem.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L27)

--- a/apps/docs/docs/api/classes/IndexDict.md
+++ b/apps/docs/docs/api/classes/IndexDict.md
@@ -33,7 +33,7 @@ The underlying structure of each index.
 
 #### Defined in
 
-[indices/BaseIndex.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L19)
+[indices/BaseIndex.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L19)
 
 ## Properties
 
@@ -43,7 +43,7 @@ The underlying structure of each index.
 
 #### Defined in
 
-[indices/BaseIndex.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L46)
+[indices/BaseIndex.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L46)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L16)
+[indices/BaseIndex.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L16)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L45)
+[indices/BaseIndex.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L45)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L17)
+[indices/BaseIndex.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L17)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L47)
+[indices/BaseIndex.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L47)
 
 ## Methods
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:56](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L56)
+[indices/BaseIndex.ts:56](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L56)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:49](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L49)
+[indices/BaseIndex.ts:49](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L49)
 
 ___
 
@@ -148,4 +148,4 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L61)
+[indices/BaseIndex.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L61)

--- a/apps/docs/docs/api/classes/IndexList.md
+++ b/apps/docs/docs/api/classes/IndexList.md
@@ -33,7 +33,7 @@ The underlying structure of each index.
 
 #### Defined in
 
-[indices/BaseIndex.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L19)
+[indices/BaseIndex.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L19)
 
 ## Properties
 
@@ -47,7 +47,7 @@ The underlying structure of each index.
 
 #### Defined in
 
-[indices/BaseIndex.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L16)
+[indices/BaseIndex.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L16)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:85](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L85)
+[indices/BaseIndex.ts:85](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L85)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L17)
+[indices/BaseIndex.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L17)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:86](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L86)
+[indices/BaseIndex.ts:86](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L86)
 
 ## Methods
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:88](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L88)
+[indices/BaseIndex.ts:88](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L88)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L31)
+[indices/BaseIndex.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L31)
 
 ___
 
@@ -137,4 +137,4 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:92](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L92)
+[indices/BaseIndex.ts:92](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L92)

--- a/apps/docs/docs/api/classes/IndexNode.md
+++ b/apps/docs/docs/api/classes/IndexNode.md
@@ -32,7 +32,7 @@ TextNode is the default node type for text. Most common node type in LlamaIndex.
 
 #### Defined in
 
-[Node.ts:144](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L144)
+[Node.ts:144](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L144)
 
 ## Properties
 
@@ -46,7 +46,7 @@ TextNode is the default node type for text. Most common node type in LlamaIndex.
 
 #### Defined in
 
-[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L39)
+[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L39)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[Node.ts:139](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L139)
+[Node.ts:139](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L139)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L43)
+[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L43)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L44)
+[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L44)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L46)
+[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L46)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L38)
+[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L38)
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 #### Defined in
 
-[Node.ts:205](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L205)
+[Node.ts:205](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L205)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L42)
+[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L42)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[Node.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L142)
+[Node.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L142)
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L45)
+[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L45)
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 #### Defined in
 
-[Node.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L138)
+[Node.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L138)
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 #### Defined in
 
-[Node.ts:137](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L137)
+[Node.ts:137](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L137)
 
 ## Accessors
 
@@ -214,7 +214,7 @@ TextNode.childNodes
 
 #### Defined in
 
-[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L104)
+[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L104)
 
 ___
 
@@ -232,7 +232,7 @@ TextNode.nextNode
 
 #### Defined in
 
-[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L84)
+[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L84)
 
 ___
 
@@ -250,7 +250,7 @@ TextNode.nodeId
 
 #### Defined in
 
-[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L58)
+[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L58)
 
 ___
 
@@ -268,7 +268,7 @@ TextNode.parentNode
 
 #### Defined in
 
-[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L94)
+[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L94)
 
 ___
 
@@ -286,7 +286,7 @@ TextNode.prevNode
 
 #### Defined in
 
-[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L72)
+[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L72)
 
 ___
 
@@ -304,7 +304,7 @@ TextNode.sourceNode
 
 #### Defined in
 
-[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L62)
+[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L62)
 
 ## Methods
 
@@ -322,7 +322,7 @@ TextNode.sourceNode
 
 #### Defined in
 
-[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L124)
+[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L124)
 
 ___
 
@@ -340,7 +340,7 @@ ___
 
 #### Defined in
 
-[Node.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L149)
+[Node.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L149)
 
 ___
 
@@ -364,7 +364,7 @@ ___
 
 #### Defined in
 
-[Node.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L157)
+[Node.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L157)
 
 ___
 
@@ -382,7 +382,7 @@ ___
 
 #### Defined in
 
-[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L116)
+[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L116)
 
 ___
 
@@ -406,7 +406,7 @@ ___
 
 #### Defined in
 
-[Node.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L162)
+[Node.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L162)
 
 ___
 
@@ -429,7 +429,7 @@ ___
 
 #### Defined in
 
-[Node.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L187)
+[Node.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L187)
 
 ___
 
@@ -447,7 +447,7 @@ ___
 
 #### Defined in
 
-[Node.ts:191](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L191)
+[Node.ts:191](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L191)
 
 ___
 
@@ -465,7 +465,7 @@ ___
 
 #### Defined in
 
-[Node.ts:207](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L207)
+[Node.ts:207](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L207)
 
 ___
 
@@ -489,4 +489,4 @@ ___
 
 #### Defined in
 
-[Node.ts:183](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L183)
+[Node.ts:183](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L183)

--- a/apps/docs/docs/api/classes/IndexStruct.md
+++ b/apps/docs/docs/api/classes/IndexStruct.md
@@ -31,7 +31,7 @@ The underlying structure of each index.
 
 #### Defined in
 
-[indices/BaseIndex.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L19)
+[indices/BaseIndex.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L19)
 
 ## Properties
 
@@ -41,7 +41,7 @@ The underlying structure of each index.
 
 #### Defined in
 
-[indices/BaseIndex.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L16)
+[indices/BaseIndex.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L16)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L17)
+[indices/BaseIndex.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L17)
 
 ## Methods
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L31)
+[indices/BaseIndex.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L31)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L24)
+[indices/BaseIndex.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L24)

--- a/apps/docs/docs/api/classes/LLMQuestionGenerator.md
+++ b/apps/docs/docs/api/classes/LLMQuestionGenerator.md
@@ -26,7 +26,7 @@ LLMQuestionGenerator uses the LLM to generate new questions for the LLM using to
 
 #### Defined in
 
-[QuestionGenerator.ts:34](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L34)
+[QuestionGenerator.ts:34](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L34)
 
 ## Properties
 
@@ -36,7 +36,7 @@ LLMQuestionGenerator uses the LLM to generate new questions for the LLM using to
 
 #### Defined in
 
-[QuestionGenerator.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L30)
+[QuestionGenerator.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L30)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[QuestionGenerator.ts:32](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L32)
+[QuestionGenerator.ts:32](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L32)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[QuestionGenerator.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L31)
+[QuestionGenerator.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L31)
 
 ## Methods
 
@@ -81,4 +81,4 @@ ___
 
 #### Defined in
 
-[QuestionGenerator.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L40)
+[QuestionGenerator.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L40)

--- a/apps/docs/docs/api/classes/ListIndex.md
+++ b/apps/docs/docs/api/classes/ListIndex.md
@@ -32,7 +32,7 @@ A ListIndex keeps nodes in a sequential list structure
 
 #### Defined in
 
-[indices/list/ListIndex.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L43)
+[indices/list/ListIndex.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L43)
 
 ## Properties
 
@@ -46,7 +46,7 @@ A ListIndex keeps nodes in a sequential list structure
 
 #### Defined in
 
-[indices/BaseIndex.ts:117](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L117)
+[indices/BaseIndex.ts:117](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L117)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L119)
+[indices/BaseIndex.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L119)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:120](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L120)
+[indices/BaseIndex.ts:120](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L120)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L115)
+[indices/BaseIndex.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L115)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L116)
+[indices/BaseIndex.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L116)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:118](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L118)
+[indices/BaseIndex.ts:118](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L118)
 
 ## Methods
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndex.ts:193](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L193)
+[indices/list/ListIndex.ts:193](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L193)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndex.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L187)
+[indices/list/ListIndex.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L187)
 
 ___
 
@@ -185,7 +185,7 @@ and response synthezier if they are not provided.
 
 #### Defined in
 
-[indices/list/ListIndex.ts:151](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L151)
+[indices/list/ListIndex.ts:151](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L151)
 
 ___
 
@@ -212,7 +212,7 @@ Create a new retriever from the index.
 
 #### Defined in
 
-[indices/list/ListIndex.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L138)
+[indices/list/ListIndex.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L138)
 
 ___
 
@@ -226,7 +226,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndex.ts:199](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L199)
+[indices/list/ListIndex.ts:199](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L199)
 
 ___
 
@@ -248,7 +248,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndex.ts:172](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L172)
+[indices/list/ListIndex.ts:172](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L172)
 
 ___
 
@@ -271,7 +271,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndex.ts:112](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L112)
+[indices/list/ListIndex.ts:112](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L112)
 
 ___
 
@@ -291,4 +291,4 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndex.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L47)
+[indices/list/ListIndex.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L47)

--- a/apps/docs/docs/api/classes/ListIndexLLMRetriever.md
+++ b/apps/docs/docs/api/classes/ListIndexLLMRetriever.md
@@ -31,7 +31,7 @@ LLM retriever for ListIndex.
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:64](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L64)
+[indices/list/ListIndexRetriever.ts:64](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L64)
 
 ## Properties
 
@@ -41,7 +41,7 @@ LLM retriever for ListIndex.
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:59](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L59)
+[indices/list/ListIndexRetriever.ts:59](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L59)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L58)
+[indices/list/ListIndexRetriever.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L58)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:60](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L60)
+[indices/list/ListIndexRetriever.ts:60](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L60)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:57](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L57)
+[indices/list/ListIndexRetriever.ts:57](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L57)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L61)
+[indices/list/ListIndexRetriever.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L61)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L62)
+[indices/list/ListIndexRetriever.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L62)
 
 ## Methods
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:127](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L127)
+[indices/list/ListIndexRetriever.ts:127](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L127)
 
 ___
 
@@ -134,4 +134,4 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:81](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L81)
+[indices/list/ListIndexRetriever.ts:81](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L81)

--- a/apps/docs/docs/api/classes/ListIndexRetriever.md
+++ b/apps/docs/docs/api/classes/ListIndexRetriever.md
@@ -26,7 +26,7 @@ Simple retriever for ListIndex that returns all nodes
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L22)
+[indices/list/ListIndexRetriever.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L22)
 
 ## Properties
 
@@ -36,7 +36,7 @@ Simple retriever for ListIndex that returns all nodes
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L20)
+[indices/list/ListIndexRetriever.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L20)
 
 ## Methods
 
@@ -54,7 +54,7 @@ Simple retriever for ListIndex that returns all nodes
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:48](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L48)
+[indices/list/ListIndexRetriever.ts:48](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L48)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndexRetriever.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndexRetriever.ts#L26)
+[indices/list/ListIndexRetriever.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndexRetriever.ts#L26)

--- a/apps/docs/docs/api/classes/LlamaDeuce.md
+++ b/apps/docs/docs/api/classes/LlamaDeuce.md
@@ -26,7 +26,7 @@ Llama2 LLM implementation
 
 #### Defined in
 
-[llm/LLM.ts:189](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L189)
+[llm/LLM.ts:189](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L189)
 
 ## Properties
 
@@ -36,7 +36,7 @@ Llama2 LLM implementation
 
 #### Defined in
 
-[llm/LLM.ts:186](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L186)
+[llm/LLM.ts:186](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L186)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:184](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L184)
+[llm/LLM.ts:184](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L184)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L187)
+[llm/LLM.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L187)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:185](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L185)
+[llm/LLM.ts:185](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L185)
 
 ## Methods
 
@@ -93,7 +93,7 @@ Get a chat response from the LLM
 
 #### Defined in
 
-[llm/LLM.ts:209](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L209)
+[llm/LLM.ts:209](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L209)
 
 ___
 
@@ -120,7 +120,7 @@ Get a prompt completion from the LLM
 
 #### Defined in
 
-[llm/LLM.ts:234](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L234)
+[llm/LLM.ts:234](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L234)
 
 ___
 
@@ -140,4 +140,4 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:196](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L196)
+[llm/LLM.ts:196](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L196)

--- a/apps/docs/docs/api/classes/OpenAI.md
+++ b/apps/docs/docs/api/classes/OpenAI.md
@@ -26,7 +26,7 @@ OpenAI LLM implementation
 
 #### Defined in
 
-[llm/LLM.ts:80](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L80)
+[llm/LLM.ts:80](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L80)
 
 ## Properties
 
@@ -36,7 +36,7 @@ OpenAI LLM implementation
 
 #### Defined in
 
-[llm/LLM.ts:73](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L73)
+[llm/LLM.ts:73](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L73)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:78](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L78)
+[llm/LLM.ts:78](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L78)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L74)
+[llm/LLM.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L74)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:70](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L70)
+[llm/LLM.ts:70](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L70)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:68](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L68)
+[llm/LLM.ts:68](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L68)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:76](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L76)
+[llm/LLM.ts:76](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L76)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:69](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L69)
+[llm/LLM.ts:69](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L69)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L75)
+[llm/LLM.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L75)
 
 ## Methods
 
@@ -133,7 +133,7 @@ Get a chat response from the LLM
 
 #### Defined in
 
-[llm/LLM.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L116)
+[llm/LLM.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L116)
 
 ___
 
@@ -160,7 +160,7 @@ Get a prompt completion from the LLM
 
 #### Defined in
 
-[llm/LLM.ts:154](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L154)
+[llm/LLM.ts:154](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L154)
 
 ___
 
@@ -180,4 +180,4 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:99](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L99)
+[llm/LLM.ts:99](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L99)

--- a/apps/docs/docs/api/classes/OpenAIEmbedding.md
+++ b/apps/docs/docs/api/classes/OpenAIEmbedding.md
@@ -30,7 +30,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Embedding.ts:222](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L222)
+[Embedding.ts:222](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L222)
 
 ## Properties
 
@@ -40,7 +40,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Embedding.ts:217](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L217)
+[Embedding.ts:217](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L217)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:218](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L218)
+[Embedding.ts:218](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L218)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:214](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L214)
+[Embedding.ts:214](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L214)
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:220](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L220)
+[Embedding.ts:220](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L220)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:219](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L219)
+[Embedding.ts:219](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L219)
 
 ## Methods
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:237](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L237)
+[Embedding.ts:237](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L237)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:253](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L253)
+[Embedding.ts:253](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L253)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:249](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L249)
+[Embedding.ts:249](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L249)
 
 ___
 
@@ -174,4 +174,4 @@ ___
 
 #### Defined in
 
-[Embedding.ts:197](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L197)
+[Embedding.ts:197](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L197)

--- a/apps/docs/docs/api/classes/PDFReader.md
+++ b/apps/docs/docs/api/classes/PDFReader.md
@@ -41,4 +41,4 @@ Read the text of a PDF
 
 #### Defined in
 
-[readers/PDFReader.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/readers/PDFReader.ts#L11)
+[readers/PDFReader.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/readers/PDFReader.ts#L11)

--- a/apps/docs/docs/api/classes/Refine.md
+++ b/apps/docs/docs/api/classes/Refine.md
@@ -34,7 +34,7 @@ A response builder that uses the query to ask the LLM generate a better response
 
 #### Defined in
 
-[ResponseSynthesizer.ts:78](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L78)
+[ResponseSynthesizer.ts:78](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L78)
 
 ## Properties
 
@@ -44,7 +44,7 @@ A response builder that uses the query to ask the LLM generate a better response
 
 #### Defined in
 
-[ResponseSynthesizer.ts:76](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L76)
+[ResponseSynthesizer.ts:76](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L76)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L74)
+[ResponseSynthesizer.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L74)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L75)
+[ResponseSynthesizer.ts:75](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L75)
 
 ## Methods
 
@@ -91,7 +91,7 @@ BaseResponseBuilder.getResponse
 
 #### Defined in
 
-[ResponseSynthesizer.ts:88](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L88)
+[ResponseSynthesizer.ts:88](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L88)
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:113](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L113)
+[ResponseSynthesizer.ts:113](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L113)
 
 ___
 
@@ -136,4 +136,4 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L149)
+[ResponseSynthesizer.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L149)

--- a/apps/docs/docs/api/classes/Response.md
+++ b/apps/docs/docs/api/classes/Response.md
@@ -23,7 +23,7 @@ Respone is the output of a LLM
 
 #### Defined in
 
-[Response.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Response.ts#L10)
+[Response.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Response.ts#L10)
 
 ## Properties
 
@@ -33,7 +33,7 @@ Respone is the output of a LLM
 
 #### Defined in
 
-[Response.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Response.ts#L7)
+[Response.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Response.ts#L7)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[Response.ts:8](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Response.ts#L8)
+[Response.ts:8](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Response.ts#L8)
 
 ## Methods
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[Response.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Response.ts#L15)
+[Response.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Response.ts#L15)
 
 ___
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[Response.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Response.ts#L19)
+[Response.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Response.ts#L19)

--- a/apps/docs/docs/api/classes/ResponseSynthesizer.md
+++ b/apps/docs/docs/api/classes/ResponseSynthesizer.md
@@ -24,7 +24,7 @@ A ResponseSynthesizer is used to generate a response from a query and a list of 
 
 #### Defined in
 
-[ResponseSynthesizer.ts:285](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L285)
+[ResponseSynthesizer.ts:285](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L285)
 
 ## Properties
 
@@ -34,7 +34,7 @@ A ResponseSynthesizer is used to generate a response from a query and a list of 
 
 #### Defined in
 
-[ResponseSynthesizer.ts:282](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L282)
+[ResponseSynthesizer.ts:282](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L282)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:283](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L283)
+[ResponseSynthesizer.ts:283](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L283)
 
 ## Methods
 
@@ -66,4 +66,4 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:297](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L297)
+[ResponseSynthesizer.ts:297](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L297)

--- a/apps/docs/docs/api/classes/RetrieverQueryEngine.md
+++ b/apps/docs/docs/api/classes/RetrieverQueryEngine.md
@@ -27,7 +27,7 @@ A query engine that uses a retriever to query an index and then synthesizes the 
 
 #### Defined in
 
-[QueryEngine.ts:34](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L34)
+[QueryEngine.ts:34](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L34)
 
 ## Properties
 
@@ -37,7 +37,7 @@ A query engine that uses a retriever to query an index and then synthesizes the 
 
 #### Defined in
 
-[QueryEngine.ts:32](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L32)
+[QueryEngine.ts:32](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L32)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[QueryEngine.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L31)
+[QueryEngine.ts:31](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L31)
 
 ## Methods
 
@@ -74,4 +74,4 @@ Query the query engine and get a response.
 
 #### Defined in
 
-[QueryEngine.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L45)
+[QueryEngine.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L45)

--- a/apps/docs/docs/api/classes/SentenceSplitter.md
+++ b/apps/docs/docs/api/classes/SentenceSplitter.md
@@ -27,7 +27,7 @@ SentenceSplitter is our default text splitter that supports splitting into sente
 
 #### Defined in
 
-[TextSplitter.ts:33](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L33)
+[TextSplitter.ts:33](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L33)
 
 ## Properties
 
@@ -37,7 +37,7 @@ SentenceSplitter is our default text splitter that supports splitting into sente
 
 #### Defined in
 
-[TextSplitter.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L26)
+[TextSplitter.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L26)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L25)
+[TextSplitter.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L25)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L30)
+[TextSplitter.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L30)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:29](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L29)
+[TextSplitter.ts:29](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L29)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L27)
+[TextSplitter.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L27)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L28)
+[TextSplitter.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L28)
 
 ## Methods
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:153](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L153)
+[TextSplitter.ts:153](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L153)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L72)
+[TextSplitter.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L72)
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:89](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L89)
+[TextSplitter.ts:89](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L89)
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L115)
+[TextSplitter.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L115)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:128](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L128)
+[TextSplitter.ts:128](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L128)
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:233](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L233)
+[TextSplitter.ts:233](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L233)
 
 ___
 
@@ -233,4 +233,4 @@ ___
 
 #### Defined in
 
-[TextSplitter.ts:205](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/TextSplitter.ts#L205)
+[TextSplitter.ts:205](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/TextSplitter.ts#L205)

--- a/apps/docs/docs/api/classes/SimpleChatEngine.md
+++ b/apps/docs/docs/api/classes/SimpleChatEngine.md
@@ -26,7 +26,7 @@ SimpleChatEngine is the simplest possible chat engine. Useful for using your own
 
 #### Defined in
 
-[ChatEngine.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L40)
+[ChatEngine.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L40)
 
 ## Properties
 
@@ -36,7 +36,7 @@ SimpleChatEngine is the simplest possible chat engine. Useful for using your own
 
 #### Defined in
 
-[ChatEngine.ts:37](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L37)
+[ChatEngine.ts:37](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L37)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[ChatEngine.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L38)
+[ChatEngine.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L38)
 
 ## Methods
 
@@ -73,7 +73,7 @@ Send message along with the class's current chat history to the LLM.
 
 #### Defined in
 
-[ChatEngine.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L45)
+[ChatEngine.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L45)
 
 ___
 
@@ -93,4 +93,4 @@ Resets the chat history so that it's empty.
 
 #### Defined in
 
-[ChatEngine.ts:54](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L54)
+[ChatEngine.ts:54](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L54)

--- a/apps/docs/docs/api/classes/SimpleDirectoryReader.md
+++ b/apps/docs/docs/api/classes/SimpleDirectoryReader.md
@@ -40,4 +40,4 @@ Read all of the documents in a directory. Currently supports PDF and TXT files.
 
 #### Defined in
 
-[readers/SimpleDirectoryReader.ts:37](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/readers/SimpleDirectoryReader.ts#L37)
+[readers/SimpleDirectoryReader.ts:37](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/readers/SimpleDirectoryReader.ts#L37)

--- a/apps/docs/docs/api/classes/SimpleNodeParser.md
+++ b/apps/docs/docs/api/classes/SimpleNodeParser.md
@@ -31,7 +31,7 @@ SimpleNodeParser is the default NodeParser. It splits documents into TextNodes u
 
 #### Defined in
 
-[NodeParser.ts:64](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L64)
+[NodeParser.ts:64](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L64)
 
 ## Properties
 
@@ -41,7 +41,7 @@ SimpleNodeParser is the default NodeParser. It splits documents into TextNodes u
 
 #### Defined in
 
-[NodeParser.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L61)
+[NodeParser.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L61)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[NodeParser.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L62)
+[NodeParser.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L62)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[NodeParser.ts:60](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L60)
+[NodeParser.ts:60](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L60)
 
 ## Methods
 
@@ -87,7 +87,7 @@ Generate Node objects from documents
 
 #### Defined in
 
-[NodeParser.ts:95](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L95)
+[NodeParser.ts:95](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L95)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[NodeParser.ts:82](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L82)
+[NodeParser.ts:82](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L82)

--- a/apps/docs/docs/api/classes/SimpleResponseBuilder.md
+++ b/apps/docs/docs/api/classes/SimpleResponseBuilder.md
@@ -26,7 +26,7 @@ A response builder that just concatenates responses.
 
 #### Defined in
 
-[ResponseSynthesizer.ts:49](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L49)
+[ResponseSynthesizer.ts:49](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L49)
 
 ## Properties
 
@@ -36,7 +36,7 @@ A response builder that just concatenates responses.
 
 #### Defined in
 
-[ResponseSynthesizer.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L46)
+[ResponseSynthesizer.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L46)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L47)
+[ResponseSynthesizer.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L47)
 
 ## Methods
 
@@ -72,4 +72,4 @@ BaseResponseBuilder.getResponse
 
 #### Defined in
 
-[ResponseSynthesizer.ts:54](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L54)
+[ResponseSynthesizer.ts:54](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L54)

--- a/apps/docs/docs/api/classes/SubQuestionOutputParser.md
+++ b/apps/docs/docs/api/classes/SubQuestionOutputParser.md
@@ -40,7 +40,7 @@ SubQuestionOutputParser is used to parse the output of the SubQuestionGenerator.
 
 #### Defined in
 
-[OutputParser.ts:97](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/OutputParser.ts#L97)
+[OutputParser.ts:97](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/OutputParser.ts#L97)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[OutputParser.ts:89](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/OutputParser.ts#L89)
+[OutputParser.ts:89](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/OutputParser.ts#L89)

--- a/apps/docs/docs/api/classes/SubQuestionQueryEngine.md
+++ b/apps/docs/docs/api/classes/SubQuestionQueryEngine.md
@@ -29,7 +29,7 @@ SubQuestionQueryEngine decomposes a question into subquestions and then
 
 #### Defined in
 
-[QueryEngine.ts:65](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L65)
+[QueryEngine.ts:65](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L65)
 
 ## Properties
 
@@ -39,7 +39,7 @@ SubQuestionQueryEngine decomposes a question into subquestions and then
 
 #### Defined in
 
-[QueryEngine.ts:63](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L63)
+[QueryEngine.ts:63](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L63)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[QueryEngine.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L62)
+[QueryEngine.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L62)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[QueryEngine.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L61)
+[QueryEngine.ts:61](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L61)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[QueryEngine.ts:60](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L60)
+[QueryEngine.ts:60](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L60)
 
 ## Methods
 
@@ -95,7 +95,7 @@ Query the query engine and get a response.
 
 #### Defined in
 
-[QueryEngine.ts:106](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L106)
+[QueryEngine.ts:106](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L106)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[QueryEngine.ts:134](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L134)
+[QueryEngine.ts:134](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L134)
 
 ___
 
@@ -140,4 +140,4 @@ ___
 
 #### Defined in
 
-[QueryEngine.ts:82](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L82)
+[QueryEngine.ts:82](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L82)

--- a/apps/docs/docs/api/classes/TextFileReader.md
+++ b/apps/docs/docs/api/classes/TextFileReader.md
@@ -41,4 +41,4 @@ Read a .txt file
 
 #### Defined in
 
-[readers/SimpleDirectoryReader.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/readers/SimpleDirectoryReader.ts#L12)
+[readers/SimpleDirectoryReader.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/readers/SimpleDirectoryReader.ts#L12)

--- a/apps/docs/docs/api/classes/TextNode.md
+++ b/apps/docs/docs/api/classes/TextNode.md
@@ -36,7 +36,7 @@ TextNode is the default node type for text. Most common node type in LlamaIndex.
 
 #### Defined in
 
-[Node.ts:144](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L144)
+[Node.ts:144](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L144)
 
 ## Properties
 
@@ -50,7 +50,7 @@ TextNode is the default node type for text. Most common node type in LlamaIndex.
 
 #### Defined in
 
-[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L39)
+[Node.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L39)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[Node.ts:139](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L139)
+[Node.ts:139](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L139)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L43)
+[Node.ts:43](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L43)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L44)
+[Node.ts:44](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L44)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L46)
+[Node.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L46)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L38)
+[Node.ts:38](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L38)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L42)
+[Node.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L42)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[Node.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L142)
+[Node.ts:142](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L142)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 #### Defined in
 
-[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L45)
+[Node.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L45)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[Node.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L138)
+[Node.ts:138](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L138)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 #### Defined in
 
-[Node.ts:137](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L137)
+[Node.ts:137](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L137)
 
 ## Accessors
 
@@ -192,7 +192,7 @@ BaseNode.childNodes
 
 #### Defined in
 
-[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L104)
+[Node.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L104)
 
 ___
 
@@ -210,7 +210,7 @@ BaseNode.nextNode
 
 #### Defined in
 
-[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L84)
+[Node.ts:84](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L84)
 
 ___
 
@@ -228,7 +228,7 @@ BaseNode.nodeId
 
 #### Defined in
 
-[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L58)
+[Node.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L58)
 
 ___
 
@@ -246,7 +246,7 @@ BaseNode.parentNode
 
 #### Defined in
 
-[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L94)
+[Node.ts:94](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L94)
 
 ___
 
@@ -264,7 +264,7 @@ BaseNode.prevNode
 
 #### Defined in
 
-[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L72)
+[Node.ts:72](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L72)
 
 ___
 
@@ -282,7 +282,7 @@ BaseNode.sourceNode
 
 #### Defined in
 
-[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L62)
+[Node.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L62)
 
 ## Methods
 
@@ -300,7 +300,7 @@ BaseNode.sourceNode
 
 #### Defined in
 
-[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L124)
+[Node.ts:124](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L124)
 
 ___
 
@@ -314,7 +314,7 @@ ___
 
 #### Defined in
 
-[Node.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L149)
+[Node.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L149)
 
 ___
 
@@ -338,7 +338,7 @@ ___
 
 #### Defined in
 
-[Node.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L157)
+[Node.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L157)
 
 ___
 
@@ -356,7 +356,7 @@ ___
 
 #### Defined in
 
-[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L116)
+[Node.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L116)
 
 ___
 
@@ -380,7 +380,7 @@ ___
 
 #### Defined in
 
-[Node.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L162)
+[Node.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L162)
 
 ___
 
@@ -399,7 +399,7 @@ ___
 
 #### Defined in
 
-[Node.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L187)
+[Node.ts:187](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L187)
 
 ___
 
@@ -413,7 +413,7 @@ ___
 
 #### Defined in
 
-[Node.ts:191](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L191)
+[Node.ts:191](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L191)
 
 ___
 
@@ -431,7 +431,7 @@ ___
 
 #### Defined in
 
-[Node.ts:153](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L153)
+[Node.ts:153](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L153)
 
 ___
 
@@ -455,4 +455,4 @@ ___
 
 #### Defined in
 
-[Node.ts:183](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L183)
+[Node.ts:183](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L183)

--- a/apps/docs/docs/api/classes/TreeSummarize.md
+++ b/apps/docs/docs/api/classes/TreeSummarize.md
@@ -26,7 +26,7 @@ TreeSummarize repacks the text chunks into the smallest possible number of chunk
 
 #### Defined in
 
-[ResponseSynthesizer.ts:212](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L212)
+[ResponseSynthesizer.ts:212](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L212)
 
 ## Properties
 
@@ -36,7 +36,7 @@ TreeSummarize repacks the text chunks into the smallest possible number of chunk
 
 #### Defined in
 
-[ResponseSynthesizer.ts:210](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L210)
+[ResponseSynthesizer.ts:210](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L210)
 
 ## Methods
 
@@ -62,4 +62,4 @@ BaseResponseBuilder.getResponse
 
 #### Defined in
 
-[ResponseSynthesizer.ts:216](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L216)
+[ResponseSynthesizer.ts:216](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L216)

--- a/apps/docs/docs/api/classes/VectorIndexRetriever.md
+++ b/apps/docs/docs/api/classes/VectorIndexRetriever.md
@@ -28,7 +28,7 @@ VectorIndexRetriever retrieves nodes from a VectorIndex.
 
 #### Defined in
 
-[indices/vectorStore/VectorIndexRetriever.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L22)
+[indices/vectorStore/VectorIndexRetriever.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L22)
 
 ## Properties
 
@@ -38,7 +38,7 @@ VectorIndexRetriever retrieves nodes from a VectorIndex.
 
 #### Defined in
 
-[indices/vectorStore/VectorIndexRetriever.ts:18](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L18)
+[indices/vectorStore/VectorIndexRetriever.ts:18](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L18)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[indices/vectorStore/VectorIndexRetriever.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L20)
+[indices/vectorStore/VectorIndexRetriever.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L20)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[indices/vectorStore/VectorIndexRetriever.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L19)
+[indices/vectorStore/VectorIndexRetriever.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L19)
 
 ## Methods
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[indices/vectorStore/VectorIndexRetriever.ts:69](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L69)
+[indices/vectorStore/VectorIndexRetriever.ts:69](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L69)
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 #### Defined in
 
-[indices/vectorStore/VectorIndexRetriever.ts:35](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L35)
+[indices/vectorStore/VectorIndexRetriever.ts:35](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts#L35)

--- a/apps/docs/docs/api/classes/VectorStoreIndex.md
+++ b/apps/docs/docs/api/classes/VectorStoreIndex.md
@@ -32,7 +32,7 @@ The VectorStoreIndex, an index that stores the nodes only according to their vec
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:36](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L36)
+[indices/vectorStore/VectorStoreIndex.ts:36](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L36)
 
 ## Properties
 
@@ -46,7 +46,7 @@ The VectorStoreIndex, an index that stores the nodes only according to their vec
 
 #### Defined in
 
-[indices/BaseIndex.ts:117](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L117)
+[indices/BaseIndex.ts:117](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L117)
 
 ___
 
@@ -60,7 +60,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L119)
+[indices/BaseIndex.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L119)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:120](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L120)
+[indices/BaseIndex.ts:120](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L120)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L115)
+[indices/BaseIndex.ts:115](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L115)
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L116)
+[indices/BaseIndex.ts:116](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L116)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:34](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L34)
+[indices/vectorStore/VectorStoreIndex.ts:34](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L34)
 
 ## Methods
 
@@ -145,7 +145,7 @@ and response synthezier if they are not provided.
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:215](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L215)
+[indices/vectorStore/VectorStoreIndex.ts:215](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L215)
 
 ___
 
@@ -171,7 +171,7 @@ Create a new retriever from the index.
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:211](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L211)
+[indices/vectorStore/VectorStoreIndex.ts:211](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L211)
 
 ___
 
@@ -196,7 +196,7 @@ Get embeddings for nodes and place them into the index.
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:151](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L151)
+[indices/vectorStore/VectorStoreIndex.ts:151](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L151)
 
 ___
 
@@ -221,7 +221,7 @@ High level API: split documents, get embeddings, and build index.
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:186](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L186)
+[indices/vectorStore/VectorStoreIndex.ts:186](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L186)
 
 ___
 
@@ -245,7 +245,7 @@ Get the embeddings for nodes.
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:123](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L123)
+[indices/vectorStore/VectorStoreIndex.ts:123](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L123)
 
 ___
 
@@ -268,4 +268,4 @@ This is needed to handle persistence.
 
 #### Defined in
 
-[indices/vectorStore/VectorStoreIndex.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L47)
+[indices/vectorStore/VectorStoreIndex.ts:47](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/vectorStore/VectorStoreIndex.ts#L47)

--- a/apps/docs/docs/api/enums/IndexStructType.md
+++ b/apps/docs/docs/api/enums/IndexStructType.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[indices/BaseIndex.ts:41](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L41)
+[indices/BaseIndex.ts:41](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L41)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L40)
+[indices/BaseIndex.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L40)

--- a/apps/docs/docs/api/enums/ListRetrieverMode.md
+++ b/apps/docs/docs/api/enums/ListRetrieverMode.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[indices/list/ListIndex.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L26)
+[indices/list/ListIndex.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L26)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[indices/list/ListIndex.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/list/ListIndex.ts#L28)
+[indices/list/ListIndex.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/list/ListIndex.ts#L28)

--- a/apps/docs/docs/api/enums/MetadataMode.md
+++ b/apps/docs/docs/api/enums/MetadataMode.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Node.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L19)
+[Node.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L19)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[Node.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L20)
+[Node.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L20)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[Node.ts:21](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L21)
+[Node.ts:21](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L21)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[Node.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L22)
+[Node.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L22)

--- a/apps/docs/docs/api/enums/NodeRelationship.md
+++ b/apps/docs/docs/api/enums/NodeRelationship.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Node.ts:8](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L8)
+[Node.ts:8](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L8)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[Node.ts:6](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L6)
+[Node.ts:6](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L6)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[Node.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L7)
+[Node.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L7)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[Node.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L5)
+[Node.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L5)
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 #### Defined in
 
-[Node.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L4)
+[Node.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L4)

--- a/apps/docs/docs/api/enums/ObjectType.md
+++ b/apps/docs/docs/api/enums/ObjectType.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Node.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L15)
+[Node.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L15)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[Node.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L13)
+[Node.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L13)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[Node.ts:14](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L14)
+[Node.ts:14](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L14)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[Node.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L12)
+[Node.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L12)

--- a/apps/docs/docs/api/enums/SimilarityType.md
+++ b/apps/docs/docs/api/enums/SimilarityType.md
@@ -17,7 +17,7 @@ Default is cosine similarity. Dot product and negative Euclidean distance are al
 
 #### Defined in
 
-[Embedding.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L10)
+[Embedding.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L10)
 
 ___
 
@@ -27,7 +27,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L11)
+[Embedding.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L11)
 
 ___
 
@@ -37,4 +37,4 @@ ___
 
 #### Defined in
 
-[Embedding.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L12)
+[Embedding.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L12)

--- a/apps/docs/docs/api/interfaces/BaseIndexInit.md
+++ b/apps/docs/docs/api/interfaces/BaseIndexInit.md
@@ -26,7 +26,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[indices/BaseIndex.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L104)
+[indices/BaseIndex.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L104)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:106](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L106)
+[indices/BaseIndex.ts:106](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L106)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:107](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L107)
+[indices/BaseIndex.ts:107](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L107)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:102](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L102)
+[indices/BaseIndex.ts:102](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L102)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:103](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L103)
+[indices/BaseIndex.ts:103](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L103)
 
 ___
 
@@ -76,4 +76,4 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:105](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L105)
+[indices/BaseIndex.ts:105](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L105)

--- a/apps/docs/docs/api/interfaces/BaseOutputParser.md
+++ b/apps/docs/docs/api/interfaces/BaseOutputParser.md
@@ -36,7 +36,7 @@ An OutputParser is used to extract structured data from the raw output of the LL
 
 #### Defined in
 
-[OutputParser.ts:8](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/OutputParser.ts#L8)
+[OutputParser.ts:8](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/OutputParser.ts#L8)
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 #### Defined in
 
-[OutputParser.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/OutputParser.ts#L7)
+[OutputParser.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/OutputParser.ts#L7)

--- a/apps/docs/docs/api/interfaces/BaseQueryEngine.md
+++ b/apps/docs/docs/api/interfaces/BaseQueryEngine.md
@@ -34,4 +34,4 @@ Query the query engine and get a response.
 
 #### Defined in
 
-[QueryEngine.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QueryEngine.ts#L24)
+[QueryEngine.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QueryEngine.ts#L24)

--- a/apps/docs/docs/api/interfaces/BaseQuestionGenerator.md
+++ b/apps/docs/docs/api/interfaces/BaseQuestionGenerator.md
@@ -31,4 +31,4 @@ QuestionGenerators generate new questions for the LLM using tools and a user que
 
 #### Defined in
 
-[QuestionGenerator.ts:23](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L23)
+[QuestionGenerator.ts:23](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L23)

--- a/apps/docs/docs/api/interfaces/BaseReader.md
+++ b/apps/docs/docs/api/interfaces/BaseReader.md
@@ -32,4 +32,4 @@ A reader takes imports data into Document objects.
 
 #### Defined in
 
-[readers/base.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/readers/base.ts#L7)
+[readers/base.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/readers/base.ts#L7)

--- a/apps/docs/docs/api/interfaces/BaseRetriever.md
+++ b/apps/docs/docs/api/interfaces/BaseRetriever.md
@@ -26,7 +26,7 @@ Retrievers retrieve the nodes that most closely match our query in similarity.
 
 #### Defined in
 
-[Retriever.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Retriever.ts#L10)
+[Retriever.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Retriever.ts#L10)
 
 ___
 
@@ -47,4 +47,4 @@ ___
 
 #### Defined in
 
-[Retriever.ts:9](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Retriever.ts#L9)
+[Retriever.ts:9](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Retriever.ts#L9)

--- a/apps/docs/docs/api/interfaces/BaseTool.md
+++ b/apps/docs/docs/api/interfaces/BaseTool.md
@@ -22,4 +22,4 @@ Simple Tool interface. Likely to change.
 
 #### Defined in
 
-[Tool.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Tool.ts#L12)
+[Tool.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Tool.ts#L12)

--- a/apps/docs/docs/api/interfaces/ChatEngine.md
+++ b/apps/docs/docs/api/interfaces/ChatEngine.md
@@ -35,7 +35,7 @@ Send message along with the class's current chat history to the LLM.
 
 #### Defined in
 
-[ChatEngine.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L25)
+[ChatEngine.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L25)
 
 ___
 
@@ -51,4 +51,4 @@ Resets the chat history so that it's empty.
 
 #### Defined in
 
-[ChatEngine.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ChatEngine.ts#L30)
+[ChatEngine.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ChatEngine.ts#L30)

--- a/apps/docs/docs/api/interfaces/ChatMessage.md
+++ b/apps/docs/docs/api/interfaces/ChatMessage.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[llm/LLM.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L15)
+[llm/LLM.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L15)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L16)
+[llm/LLM.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L16)

--- a/apps/docs/docs/api/interfaces/ChatResponse.md
+++ b/apps/docs/docs/api/interfaces/ChatResponse.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[llm/LLM.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L22)
+[llm/LLM.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L22)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L20)
+[llm/LLM.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L20)
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:21](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L21)
+[llm/LLM.ts:21](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L21)

--- a/apps/docs/docs/api/interfaces/Event.md
+++ b/apps/docs/docs/api/interfaces/Event.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L13)
+[callbacks/CallbackManager.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L13)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L16)
+[callbacks/CallbackManager.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L16)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L15)
+[callbacks/CallbackManager.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L15)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:14](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L14)
+[callbacks/CallbackManager.ts:14](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L14)

--- a/apps/docs/docs/api/interfaces/GenericFileSystem.md
+++ b/apps/docs/docs/api/interfaces/GenericFileSystem.md
@@ -33,7 +33,7 @@ browsers.
 
 #### Defined in
 
-[storage/FileSystem.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L12)
+[storage/FileSystem.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L12)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L13)
+[storage/FileSystem.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L13)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L11)
+[storage/FileSystem.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L11)
 
 ___
 
@@ -97,4 +97,4 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L10)
+[storage/FileSystem.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L10)

--- a/apps/docs/docs/api/interfaces/LLM.md
+++ b/apps/docs/docs/api/interfaces/LLM.md
@@ -34,7 +34,7 @@ Get a chat response from the LLM
 
 #### Defined in
 
-[llm/LLM.ts:36](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L36)
+[llm/LLM.ts:36](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L36)
 
 ___
 
@@ -57,4 +57,4 @@ Get a prompt completion from the LLM
 
 #### Defined in
 
-[llm/LLM.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L42)
+[llm/LLM.ts:42](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L42)

--- a/apps/docs/docs/api/interfaces/NodeParser.md
+++ b/apps/docs/docs/api/interfaces/NodeParser.md
@@ -30,4 +30,4 @@ A node parser generates TextNodes from Documents
 
 #### Defined in
 
-[NodeParser.ts:53](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L53)
+[NodeParser.ts:53](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L53)

--- a/apps/docs/docs/api/interfaces/NodeWithEmbedding.md
+++ b/apps/docs/docs/api/interfaces/NodeWithEmbedding.md
@@ -16,7 +16,7 @@ A node with an embedding
 
 #### Defined in
 
-[Node.ts:247](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L247)
+[Node.ts:247](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L247)
 
 ___
 
@@ -26,4 +26,4 @@ ___
 
 #### Defined in
 
-[Node.ts:246](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L246)
+[Node.ts:246](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L246)

--- a/apps/docs/docs/api/interfaces/NodeWithScore.md
+++ b/apps/docs/docs/api/interfaces/NodeWithScore.md
@@ -16,7 +16,7 @@ A node with a similarity score
 
 #### Defined in
 
-[Node.ts:238](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L238)
+[Node.ts:238](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L238)
 
 ___
 
@@ -26,4 +26,4 @@ ___
 
 #### Defined in
 
-[Node.ts:239](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L239)
+[Node.ts:239](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L239)

--- a/apps/docs/docs/api/interfaces/QueryEngineTool.md
+++ b/apps/docs/docs/api/interfaces/QueryEngineTool.md
@@ -26,7 +26,7 @@ A Tool that uses a QueryEngine.
 
 #### Defined in
 
-[Tool.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Tool.ts#L12)
+[Tool.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Tool.ts#L12)
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 #### Defined in
 
-[Tool.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Tool.ts#L19)
+[Tool.ts:19](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Tool.ts#L19)

--- a/apps/docs/docs/api/interfaces/RelatedNodeInfo.md
+++ b/apps/docs/docs/api/interfaces/RelatedNodeInfo.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Node.ts:29](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L29)
+[Node.ts:29](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L29)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[Node.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L28)
+[Node.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L28)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[Node.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L26)
+[Node.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L26)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[Node.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L27)
+[Node.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L27)

--- a/apps/docs/docs/api/interfaces/RetrievalCallbackResponse.md
+++ b/apps/docs/docs/api/interfaces/RetrievalCallbackResponse.md
@@ -24,7 +24,7 @@ BaseCallbackResponse.event
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L20)
+[callbacks/CallbackManager.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L20)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L46)
+[callbacks/CallbackManager.ts:46](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L46)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L45)
+[callbacks/CallbackManager.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L45)

--- a/apps/docs/docs/api/interfaces/ServiceContext.md
+++ b/apps/docs/docs/api/interfaces/ServiceContext.md
@@ -16,7 +16,7 @@ The ServiceContext is a collection of components that are used in different part
 
 #### Defined in
 
-[ServiceContext.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L15)
+[ServiceContext.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L15)
 
 ___
 
@@ -26,7 +26,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L13)
+[ServiceContext.ts:13](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L13)
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L11)
+[ServiceContext.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L11)
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:14](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L14)
+[ServiceContext.ts:14](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L14)
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L12)
+[ServiceContext.ts:12](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L12)

--- a/apps/docs/docs/api/interfaces/ServiceContextOptions.md
+++ b/apps/docs/docs/api/interfaces/ServiceContextOptions.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[ServiceContext.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L24)
+[ServiceContext.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L24)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L27)
+[ServiceContext.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L27)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L26)
+[ServiceContext.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L26)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L22)
+[ServiceContext.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L22)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L20)
+[ServiceContext.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L20)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:23](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L23)
+[ServiceContext.ts:23](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L23)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:21](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L21)
+[ServiceContext.ts:21](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L21)

--- a/apps/docs/docs/api/interfaces/StorageContext.md
+++ b/apps/docs/docs/api/interfaces/StorageContext.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[storage/StorageContext.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/StorageContext.ts#L15)
+[storage/StorageContext.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/StorageContext.ts#L15)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[storage/StorageContext.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/StorageContext.ts#L16)
+[storage/StorageContext.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/StorageContext.ts#L16)
 
 ___
 
@@ -34,4 +34,4 @@ ___
 
 #### Defined in
 
-[storage/StorageContext.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/StorageContext.ts#L17)
+[storage/StorageContext.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/StorageContext.ts#L17)

--- a/apps/docs/docs/api/interfaces/StreamCallbackResponse.md
+++ b/apps/docs/docs/api/interfaces/StreamCallbackResponse.md
@@ -24,7 +24,7 @@ BaseCallbackResponse.event
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L20)
+[callbacks/CallbackManager.ts:20](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L20)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L39)
+[callbacks/CallbackManager.ts:39](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L39)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L40)
+[callbacks/CallbackManager.ts:40](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L40)
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:41](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L41)
+[callbacks/CallbackManager.ts:41](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L41)

--- a/apps/docs/docs/api/interfaces/StreamToken.md
+++ b/apps/docs/docs/api/interfaces/StreamToken.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L28)
+[callbacks/CallbackManager.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L28)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L26)
+[callbacks/CallbackManager.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L26)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L24)
+[callbacks/CallbackManager.ts:24](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L24)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L27)
+[callbacks/CallbackManager.ts:27](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L27)
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L25)
+[callbacks/CallbackManager.ts:25](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L25)

--- a/apps/docs/docs/api/interfaces/StructuredOutput.md
+++ b/apps/docs/docs/api/interfaces/StructuredOutput.md
@@ -22,7 +22,7 @@ StructuredOutput is just a combo of the raw output and the parsed output.
 
 #### Defined in
 
-[OutputParser.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/OutputParser.ts#L16)
+[OutputParser.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/OutputParser.ts#L16)
 
 ___
 
@@ -32,4 +32,4 @@ ___
 
 #### Defined in
 
-[OutputParser.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/OutputParser.ts#L15)
+[OutputParser.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/OutputParser.ts#L15)

--- a/apps/docs/docs/api/interfaces/SubQuestion.md
+++ b/apps/docs/docs/api/interfaces/SubQuestion.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[QuestionGenerator.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L15)
+[QuestionGenerator.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L15)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[QuestionGenerator.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/QuestionGenerator.ts#L16)
+[QuestionGenerator.ts:16](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/QuestionGenerator.ts#L16)

--- a/apps/docs/docs/api/interfaces/ToolMetadata.md
+++ b/apps/docs/docs/api/interfaces/ToolMetadata.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[Tool.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Tool.ts#L4)
+[Tool.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Tool.ts#L4)
 
 ___
 
@@ -24,4 +24,4 @@ ___
 
 #### Defined in
 
-[Tool.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Tool.ts#L5)
+[Tool.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Tool.ts#L5)

--- a/apps/docs/docs/api/interfaces/VectorIndexConstructorProps.md
+++ b/apps/docs/docs/api/interfaces/VectorIndexConstructorProps.md
@@ -24,7 +24,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[indices/BaseIndex.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L104)
+[indices/BaseIndex.ts:104](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L104)
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:106](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L106)
+[indices/BaseIndex.ts:106](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L106)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:107](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L107)
+[indices/BaseIndex.ts:107](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L107)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:102](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L102)
+[indices/BaseIndex.ts:102](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L102)
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:103](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L103)
+[indices/BaseIndex.ts:103](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L103)
 
 ___
 
@@ -94,4 +94,4 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L157)
+[indices/BaseIndex.ts:157](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L157)

--- a/apps/docs/docs/api/interfaces/VectorIndexOptions.md
+++ b/apps/docs/docs/api/interfaces/VectorIndexOptions.md
@@ -14,7 +14,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[indices/BaseIndex.ts:151](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L151)
+[indices/BaseIndex.ts:151](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L151)
 
 ___
 
@@ -24,7 +24,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:150](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L150)
+[indices/BaseIndex.ts:150](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L150)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L149)
+[indices/BaseIndex.ts:149](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L149)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:152](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L152)
+[indices/BaseIndex.ts:152](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L152)
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:153](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L153)
+[indices/BaseIndex.ts:153](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L153)

--- a/apps/docs/docs/api/interfaces/WalkableFileSystem.md
+++ b/apps/docs/docs/api/interfaces/WalkableFileSystem.md
@@ -24,7 +24,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[storage/FileSystem.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L17)
+[storage/FileSystem.ts:17](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L17)
 
 ___
 
@@ -44,4 +44,4 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:18](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L18)
+[storage/FileSystem.ts:18](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L18)

--- a/apps/docs/docs/api/modules.md
+++ b/apps/docs/docs/api/modules.md
@@ -96,7 +96,7 @@ custom_edit_url: null
 
 #### Defined in
 
-[storage/FileSystem.ts:49](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L49)
+[storage/FileSystem.ts:49](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L49)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L26)
+[llm/LLM.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L26)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L10)
+[callbacks/CallbackManager.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L10)
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 #### Defined in
 
-[callbacks/CallbackManager.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/callbacks/CallbackManager.ts#L11)
+[callbacks/CallbackManager.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/callbacks/CallbackManager.ts#L11)
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L7)
+[llm/LLM.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L7)
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 #### Defined in
 
-[Node.ts:32](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Node.ts#L32)
+[Node.ts:32](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Node.ts#L32)
 
 ___
 
@@ -165,7 +165,7 @@ ___
 
 #### Defined in
 
-[readers/SimpleDirectoryReader.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/readers/SimpleDirectoryReader.ts#L26)
+[readers/SimpleDirectoryReader.ts:26](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/readers/SimpleDirectoryReader.ts#L26)
 
 ___
 
@@ -193,7 +193,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ## Variables
 
@@ -217,7 +217,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[llm/LLM.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L162)
+[llm/LLM.ts:162](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L162)
 
 ___
 
@@ -242,7 +242,7 @@ We currently support GPT-3.5 and GPT-4 models
 
 #### Defined in
 
-[llm/LLM.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L58)
+[llm/LLM.ts:58](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L58)
 
 ___
 
@@ -252,7 +252,7 @@ ___
 
 #### Defined in
 
-[constants.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L5)
+[constants.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L5)
 
 ___
 
@@ -262,7 +262,7 @@ ___
 
 #### Defined in
 
-[constants.ts:6](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L6)
+[constants.ts:6](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L6)
 
 ___
 
@@ -272,7 +272,7 @@ ___
 
 #### Defined in
 
-[constants.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L4)
+[constants.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L4)
 
 ___
 
@@ -282,7 +282,7 @@ ___
 
 #### Defined in
 
-[storage/constants.ts:1](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/constants.ts#L1)
+[storage/constants.ts:1](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/constants.ts#L1)
 
 ___
 
@@ -292,7 +292,7 @@ ___
 
 #### Defined in
 
-[constants.ts:1](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L1)
+[constants.ts:1](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L1)
 
 ___
 
@@ -302,7 +302,7 @@ ___
 
 #### Defined in
 
-[storage/constants.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/constants.ts#L4)
+[storage/constants.ts:4](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/constants.ts#L4)
 
 ___
 
@@ -312,7 +312,7 @@ ___
 
 #### Defined in
 
-[constants.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L10)
+[constants.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L10)
 
 ___
 
@@ -322,7 +322,7 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L62)
+[storage/FileSystem.ts:62](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L62)
 
 ___
 
@@ -332,7 +332,7 @@ ___
 
 #### Defined in
 
-[storage/constants.ts:6](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/constants.ts#L6)
+[storage/constants.ts:6](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/constants.ts#L6)
 
 ___
 
@@ -342,7 +342,7 @@ ___
 
 #### Defined in
 
-[storage/constants.ts:3](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/constants.ts#L3)
+[storage/constants.ts:3](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/constants.ts#L3)
 
 ___
 
@@ -352,7 +352,7 @@ ___
 
 #### Defined in
 
-[storage/constants.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/constants.ts#L7)
+[storage/constants.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/constants.ts#L7)
 
 ___
 
@@ -362,7 +362,7 @@ ___
 
 #### Defined in
 
-[constants.ts:2](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L2)
+[constants.ts:2](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L2)
 
 ___
 
@@ -372,7 +372,7 @@ ___
 
 #### Defined in
 
-[constants.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L11)
+[constants.ts:11](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L11)
 
 ___
 
@@ -382,7 +382,7 @@ ___
 
 #### Defined in
 
-[storage/constants.ts:2](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/constants.ts#L2)
+[storage/constants.ts:2](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/constants.ts#L2)
 
 ___
 
@@ -392,7 +392,7 @@ ___
 
 #### Defined in
 
-[constants.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/constants.ts#L7)
+[constants.ts:7](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/constants.ts#L7)
 
 ___
 
@@ -402,7 +402,7 @@ ___
 
 #### Defined in
 
-[storage/constants.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/constants.ts#L5)
+[storage/constants.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/constants.ts#L5)
 
 ___
 
@@ -421,7 +421,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L45)
+[llm/LLM.ts:45](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L45)
 
 ___
 
@@ -440,7 +440,7 @@ ___
 
 #### Defined in
 
-[llm/LLM.ts:50](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/llm/LLM.ts#L50)
+[llm/LLM.ts:50](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/llm/LLM.ts#L50)
 
 ___
 
@@ -450,7 +450,7 @@ ___
 
 #### Defined in
 
-[GlobalsHelper.ts:50](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/GlobalsHelper.ts#L50)
+[GlobalsHelper.ts:50](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/GlobalsHelper.ts#L50)
 
 ## Functions
 
@@ -470,7 +470,7 @@ ___
 
 #### Defined in
 
-[Prompt.ts:198](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L198)
+[Prompt.ts:198](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L198)
 
 ___
 
@@ -494,7 +494,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ___
 
@@ -518,7 +518,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ___
 
@@ -542,7 +542,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ___
 
@@ -566,7 +566,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ___
 
@@ -590,7 +590,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ___
 
@@ -614,7 +614,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ___
 
@@ -638,7 +638,7 @@ NOTE 2: we default to empty string to make it easy to calculate prompt sizes
 
 #### Defined in
 
-[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L10)
+[Prompt.ts:10](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L10)
 
 ___
 
@@ -664,7 +664,7 @@ A promise that resolves to true if the file exists, false otherwise.
 
 #### Defined in
 
-[storage/FileSystem.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L74)
+[storage/FileSystem.ts:74](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L74)
 
 ___
 
@@ -678,7 +678,7 @@ ___
 
 #### Defined in
 
-[storage/FileSystem.ts:51](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L51)
+[storage/FileSystem.ts:51](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L51)
 
 ___
 
@@ -701,7 +701,7 @@ ___
 
 #### Defined in
 
-[NodeParser.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L15)
+[NodeParser.ts:15](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L15)
 
 ___
 
@@ -722,7 +722,7 @@ ___
 
 #### Defined in
 
-[ResponseSynthesizer.ts:262](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ResponseSynthesizer.ts#L262)
+[ResponseSynthesizer.ts:262](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ResponseSynthesizer.ts#L262)
 
 ___
 
@@ -743,7 +743,7 @@ ___
 
 #### Defined in
 
-[NodeParser.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/NodeParser.ts#L5)
+[NodeParser.ts:5](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/NodeParser.ts#L5)
 
 ___
 
@@ -769,7 +769,7 @@ Get the top K embeddings from a list of embeddings ordered by similarity to the 
 
 #### Defined in
 
-[Embedding.ts:77](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L77)
+[Embedding.ts:77](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L77)
 
 ___
 
@@ -793,7 +793,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L119)
+[Embedding.ts:119](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L119)
 
 ___
 
@@ -819,7 +819,7 @@ ___
 
 #### Defined in
 
-[Embedding.ts:131](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L131)
+[Embedding.ts:131](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L131)
 
 ___
 
@@ -839,7 +839,7 @@ ___
 
 #### Defined in
 
-[indices/BaseIndex.ts:70](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/indices/BaseIndex.ts#L70)
+[indices/BaseIndex.ts:70](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/indices/BaseIndex.ts#L70)
 
 ___
 
@@ -859,7 +859,7 @@ ___
 
 #### Defined in
 
-[Prompt.ts:300](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Prompt.ts#L300)
+[Prompt.ts:300](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Prompt.ts#L300)
 
 ___
 
@@ -879,7 +879,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L30)
+[ServiceContext.ts:30](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L30)
 
 ___
 
@@ -908,7 +908,7 @@ ___
 
 #### Defined in
 
-[ServiceContext.ts:48](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/ServiceContext.ts#L48)
+[ServiceContext.ts:48](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/ServiceContext.ts#L48)
 
 ___
 
@@ -934,7 +934,7 @@ similartiy score with higher numbers meaning the two embeddings are more similar
 
 #### Defined in
 
-[Embedding.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/Embedding.ts#L22)
+[Embedding.ts:22](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/Embedding.ts#L22)
 
 ___
 
@@ -954,7 +954,7 @@ ___
 
 #### Defined in
 
-[storage/StorageContext.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/StorageContext.ts#L28)
+[storage/StorageContext.ts:28](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/StorageContext.ts#L28)
 
 ___
 
@@ -977,4 +977,4 @@ Recursively traverses a directory and yields all the paths to the files in it.
 
 #### Defined in
 
-[storage/FileSystem.ts:91](https://github.com/run-llama/LlamaIndexTS/blob/35f3030/packages/core/src/storage/FileSystem.ts#L91)
+[storage/FileSystem.ts:91](https://github.com/run-llama/LlamaIndexTS/blob/main/packages/core/src/storage/FileSystem.ts#L91)

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -138,6 +138,7 @@ const config = {
       {
         entryPoints: ["../../packages/core/src/index.ts"],
         tsconfig: "../../packages/core/tsconfig.json",
+        gitRevision: "main",
         sidebar: {
           position: 6,
         },


### PR DESCRIPTION
In theory this will stop the API docs thrashing on every build.

Of course, there is a drawback in that if main changes but we haven't released a new version of the docs yet the links will go out of date.

So longer term we might want to investigate some kind of variable where we can continue to have up to date revs but keep the rev in a single variable somewhere:

https://github.com/facebook/docusaurus/issues/395

In the meantime much smaller commits will be a relief