### PR TITLE
Fix: env is not loaded in time to prevent erroring out

### DIFF
--- a/packages/create-llama/templates/types/simple/fastapi/main.py
+++ b/packages/create-llama/templates/types/simple/fastapi/main.py
@@ -1,12 +1,12 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 import logging
 import os
 import uvicorn
 from app.api.routers.chat import chat_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from dotenv import load_dotenv
-
-load_dotenv()
 
 app = FastAPI()
 

--- a/packages/create-llama/templates/types/streaming/fastapi/main.py
+++ b/packages/create-llama/templates/types/streaming/fastapi/main.py
@@ -1,12 +1,12 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 import logging
 import os
 import uvicorn
 from app.api.routers.chat import chat_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from dotenv import load_dotenv
-
-load_dotenv()
 
 app = FastAPI()
 


### PR DESCRIPTION
dotenv must load before chat_router or .env isn't picked up in time