### PR TITLE
Update backend README Fixes run-llama/LlamaIndexTS#198

### DIFF
--- a/packages/create-llama/templates/types/simple/fastapi/README-template.md
+++ b/packages/create-llama/templates/types/simple/fastapi/README-template.md
@@ -9,9 +9,10 @@ poetry install
 poetry shell
 ```
 
-Second, run the development server:
+Second, export your API key. Then run the development server:
 
 ```
+export $(cat .env)
 python main.py
 ```
 


### PR DESCRIPTION
Describe how to export your API key added during setup before running the backend server (this is required if you provided an OpenAI API key).