### PR TITLE
Export storage

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,4 @@ export * from "./readers/base";
 export * from "./readers/PDFReader";
 export * from "./readers/SimpleDirectoryReader";
 
-export * from "./storage/constants";
-export * from "./storage/FileSystem";
-export * from "./storage/StorageContext";
-export * from "./storage/vectorStore/types";
+export * from "./storage";

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,0 +1,7 @@
+export * from "./constants";
+export * from "./FileSystem";
+export * from "./StorageContext";
+export * from "./vectorStore/types";
+export { SimpleDocumentStore } from "./docStore/SimpleDocumentStore";
+export { SimpleIndexStore } from "./indexStore/SimpleIndexStore";
+export { SimpleVectorStore } from "./vectorStore/SimpleVectorStore";


### PR DESCRIPTION
`storageContextFromDefaults` accepts Store as an argument, but the Store to generate those arguments is not exposed, so we exported it.