### PR TITLE
add constructor to index node so it keeps passed-in indexId

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -204,6 +204,11 @@ export class TextNode extends BaseNode {
 export class IndexNode extends TextNode {
   indexId: string = "";
 
+  constructor(init?: Partial<IndexNode>) {
+    super(init);
+    Object.assign(this, init);
+  }
+
   getType(): ObjectType {
     return ObjectType.INDEX;
   }


### PR DESCRIPTION
Without its own constructor, one is created that calls `super` and then sets `indexId` to its default value (`""`). That ends up blanking out any passed-in value :(