### PR TITLE
fix: generated frontend is sending text/plain

### DIFF
--- a/packages/create-llama/templates/types/simple/express/index.ts
+++ b/packages/create-llama/templates/types/simple/express/index.ts
@@ -13,7 +13,7 @@ if (isDevelopment) {
   app.use(cors());
 }
 
-app.use(express.json());
+app.use(express.text());
 
 app.get("/", (req: Request, res: Response) => {
   res.send("LlamaIndex Express Server");

--- a/packages/create-llama/templates/types/simple/express/src/controllers/chat.controller.ts
+++ b/packages/create-llama/templates/types/simple/express/src/controllers/chat.controller.ts
@@ -4,7 +4,7 @@ import { createChatEngine } from "./engine";
 
 export const chat = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { messages }: { messages: ChatMessage[] } = req.body;
+    const { messages }: { messages: ChatMessage[] } = JSON.parse(req.body);
     const lastMessage = messages.pop();
     if (!messages || !lastMessage || lastMessage.role !== "user") {
       return res.status(400).json({

--- a/packages/create-llama/templates/types/streaming/express/index.ts
+++ b/packages/create-llama/templates/types/streaming/express/index.ts
@@ -13,7 +13,7 @@ if (isDevelopment) {
   app.use(cors());
 }
 
-app.use(express.json());
+app.use(express.text());
 
 app.get("/", (req: Request, res: Response) => {
   res.send("LlamaIndex Express Server");

--- a/packages/create-llama/templates/types/streaming/express/src/controllers/chat.controller.ts
+++ b/packages/create-llama/templates/types/streaming/express/src/controllers/chat.controller.ts
@@ -6,7 +6,7 @@ import { LlamaIndexStream } from "./llamaindex-stream";
 
 export const chat = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { messages }: { messages: ChatMessage[] } = req.body;
+    const { messages }: { messages: ChatMessage[] } = JSON.parse(req.body);
     const lastMessage = messages.pop();
     if (!messages || !lastMessage || lastMessage.role !== "user") {
       return res.status(400).json({


### PR DESCRIPTION
Express middleware was expecting a JSON payload and getting text/plain, so parse the JSON in the controller instead.

There may be a smarter way to do this.