### PR TITLE
add a filter type to exact match filters

### DIFF
--- a/packages/core/src/storage/vectorStore/types.ts
+++ b/packages/core/src/storage/vectorStore/types.ts
@@ -21,6 +21,7 @@ export enum VectorStoreQueryMode {
 }
 
 export interface ExactMatchFilter {
+  filterType: "ExactMatch";
   key: string;
   value: string | number;
 }


### PR DESCRIPTION
Since types only exist at compile time, it's very difficult to switch off of an `interface` without a key.

This makes it much easier to `switch` over `MetadataFilter`s and map to other structures, like Pinecone filters.