### PR TITLE
Add Notion database support to NotionReader

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
     "@anthropic-ai/sdk": "^0.6.2",
     "@notionhq/client": "^2.2.12",
     "lodash": "^4.17.21",
-    "md-utils-ts": "^2.0.0",
+    "notion-md-crawler": "^0.0.2",
     "openai": "^4.3.1",
     "papaparse": "^5.4.1",
     "pdf-parse": "^1.1.1",

--- a/packages/core/src/readers/NotionReader.ts
+++ b/packages/core/src/readers/NotionReader.ts
@@ -3,11 +3,17 @@ import { crawler, Crawler, Pages, pageToString } from "notion-md-crawler";
 import { Document } from "../Node";
 import { BaseReader } from "./base";
 
+type OptionalSerializers = Parameters<Crawler>[number]["serializers"];
+type NotionReaderOptions = {
+  client: Client;
+  serializers?: OptionalSerializers;
+};
+
 export class NotionReader implements BaseReader {
   private crawl: ReturnType<Crawler>;
 
-  constructor(options: { client: Client }) {
-    this.crawl = crawler({ client: options.client });
+  constructor({ client, serializers }: NotionReaderOptions) {
+    this.crawl = crawler({ client, serializers });
   }
 
   toDocuments(pages: Pages): Document[] {

--- a/packages/core/src/readers/NotionReader.ts
+++ b/packages/core/src/readers/NotionReader.ts
@@ -1,271 +1,28 @@
-import { Client, collectPaginatedAPI } from "@notionhq/client";
-import * as md from "md-utils-ts";
+import { Client } from "@notionhq/client";
+import { crawler, Crawler, Pages, pageToString } from "notion-md-crawler";
 import { Document } from "../Node";
 import { BaseReader } from "./base";
 
-type NotionClient = InstanceType<typeof Client>;
-
-// Notion Page
-type NotionPageRetrieveMethod = NotionClient["pages"]["retrieve"];
-type NotionPartialPageObjectResponse = Awaited<
-  ReturnType<NotionPageRetrieveMethod>
->;
-
-// Notion Block
-type NotionBlockListMethod = NotionClient["blocks"]["children"]["list"];
-type NotionBlockListResponse = Awaited<ReturnType<NotionBlockListMethod>>;
-type NotionBlockObjectResponse = NotionBlockListResponse["results"][number];
-type ExtractBlockObjectResponse<T> = T extends { type: string } ? T : never;
-type NotionBlock = ExtractBlockObjectResponse<NotionBlockObjectResponse>;
-type NotionChildPageBlock = Extract<NotionBlock, { type: "child_page" }>;
-type NotionParagraphBlock = Extract<NotionBlock, { type: "paragraph" }>;
-type NotionTableRowBlock = Extract<NotionBlock, { type: "table_row" }>;
-type NotionRichText = NotionParagraphBlock["paragraph"]["rich_text"];
-type NotionAnnotations = NotionRichText[number]["annotations"];
-
-const fetchNotionBlocks = (client: Client) => async (blockId: string) =>
-  collectPaginatedAPI(client.blocks.children.list, {
-    block_id: blockId,
-  });
-
-const fetchNotionPage = (client: Client) => (pageId: string) =>
-  client.pages.retrieve({ page_id: pageId });
-
-type Page = {
-  metadata: {
-    id: string;
-    title: string;
-    createdTime: string;
-    lastEditedTime: string;
-    parentId?: string;
-  };
-  lines: string[];
-};
-
-type Pages = Record<string, Page>;
-
-const hasType = (block: NotionBlockObjectResponse): block is NotionBlock =>
-  "type" in block;
-
-const blockIs = <T extends NotionBlock["type"]>(
-  block: NotionBlock,
-  type: T,
-): block is Extract<NotionBlock, { type: T }> => block.type === type;
-
-const getCursor = (
-  pageBlock: NotionChildPageBlock,
-  parentId?: string,
-): Page => ({
-  metadata: {
-    id: pageBlock.id,
-    title: pageBlock.child_page.title,
-    createdTime: pageBlock.created_time,
-    lastEditedTime: pageBlock.last_edited_time,
-    parentId,
-  },
-  lines: [],
-});
-
-const annotateText = (text: string, annotations: NotionAnnotations) => {
-  if (annotations.code) text = md.inlineCode(text);
-  if (annotations.bold) text = md.bold(text);
-  if (annotations.italic) text = md.italic(text);
-  if (annotations.strikethrough) text = md.del(text);
-  if (annotations.underline) text = md.underline(text);
-
-  return text;
-};
-
-const richTextToString = (richText: NotionRichText) =>
-  richText
-    .map(({ plain_text, annotations, href }) => {
-      if (plain_text.match(/^\s*$/)) return plain_text;
-
-      const leadingSpaceMatch = plain_text.match(/^(\s*)/);
-      const trailingSpaceMatch = plain_text.match(/(\s*)$/);
-
-      const leading_space = leadingSpaceMatch ? leadingSpaceMatch[0] : "";
-      const trailing_space = trailingSpaceMatch ? trailingSpaceMatch[0] : "";
-
-      const text = plain_text.trim();
-
-      if (text === "") return leading_space + trailing_space;
-
-      const annotatedText = annotateText(text, annotations);
-      const linkedText = href ? md.anchor(annotatedText, href) : annotatedText;
-
-      return leading_space + linkedText + trailing_space;
-    })
-    .join("");
-
-const tableRowToString = (block: NotionTableRowBlock) =>
-  `| ${block.table_row.cells
-    .flatMap((row) => row.map((column) => richTextToString([column])))
-    .join(" | ")} |`;
-
-const blockToString = (block: NotionBlock): string => {
-  switch (block.type) {
-    case "divider":
-      return md.hr();
-    case "equation":
-      return md.equationBlock(block.equation.expression);
-    case "bookmark":
-      return md.anchor(
-        richTextToString(block.bookmark.caption),
-        block.bookmark.url,
-      );
-    case "link_preview":
-      return md.anchor(block.type, block.link_preview.url);
-    case "link_to_page":
-      const href =
-        block.link_to_page.type === "page_id" ? block.link_to_page.page_id : "";
-      return md.anchor(block.type, href);
-    case "child_page":
-      return `[${block.child_page.title}]`;
-    case "child_database":
-      return `[${block.child_database.title}]`;
-    case "paragraph":
-      return richTextToString(block.paragraph.rich_text);
-    case "heading_1":
-      return md.h1(richTextToString(block.heading_1.rich_text));
-    case "heading_2":
-      return md.h2(richTextToString(block.heading_2.rich_text));
-    case "heading_3":
-      return md.h3(richTextToString(block.heading_3.rich_text));
-    case "bulleted_list_item":
-      return md.bullet(richTextToString(block.bulleted_list_item.rich_text));
-    case "numbered_list_item":
-      return md.bullet(richTextToString(block.numbered_list_item.rich_text), 1);
-    case "quote":
-      return md.quote(richTextToString(block.quote.rich_text));
-    case "table_row":
-      return tableRowToString(block);
-    case "to_do":
-      return md.todo(
-        richTextToString(block.to_do.rich_text),
-        block.to_do.checked,
-      );
-    case "template":
-      return richTextToString(block.template.rich_text);
-    case "code":
-      return md.codeBlock(block.code.language)(
-        richTextToString(block.code.rich_text),
-      );
-    case "callout":
-      return md.quote(richTextToString(block.callout.rich_text));
-
-    case "image":
-    case "video":
-    case "audio":
-    case "file":
-    case "pdf":
-    case "table":
-    case "embed":
-    case "breadcrumb":
-    case "synced_block":
-    case "table_of_contents":
-    case "unsupported":
-    default:
-      return "";
-  }
-};
-
-const getNest = (block: NotionBlock, baseNest: number) => {
-  switch (block.type) {
-    // Reset nest
-    case "child_page":
-      return 0;
-
-    // Eliminates unnecessary nests due to NotionBlock structure
-    case "table_row":
-    case "column_list":
-    case "column":
-    case "synced_block":
-      return baseNest;
-
-    default:
-      return baseNest + 1;
-  }
-};
-
-const crawlPages =
-  (client: Client) =>
-  async (
-    blocks: NotionBlockObjectResponse[],
-    cursor: Page,
-    pages: Pages = {},
-    nest = 0,
-  ): Promise<Pages> => {
-    pages[cursor.metadata.id] = pages[cursor.metadata.id] || cursor;
-
-    for (const block of blocks) {
-      if (!hasType(block)) continue;
-
-      const line = md.indent()(blockToString(block), nest);
-      cursor.lines.push(line);
-
-      if (block.has_children) {
-        const blockId = blockIs(block, "synced_block")
-          ? block.synced_block.synced_from?.block_id || block.id
-          : block.id;
-        const childBlocks = await fetchNotionBlocks(client)(blockId);
-        const nextCursor = blockIs(block, "child_page")
-          ? getCursor(block, cursor.metadata.id)
-          : cursor;
-        const childPages = await crawlPages(client)(
-          childBlocks,
-          nextCursor,
-          pages,
-          getNest(block, nest),
-        );
-        pages = { ...pages, ...childPages };
-      }
-    }
-
-    return pages;
-  };
-
-const extractPageTitle = (page: NotionPartialPageObjectResponse) => {
-  if (!("properties" in page)) return "";
-
-  if (page.properties.title.type !== "title") return "";
-
-  return page.properties.title.title[0].plain_text;
-};
-
-const nestHeading = (text: string) => (text.match(/^#+\s/) ? "#" + text : text);
-
-const pagesToDocuments = (pages: Pages): Document[] =>
-  Object.entries(pages).map(([, { lines, metadata }]) => {
-    const title = md.h1(metadata.title);
-    const body = lines.map(nestHeading);
-    const text = [title, ...body].join("\n");
-    return new Document({ text, metadata });
-  });
-
 export class NotionReader implements BaseReader {
-  private client: Client;
+  private crawl: ReturnType<Crawler>;
 
   constructor(options: { client: Client }) {
-    this.client = options.client;
+    this.crawl = crawler({ client: options.client });
   }
 
-  async loadData(pageId: string): Promise<Document[]> {
-    const rootPage = (await fetchNotionPage(this.client)(pageId)) as any;
-    const rootPageTitle = extractPageTitle(rootPage);
-    const rootBlocks = await fetchNotionBlocks(this.client)(rootPage.id);
+  toDocuments(pages: Pages): Document[] {
+    return Object.values(pages).map((page) => {
+      const text = pageToString(page);
+      return new Document({ text, metadata: page.metadata });
+    });
+  }
 
-    const cursor: Page = {
-      metadata: {
-        id: rootPage.id,
-        title: rootPageTitle,
-        createdTime: rootPage.created_time,
-        lastEditedTime: rootPage.last_edited_time,
-      },
-      lines: [],
-    };
-    const pages = await crawlPages(this.client)(rootBlocks, cursor);
+  async loadPages(rootPageId: string): Promise<Pages> {
+    return this.crawl(rootPageId);
+  }
 
-    return pagesToDocuments(pages);
+  async loadData(rootPageId: string): Promise<Document[]> {
+    const pages = await this.loadPages(rootPageId);
+    return this.toDocuments(pages);
   }
 }

--- a/packages/core/src/readers/NotionReader.ts
+++ b/packages/core/src/readers/NotionReader.ts
@@ -4,18 +4,41 @@ import { Document } from "../Node";
 import { BaseReader } from "./base";
 
 type OptionalSerializers = Parameters<Crawler>[number]["serializers"];
+
+/**
+ * Options for initializing the NotionReader class
+ * @typedef {Object} NotionReaderOptions
+ * @property {Client} client - The Notion Client object for API interactions
+ * @property {OptionalSerializers} [serializers] - Option to customize serialization. See [the url](https://github.com/TomPenguin/notion-md-crawler/tree/main) for details.
+ */
 type NotionReaderOptions = {
   client: Client;
   serializers?: OptionalSerializers;
 };
 
+/**
+ * Notion pages are retrieved recursively and converted to Document objects.
+ * Notion Database can also be loaded, and [the serialization method can be customized](https://github.com/TomPenguin/notion-md-crawler/tree/main).
+ *
+ * [Note] To use this reader, must be created the Notion integration must be created in advance
+ * Please refer to [this document](https://www.notion.so/help/create-integrations-with-the-notion-api) for details.
+ */
 export class NotionReader implements BaseReader {
   private crawl: ReturnType<Crawler>;
 
+  /**
+   * Constructor for the NotionReader class
+   * @param {NotionReaderOptions} options - Configuration options for the reader
+   */
   constructor({ client, serializers }: NotionReaderOptions) {
     this.crawl = crawler({ client, serializers });
   }
 
+  /**
+   * Converts Pages to an array of Document objects
+   * @param {Pages} pages - The Notion pages to convert (Return value of `loadPages`)
+   * @returns {Document[]} An array of Document objects
+   */
   toDocuments(pages: Pages): Document[] {
     return Object.values(pages).map((page) => {
       const text = pageToString(page);
@@ -23,10 +46,20 @@ export class NotionReader implements BaseReader {
     });
   }
 
+  /**
+   * Loads recursively the Notion page with the specified root page ID.
+   * @param {string} rootPageId - The root Notion page ID
+   * @returns {Promise<Pages>} A Promise that resolves to a Pages object(Convertible with the `toDocuments` method)
+   */
   async loadPages(rootPageId: string): Promise<Pages> {
     return this.crawl(rootPageId);
   }
 
+  /**
+   * Loads recursively Notion pages and converts them to an array of Document objects
+   * @param {string} rootPageId - The root Notion page ID
+   * @returns {Promise<Document[]>} A Promise that resolves to an array of Document objects
+   */
   async loadData(rootPageId: string): Promise<Document[]> {
     const pages = await this.loadPages(rootPageId);
     return this.toDocuments(pages);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,9 +128,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      md-utils-ts:
-        specifier: ^2.0.0
-        version: 2.0.0
+      notion-md-crawler:
+        specifier: ^0.0.2
+        version: 0.0.2
       openai:
         specifier: ^4.3.1
         version: 4.3.1
@@ -10178,6 +10178,15 @@ packages:
   /normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
+    dev: false
+
+  /notion-md-crawler@0.0.2:
+    resolution: {integrity: sha512-lE3/DFMrg7GSbl1sBfDuLVLyxw+yjdarPVm1JGfQ6eONEbNGgO+BdZxpwwZQ1uYeEJurAXMXb/AXT8GKYjKAyg==}
+    dependencies:
+      '@notionhq/client': 2.2.12
+      md-utils-ts: 2.0.0
+    transitivePeerDependencies:
+      - encoding
     dev: false
 
   /npm-run-path@4.0.1:


### PR DESCRIPTION
## Summary
I/F is backward compatible. The core functionality to be crawled was carved out as a separate library, and the logic to crawl the db was added to that library.

## Feature

- Add Notion DB Suport
- Add method `loadPages`, `toDocuments`
  - To allow users to handle the serialization process
  - They are also used inside `loadData`

