### PR TITLE
Cache LLM responses using Redis, for cheap integration testing [on hold]

### DIFF
--- a/packages/core/src/Embedding.ts
+++ b/packages/core/src/Embedding.ts
@@ -296,3 +296,5 @@ export class OpenAIEmbedding extends BaseEmbedding {
     return this.getOpenAIEmbedding(query);
   }
 }
+
+//We need a class that wraps and caches embeddings

--- a/packages/core/src/llm/RedisCacheLLM.ts
+++ b/packages/core/src/llm/RedisCacheLLM.ts
@@ -1,0 +1,45 @@
+import { LLM, ChatResponse, CompletionResponse, ChatMessage} from './LLM';
+
+
+
+export class RedisCacheLLM implements LLM {
+
+  llm: LLM;
+  to_cache: boolean;
+
+  constructor(llm: LLM, to_cache: boolean){
+    this.llm = llm;
+  }
+
+  async chat(messages: ChatMessage[]): Promise<ChatResponse> {
+
+    //Get response
+    const item = await this.llm.chat(messages);
+
+    if(this.to_cache === true){
+      //Cache response
+    }
+
+    //Return LLM response
+    return item;
+  }
+
+
+  async complete(prompt: string): Promise<CompletionResponse> {
+    const item = await this.llm.complete(prompt);
+
+
+    //Check the flag
+    if(this.to_cache === true){
+
+    
+    //Try cache lookup. If we don't have it, query and store.
+
+
+    //Return value.
+    }
+
+
+    return item;
+  }
+}

--- a/packages/core/src/tests/QueryEngine.int.test.ts
+++ b/packages/core/src/tests/QueryEngine.int.test.ts
@@ -1,0 +1,42 @@
+import { LLM, MessageType } from "../llm/LLM";
+import MockLLM from "../llm/mock";
+import { defaultMultiSelectPrompt } from "../Prompt";
+import { LLMSelector } from "../Selector";
+import { RouterQueryEngine } from "../QueryEngine";
+import { ToolMetadata } from "../Tool";
+
+describe("Selector ", () => {
+  test(".select method compiles", async () => {
+    //In-memory integration test for RouterQueryEngine
+    //Warning: This alone doesn't mean that RQE works for every LLM and every prompt.
+
+    const msgType: MessageType = "user";
+    const regVal = {
+      message: {
+        content: `[{"answer": 0, "reason": "something"}]`,
+        role: msgType,
+      },
+    };
+
+    //Using an empty mock LLM, override the .complete() method
+    // + use a dummy prompt
+    const fakeLLM: LLM = new MockLLM();
+    fakeLLM.complete = async (query: string) => {
+      return regVal;
+    };
+
+    //LLM Selector method
+    const selector: LLMSelector = new LLMSelector(
+      fakeLLM,
+      defaultMultiSelectPrompt,
+    );
+
+    const fakeToolData: ToolMetadata[]
+    const final_val = await selector.select("something", [
+      { name: "something1", description: "something2" },
+    ]);
+
+    //Final expect value
+    expect(final_val).toEqual([{ answer: 0, reason: "something" }]);
+  });
+});


### PR DESCRIPTION
Before we push more features, we should lay the groundwork for setting up robust tests. As an integration platform, it's essential to have integration tests. But LLM calls are expensive. But don't worry, caching to the rescue! (I hope)

## Issues
- There are few/no integration tests in LlamaIndexTS
- But to do integration tests, we need API calls

"Well. Looks like we have ourselves a genuine conundrum. A quandry if you will. A real life dilemma." – Killa, John Wick 4

## Ways to resolve issues
- Make it easy to write integration tests
- Cache LLM calls using Redis (both embedding and completions)

## How we'll implement this
- Keep a dump of cached prompts in Redis .rdb file, which can be loaded in during testing

#### Quick Maths (rough estimate) about Redis store size
  - 1 prompt (~8000 tokens) * 5 characters/token  = 40K characters/prompt * ~2 byte/char (utf-8, including special chars) ≈ 80KB/prompt
  -  1 GB / 80KB ≈ 12K prompts
  - 12K / 25 (# prompts/integration test) ≈ 500 integration tests * 70% (-30% overhead discount, just in case)
  - divided by 2, since we have to cache {text_chunk: embedding} too
  - which evaluates to ≈175 integration tests minimum before we hit 1GB.

**TL;DR** We can use this approach for a while. These estimates are really conservative too.

## Edge Cases/Concerns
- **Multiple LLMs?** We can have multiple hash stores
- **Cost?** The first integration test will be expensive, but the rest will be free
- **Maintenance?** Store the DB dump file and load it in
- **Cloud?** Nope, everything is done locally
- **Scale?** See above

## To-do List
- [ ] Make wrapper class over LLM that caches completions/embeddings
- [ ] Test Redis in sandbox
- [ ] Implement Redis store, RedisGUI sanity check
- [ ] Get Redis to work during integration test
- [ ] (Proof of Concept) Write full integration test for src/QueryEngine, and get it running

