### PR TITLE
Handle Azure specific responses, where choices could be 0

### DIFF
--- a/packages/core/src/llm/LLM.ts
+++ b/packages/core/src/llm/LLM.ts
@@ -337,6 +337,8 @@ export class OpenAI implements LLM {
     //Indices
     var idx_counter: number = 0;
     for await (const part of chunk_stream) {
+      if (!part.choices.length) continue;
+
       //Increment
       part.choices[0].index = idx_counter;
       const is_done: boolean =


### PR DESCRIPTION
When streaming Azure replies the following as part of a chunk. Notice that there are no `choices`.

```
{
  id: '',
  object: '',
  created: 0,
  model: '',
  prompt_filter_results: [ { prompt_index: 0, content_filter_results: [Object] } ],
  choices: []
}
```

The suggested fix skips over these chunks as so not to cause `TypeError: Cannot set properties of undefined (setting 'index')` error