### PR TITLE
make VectorStore function signatures unique, export VectorStore types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,3 +27,4 @@ export * from "./readers/SimpleDirectoryReader";
 export * from "./storage/constants";
 export * from "./storage/FileSystem";
 export * from "./storage/StorageContext";
+export * from "./storage/vectorStore/types";

--- a/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts
+++ b/packages/core/src/indices/vectorStore/VectorIndexRetriever.ts
@@ -41,7 +41,7 @@ export class VectorIndexRetriever implements BaseRetriever {
       mode: VectorStoreQueryMode.DEFAULT,
       similarityTopK: this.similarityTopK,
     };
-    const result = this.index.vectorStore.query(q);
+    const result = await this.index.vectorStore.query(q);
 
     let nodesWithScores: NodeWithScore[] = [];
     for (let i = 0; i < result.ids.length; i++) {

--- a/packages/core/src/storage/vectorStore/SimpleVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/SimpleVectorStore.ts
@@ -51,11 +51,11 @@ export class SimpleVectorStore implements VectorStore {
     return null;
   }
 
-  get(textId: string): number[] {
+  async get(textId: string): Promise<number[]> {
     return this.data.embeddingDict[textId];
   }
 
-  add(embeddingResults: NodeWithEmbedding[]): string[] {
+  async add(embeddingResults: NodeWithEmbedding[]): Promise<string[]> {
     for (let result of embeddingResults) {
       this.data.embeddingDict[result.node.id_] = result.embedding;
 
@@ -69,13 +69,13 @@ export class SimpleVectorStore implements VectorStore {
     }
 
     if (this.persistPath) {
-      this.persist(this.persistPath, this.fs);
+      await this.persist(this.persistPath, this.fs);
     }
 
     return embeddingResults.map((result) => result.node.id_);
   }
 
-  delete(refDocId: string): void {
+  async delete(refDocId: string): Promise<void> {
     let textIdsToDelete = Object.keys(this.data.textIdToRefDocId).filter(
       (textId) => this.data.textIdToRefDocId[textId] === refDocId
     );
@@ -83,9 +83,10 @@ export class SimpleVectorStore implements VectorStore {
       delete this.data.embeddingDict[textId];
       delete this.data.textIdToRefDocId[textId];
     }
+    return Promise.resolve();
   }
 
-  query(query: VectorStoreQuery): VectorStoreQueryResult {
+  async query(query: VectorStoreQuery): Promise<VectorStoreQueryResult> {
     if (!_.isNil(query.filters)) {
       throw new Error(
         "Metadata filters not implemented for SimpleVectorStore yet."
@@ -137,10 +138,10 @@ export class SimpleVectorStore implements VectorStore {
       throw new Error(`Invalid query mode: ${query.mode}`);
     }
 
-    return {
+    return Promise.resolve({
       similarities: topSimilarities,
       ids: topIds,
-    };
+    });
   }
 
   async persist(

--- a/packages/core/src/storage/vectorStore/types.ts
+++ b/packages/core/src/storage/vectorStore/types.ts
@@ -61,8 +61,8 @@ export interface VectorStore {
   storesText: boolean;
   isEmbeddingQuery?: boolean;
   client(): any;
-  add(embeddingResults: NodeWithEmbedding[]): string[];
-  delete(refDocId: string, deleteKwargs?: any): void;
-  query(query: VectorStoreQuery, kwargs?: any): VectorStoreQueryResult;
-  persist(persistPath: string, fs?: GenericFileSystem): void;
+  add(embeddingResults: NodeWithEmbedding[]): Promise<string[]>;
+  delete(refDocId: string, deleteKwargs?: any): Promise<void>;
+  query(query: VectorStoreQuery, kwargs?: any): Promise<VectorStoreQueryResult>;
+  persist(persistPath: string, fs?: GenericFileSystem): Promise<void>;
 }


### PR DESCRIPTION
**Changes**
+ Make VectorStore interface function signatures `async` to support API-based stores, whose operations are all async
+ export VectorStore types so they can be implemented by custom integrations

Ran lint and all tests pass.