### PR TITLE
[BUG FIX] Use retriever from argument if exist in asQueryEngine of VectorStoreIndex

### DIFF
--- a/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
+++ b/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
@@ -20,11 +20,11 @@ import {
   IndexDict,
   VectorIndexConstructorProps,
   VectorIndexOptions,
+  IndexStructType
 } from "../BaseIndex";
 import { BaseRetriever } from "../../Retriever";
 import { ResponseSynthesizer } from "../../ResponseSynthesizer";
 import { BaseDocumentStore } from "../../storage/docStore/types";
-import { IndexStructType } from "../BaseIndex";
 
 /**
  * The VectorStoreIndex, an index that stores the nodes only according to their vector embedings.

--- a/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
+++ b/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
@@ -216,9 +216,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
     retriever?: BaseRetriever;
     responseSynthesizer?: ResponseSynthesizer;
   }): BaseQueryEngine {
-    let { retriever, responseSynthesizer } = options ?? {};
-
-    retriever = retriever ?? this.asRetriever();
-    return new RetrieverQueryEngine(this.asRetriever(), responseSynthesizer);
+    const { retriever, responseSynthesizer } = options ?? {};
+    return new RetrieverQueryEngine(retriever ?? this.asRetriever(), responseSynthesizer);
   }
 }


### PR DESCRIPTION
## What

Use `retriever` from argument if it exists.

## Why

Just a brief bug fix. I noticed you take `retriever` as argument of asQueryEngine function but always use `this.asRetriever()` despite you declaring retriever as `retriever ?? this.asRetriever();`. I think it is a mistake.

So use `retriever` if it exists.

## How

- c06d1e5b0930de9f84b43b21b0be4c06552ac727 Use `retriever` as argument of RetrieverQueryEngine if it exists. The current behavior is always using `this.asRetriever()` and just ignoring `retriever` despite declaring it.
- 34f5398f41109758a655bc1c1adbe67ddb5a26f4 Brief refactoring. Integrate module importations from `BaseIndex` to one declaration.