### PR TITLE
Fix: Set max tokens to 512 for nextjs examples

### DIFF
--- a/packages/create-llama/templates/types/streaming/nextjs/app/api/chat/route.ts
+++ b/packages/create-llama/templates/types/streaming/nextjs/app/api/chat/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: NextRequest) {
 
     const llm = new OpenAI({
       model: MODEL,
-      maxTokens: 2048,
+      maxTokens: 512,
     });
 
     const chatEngine = await createChatEngine(llm);


### PR DESCRIPTION
Sets max tokens to 512. I talked with @logan-markewich that this is a good default. (2048 is too high for GPT3.5). 

The reason why we have to set a value:
If we don't do so, for the GPT4 Vision model, the stream stops after a couple of characters; see:

<img width="1071" alt="image" src="https://github.com/run-llama/LlamaIndexTS/assets/17126/a3fda2da-cc60-4bac-b0ce-43779451e71e">
