### PR TITLE
fix: use llamaindex version and not create-llama version

### DIFF
--- a/packages/create-llama/templates/index.ts
+++ b/packages/create-llama/templates/index.ts
@@ -5,7 +5,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { bold, cyan } from "picocolors";
-import { version } from "../package.json";
+import { version } from "../../core/package.json";
 
 import { PackageManager } from "../helpers/get-pkg-manager";
 import {


### PR DESCRIPTION
use llamaindex version for referencing llamaindex in the generated `package.json` and not the wrong create-llama version (worked before as both versions have been in sync)