### PR TITLE
Feature: Added `LLMMetadata` interface

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,6 @@
     "lint": "eslint .",
     "test": "jest",
     "build": "tsup src/index.ts --format esm,cjs --dts",
-    "dev": "tsup src/index.ts --format esm,cjs --watch"
+    "dev": "tsup src/index.ts --format esm,cjs --dts --watch"
   }
 }

--- a/packages/core/src/ChatEngine.ts
+++ b/packages/core/src/ChatEngine.ts
@@ -297,7 +297,7 @@ export class ContextChatEngine implements ChatEngine {
  */
 export class HistoryChatEngine implements ChatEngine {
   summaryChatHistory: SummaryChatHistory;
-  llm: OpenAI;
+  llm: LLM;
 
   constructor(init?: Partial<HistoryChatEngine>) {
     const llm = init?.llm ?? new OpenAI();

--- a/packages/core/src/ChatHistory.ts
+++ b/packages/core/src/ChatHistory.ts
@@ -1,4 +1,4 @@
-import tiktoken from "tiktoken";
+import { globalsHelper } from "./GlobalsHelper";
 import {
   ALL_AVAILABLE_OPENAI_MODELS,
   ChatMessage,
@@ -76,13 +76,13 @@ export class SummaryChatHistory implements ChatHistory {
 
   private tokens(messages: ChatMessage[]): number {
     // for latest OpenAI models, see https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-    const encoding = tiktoken.encoding_for_model(this.llm.model);
+    const tokenizer = globalsHelper.tokenizer();
     const tokensPerMessage = 3;
     let numTokens = 0;
     for (const message of messages) {
       numTokens += tokensPerMessage;
       for (const value of Object.values(message)) {
-        numTokens += encoding.encode(value).length;
+        numTokens += tokenizer(value).length;
       }
     }
     numTokens += 3; // every reply is primed with <|im_start|>assistant<|im_sep|>

--- a/packages/core/src/ChatHistory.ts
+++ b/packages/core/src/ChatHistory.ts
@@ -1,10 +1,4 @@
-import { globalsHelper } from "./GlobalsHelper";
-import {
-  ALL_AVAILABLE_OPENAI_MODELS,
-  ChatMessage,
-  MessageType,
-  OpenAI,
-} from "./llm/LLM";
+import { ChatMessage, LLM, MessageType, OpenAI } from "./llm/LLM";
 import {
   defaultSummaryPrompt,
   messagesToHistoryStr,
@@ -56,37 +50,19 @@ export class SummaryChatHistory implements ChatHistory {
   tokensToSummarize: number;
   messages: ChatMessage[];
   summaryPrompt: SummaryPrompt;
-  llm: OpenAI;
+  llm: LLM;
 
   constructor(init?: Partial<SummaryChatHistory>) {
     this.messages = init?.messages ?? [];
     this.summaryPrompt = init?.summaryPrompt ?? defaultSummaryPrompt;
     this.llm = init?.llm ?? new OpenAI();
-    if (!this.llm.maxTokens) {
+    if (!this.llm.metadata.maxTokens) {
       throw new Error(
         "LLM maxTokens is not set. Needed so the summarizer ensures the context window size of the LLM.",
       );
     }
-    // TODO: currently, this only works with OpenAI
-    // to support more LLMs, we have to move the tokenizer and the context window size to the LLM interface
     this.tokensToSummarize =
-      ALL_AVAILABLE_OPENAI_MODELS[this.llm.model].contextWindow -
-      this.llm.maxTokens;
-  }
-
-  private tokens(messages: ChatMessage[]): number {
-    // for latest OpenAI models, see https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-    const tokenizer = globalsHelper.tokenizer();
-    const tokensPerMessage = 3;
-    let numTokens = 0;
-    for (const message of messages) {
-      numTokens += tokensPerMessage;
-      for (const value of Object.values(message)) {
-        numTokens += tokenizer(value).length;
-      }
-    }
-    numTokens += 3; // every reply is primed with <|im_start|>assistant<|im_sep|>
-    return numTokens;
+      this.llm.metadata.contextWindow - this.llm.metadata.maxTokens;
   }
 
   private async summarize(): Promise<ChatMessage> {
@@ -109,7 +85,7 @@ export class SummaryChatHistory implements ChatHistory {
       ];
       // remove oldest message until the chat history is short enough for the context window
       messagesToSummarize.shift();
-    } while (this.tokens(promptMessages) > this.tokensToSummarize);
+    } while (this.llm.tokens(promptMessages) > this.tokensToSummarize);
 
     const response = await this.llm.chat(promptMessages);
     return { content: response.message.content, role: "memory" };
@@ -117,7 +93,7 @@ export class SummaryChatHistory implements ChatHistory {
 
   async addMessage(message: ChatMessage) {
     // get tokens of current request messages and the new message
-    const tokens = this.tokens([...this.requestMessages, message]);
+    const tokens = this.llm.tokens([...this.requestMessages, message]);
     // if there are too many tokens for the next request, call summarize
     if (tokens > this.tokensToSummarize) {
       const memoryMessage = await this.summarize();

--- a/packages/core/src/GlobalsHelper.ts
+++ b/packages/core/src/GlobalsHelper.ts
@@ -4,6 +4,10 @@ import { Tiktoken } from "tiktoken/lite";
 import { v4 as uuidv4 } from "uuid";
 import { Event, EventTag, EventType } from "./callbacks/CallbackManager";
 
+export enum Tokenizers {
+  CL100K_BASE = "cl100k_base",
+}
+
 /**
  * Helper class singleton
  */
@@ -30,7 +34,10 @@ class GlobalsHelper {
     };
   }
 
-  tokenizer() {
+  tokenizer(encoding?: string) {
+    if (encoding && encoding !== Tokenizers.CL100K_BASE) {
+      throw new Error(`Tokenizer encoding ${encoding} not yet supported`);
+    }
     if (!this.defaultTokenizer) {
       this.initDefaultTokenizer();
     }
@@ -38,7 +45,10 @@ class GlobalsHelper {
     return this.defaultTokenizer!.encode.bind(this.defaultTokenizer);
   }
 
-  tokenizerDecoder() {
+  tokenizerDecoder(encoding?: string) {
+    if (encoding && encoding !== Tokenizers.CL100K_BASE) {
+      throw new Error(`Tokenizer encoding ${encoding} not yet supported`);
+    }
     if (!this.defaultTokenizer) {
       this.initDefaultTokenizer();
     }


### PR DESCRIPTION
- Make usage of `HistoryChatEngine` the same as the usage of `ContextChatEngine`
- Add `LLMMetadata` interface and use it by the `SummaryChatHistory`
- Moved `tokens` function for the calculation of tokens per a set of chat messages to the LLM (as it's LLM specific)