### PR TITLE
Feat: Update AssemblyAI reader to use new SDK functions

### DIFF
--- a/apps/simple/assemblyai.ts
+++ b/apps/simple/assemblyai.ts
@@ -1,5 +1,5 @@
 import { program } from "commander";
-import { AudioTranscriptReader, CreateTranscriptParameters } from "llamaindex";
+import { AudioTranscriptReader, TranscribeParams } from "llamaindex";
 import { stdin as input, stdout as output } from "node:process";
 // readline/promises is still experimental so not in @types/node yet
 // @ts-ignore
@@ -19,11 +19,10 @@ program
     }
 
     const reader = new AudioTranscriptReader();
-    let params: CreateTranscriptParameters | string;
-    console.log(options);
+    let params: TranscribeParams | string;
     if (options.audioUrl) {
       params = {
-        audio_url: options.audioUrl,
+        audio: options.audioUrl,
       };
     } else if (options.transcriptId) {
       params = options.transcriptId;

--- a/examples/assemblyai.ts
+++ b/examples/assemblyai.ts
@@ -1,5 +1,5 @@
 import { program } from "commander";
-import { AudioTranscriptReader, CreateTranscriptParameters } from "llamaindex";
+import { AudioTranscriptReader, TranscribeParams } from "llamaindex";
 import { stdin as input, stdout as output } from "node:process";
 // readline/promises is still experimental so not in @types/node yet
 // @ts-ignore
@@ -19,11 +19,10 @@ program
     }
 
     const reader = new AudioTranscriptReader();
-    let params: CreateTranscriptParameters | string;
-    console.log(options);
+    let params: TranscribeParams | string;
     if (options.audioUrl) {
       params = {
-        audio_url: options.audioUrl,
+        audio: options.audioUrl,
       };
     } else if (options.transcriptId) {
       params = options.transcriptId;

--- a/packages/core/src/readers/AssemblyAI.ts
+++ b/packages/core/src/readers/AssemblyAI.ts
@@ -1,8 +1,8 @@
 import {
   AssemblyAI,
   BaseServiceParams,
-  CreateTranscriptParameters,
   SubtitleFormat,
+  TranscribeParams,
   TranscriptParagraph,
   TranscriptSentence,
 } from "assemblyai";
@@ -31,7 +31,9 @@ abstract class AssemblyAIReader implements BaseReader {
       options.apiKey = process.env.ASSEMBLYAI_API_KEY;
     }
     if (!options.apiKey) {
-      throw new Error("No AssemblyAI API key provided. Pass an `apiKey` option, or configure the `ASSEMBLYAI_API_KEY` environment variable.");
+      throw new Error(
+        "No AssemblyAI API key provided. Pass an `apiKey` option, or configure the `ASSEMBLYAI_API_KEY` environment variable.",
+      );
     }
 
     this.client = new AssemblyAI(options as BaseServiceParams);
@@ -39,110 +41,103 @@ abstract class AssemblyAIReader implements BaseReader {
 
   abstract loadData(...args: any[]): Promise<Document[]>;
 
-  protected async getOrCreateTranscript(params: CreateTranscriptParameters | string) {
+  protected async transcribeOrGetTranscript(params: TranscribeParams | string) {
     if (typeof params === "string") {
       return await this.client.transcripts.get(params);
-    }
-    else {
-      return await this.client.transcripts.create(params);
+    } else {
+      return await this.client.transcripts.transcribe(params);
     }
   }
 
-  protected async getTranscriptId(params: CreateTranscriptParameters | string) {
+  protected async getTranscriptId(params: TranscribeParams | string) {
     if (typeof params === "string") {
       return params;
-    }
-    else {
-      return (await this.client.transcripts.create(params)).id;
+    } else {
+      return (await this.client.transcripts.transcribe(params)).id;
     }
   }
 }
 
 /**
- * Creates and reads the transcript as a document using AssemblyAI.
+ * Transcribe audio and read the transcript as a document using AssemblyAI.
  */
 class AudioTranscriptReader extends AssemblyAIReader {
   /**
-   * Creates or gets a transcript and loads the transcript as a document using AssemblyAI.
-   * @param params The parameters to create or get the transcript.
+   * Transcribe audio or get a transcript and load the transcript as a document using AssemblyAI.
+   * @param params Parameters to transcribe an audio file or get an existing transcript.
    * @returns A promise that resolves to a single document containing the transcript text.
    */
-  async loadData(params: CreateTranscriptParameters | string): Promise<Document[]> {
-    const transcript = await this.getOrCreateTranscript(params);
-    return [
-      new Document({ text: transcript.text || undefined }),
-    ];
+  async loadData(params: TranscribeParams | string): Promise<Document[]> {
+    const transcript = await this.transcribeOrGetTranscript(params);
+    return [new Document({ text: transcript.text || undefined })];
   }
 }
 
 /**
- * Creates a transcript and returns a document for each paragraph.
+ * Transcribe audio and return a document for each paragraph.
  */
 class AudioTranscriptParagraphsReader extends AssemblyAIReader {
   /**
-   * Creates or gets a transcript, and returns a document for each paragraph.
-   * @param params The parameters to create or get the transcript.
+   * Transcribe audio or get a transcript, and returns a document for each paragraph.
+   * @param params The parameters to transcribe audio or get an existing transcript.
    * @returns A promise that resolves to an array of documents, each containing a paragraph of the transcript.
    */
-  async loadData(params: CreateTranscriptParameters | string): Promise<Document[]> {
+  async loadData(params: TranscribeParams | string): Promise<Document[]> {
     let transcriptId = await this.getTranscriptId(params);
-    const paragraphsResponse = await this.client.transcripts.paragraphs(
-      transcriptId
-    );
-    return paragraphsResponse.paragraphs.map((p: TranscriptParagraph) =>
-      new Document({ text: p.text }),
+    const paragraphsResponse =
+      await this.client.transcripts.paragraphs(transcriptId);
+    return paragraphsResponse.paragraphs.map(
+      (p: TranscriptParagraph) => new Document({ text: p.text }),
     );
   }
 }
 
 /**
- * Creates a transcript and returns a document for each sentence.
+ * Transcribe audio and return a document for each sentence.
  */
 class AudioTranscriptSentencesReader extends AssemblyAIReader {
   /**
-   * Creates or gets a transcript, and returns a document for each sentence.
-   * @param params The parameters to create or get the transcript.
+   * Transcribe audio or get a transcript, and returns a document for each sentence.
+   * @param params The parameters to transcribe audio or get an existing transcript.
    * @returns A promise that resolves to an array of documents, each containing a sentence of the transcript.
    */
-  async loadData(params: CreateTranscriptParameters | string): Promise<Document[]> {
+  async loadData(params: TranscribeParams | string): Promise<Document[]> {
     let transcriptId = await this.getTranscriptId(params);
-    const sentencesResponse = await this.client.transcripts.sentences(
-      transcriptId
-    );
-    return sentencesResponse.sentences.map((p: TranscriptSentence) =>
-      new Document({ text: p.text }),
+    const sentencesResponse =
+      await this.client.transcripts.sentences(transcriptId);
+    return sentencesResponse.sentences.map(
+      (p: TranscriptSentence) => new Document({ text: p.text }),
     );
   }
 }
 
 /**
- * Creates a transcript and reads subtitles for the transcript as `srt` or `vtt` format.
+ * Transcribe audio a transcript and read subtitles for the transcript as `srt` or `vtt` format.
  */
 class AudioSubtitlesReader extends AssemblyAIReader {
   /**
-   * Creates or gets a transcript and reads subtitles for the transcript as `srt` or `vtt` format.
-   * @param params The parameters to create or get the transcript.
+   * Transcribe audio or get a transcript and reads subtitles for the transcript as `srt` or `vtt` format.
+   * @param params The parameters to transcribe audio or get an existing transcript.
    * @param subtitleFormat The format of the subtitles, either `srt` or `vtt`.
    * @returns A promise that resolves a document containing the subtitles as the page content.
    */
   async loadData(
-    params: CreateTranscriptParameters | string,
-    subtitleFormat: SubtitleFormat = 'srt'
+    params: TranscribeParams | string,
+    subtitleFormat: SubtitleFormat = "srt",
   ): Promise<Document[]> {
     let transcriptId = await this.getTranscriptId(params);
-    const subtitles = await this.client.transcripts.subtitles(transcriptId, subtitleFormat);
+    const subtitles = await this.client.transcripts.subtitles(
+      transcriptId,
+      subtitleFormat,
+    );
     return [new Document({ text: subtitles })];
   }
 }
 
 export {
-  AudioTranscriptReader,
-  AudioTranscriptParagraphsReader,
-  AudioTranscriptSentencesReader,
   AudioSubtitlesReader,
-}
-export type {
-  AssemblyAIOptions,
-  CreateTranscriptParameters,
-  SubtitleFormat
-}
+  AudioTranscriptParagraphsReader,
+  AudioTranscriptReader,
+  AudioTranscriptSentencesReader,
+};
+export type { AssemblyAIOptions, SubtitleFormat, TranscribeParams };


### PR DESCRIPTION
I noticed you have this PR open to re-add AssemblyAI with the latest version.
I took the liberty to update the code to use the new function `transcribe` instead of the deprecated `create`.