### PR TITLE
Fix: python backend leaks API key by default

### DIFF
--- a/packages/create-llama/templates/types/simple/fastapi/gitignore
+++ b/packages/create-llama/templates/types/simple/fastapi/gitignore
@@ -1,2 +1,3 @@
 __pycache__
 storage
+.env

--- a/packages/create-llama/templates/types/streaming/fastapi/gitignore
+++ b/packages/create-llama/templates/types/streaming/fastapi/gitignore
@@ -1,2 +1,3 @@
 __pycache__
 storage
+.env


### PR DESCRIPTION
.gitignore should include .env