### PR TITLE
Update Astra client and associated type changes

### DIFF
--- a/examples/astradb/README.md
+++ b/examples/astradb/README.md
@@ -12,10 +12,8 @@ Here are two sample scripts which work well with the sample data in the Astra Po
 
 1. Set your env variables:
 
-- `ASTRA_DB_ID`: Your Astra DB vector database id
 - `ASTRA_DB_APPLICATION_TOKEN`: The generated app token for your Astra database
-- `ASTRA_DB_REGION`: Your Astra DB database region
-- `ASTRA_DB_NAMESPACE`: The existing Astra Namespace/Keyspace (if you don't set this it will default to `default_keyspace`)
+- `ASTRA_DB_ENDPOINT`: The API endpoint for your Astra database
 - `OPENAI_API_KEY`: Your OpenAI key
 
 2. `cd` Into the `examples` directory

--- a/examples/astradb/load.ts
+++ b/examples/astradb/load.ts
@@ -14,7 +14,7 @@ async function main() {
 
     const astraVS = new AstraDBVectorStore();
     await astraVS.create(collectionName, {
-      vector: { size: 1536, function: "cosine" },
+      vector: { dimension: 1536, metric: "cosine" },
     });
     await astraVS.connect(collectionName);
 

--- a/examples/astradb/query.ts
+++ b/examples/astradb/query.ts
@@ -4,7 +4,7 @@ import {
   VectorStoreIndex,
 } from "llamaindex";
 
-const collectionName = "movie_reviews_2";
+const collectionName = "movie_reviews";
 
 async function main() {
   try {

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,7 +4,7 @@
   "name": "simple",
   "dependencies": {
     "@notionhq/client": "^2.2.13",
-    "@datastax/astra-db-ts": "^0.1.0",
+    "@datastax/astra-db-ts": "^0.1.2",
     "@pinecone-database/pinecone": "^1.1.2",
     "commander": "^11.1.0",
     "llamaindex": "latest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.9.1",
-    "@datastax/astra-db-ts": "^0.1.0",
+    "@datastax/astra-db-ts": "^0.1.2",
     "@mistralai/mistralai": "^0.0.7",
     "@notionhq/client": "^2.2.14",
     "@xenova/transformers": "^2.10.0",

--- a/packages/core/src/storage/vectorStore/AstraDBVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/AstraDBVectorStore.ts
@@ -1,5 +1,6 @@
 import { AstraDB } from "@datastax/astra-db-ts";
 import { Collection } from "@datastax/astra-db-ts/dist/collections";
+import { CreateCollectionOptions } from "@datastax/astra-db-ts/dist/collections/options";
 import { BaseNode, Document, MetadataMode } from "../../Node";
 import { VectorStore, VectorStoreQuery, VectorStoreQueryResult } from "./types";
 
@@ -20,9 +21,7 @@ export class AstraDBVectorStore implements VectorStore {
     init?: Partial<AstraDBVectorStore> & {
       params?: {
         token: string;
-        dbId: string;
-        region: string;
-        keyspace: string;
+        endpoint: string;
       };
     },
   ) {
@@ -31,22 +30,17 @@ export class AstraDBVectorStore implements VectorStore {
     } else {
       const token =
         init?.params?.token ?? process.env.ASTRA_DB_APPLICATION_TOKEN;
-      const dbId = init?.params?.dbId ?? process.env.ASTRA_DB_ID;
-      const region = init?.params?.region ?? process.env.ASTRA_DB_REGION;
-      const keyspace = init?.params?.keyspace ?? process.env.ASTRA_DB_NAMESPACE;
+      const endpoint = init?.params?.endpoint ?? process.env.ASTRA_DB_ENDPOINT;
 
-      if (!dbId) {
-        throw new Error("Must specify ASTRA_DB_ID via env variable.");
-      }
       if (!token) {
         throw new Error(
           "Must specify ASTRA_DB_APPLICATION_TOKEN via env variable.",
         );
       }
-      if (!region) {
-        throw new Error("Must specify ASTRA_DB_REGION via env variable.");
+      if (!endpoint) {
+        throw new Error("Must specify ASTRA_DB_ENDPOINT via env variable.");
       }
-      this.astraDBClient = new AstraDB(token, dbId, region, keyspace);
+      this.astraDBClient = new AstraDB(token, endpoint);
     }
 
     this.idKey = init?.idKey ?? "_id";
@@ -63,7 +57,10 @@ export class AstraDBVectorStore implements VectorStore {
    * @param options: CreateCollectionOptions used to set the number of vector dimensions and similarity metric
    * @returns Promise that resolves if the creation did not throw an error.
    */
-  async create(collection: string, options: any): Promise<void> {
+  async create(
+    collection: string,
+    options: CreateCollectionOptions,
+  ): Promise<void> {
     await this.astraDBClient.createCollection(collection, options);
     console.debug("Created Astra DB collection");
 
@@ -118,7 +115,7 @@ export class AstraDBVectorStore implements VectorStore {
     console.debug(`Adding ${dataToInsert.length} rows to table`);
 
     // Perform inserts in steps of MAX_INSERT_BATCH_SIZE
-    let batchData = [];
+    let batchData: any[] = [];
 
     for (let i = 0; i < dataToInsert.length; i += MAX_INSERT_BATCH_SIZE) {
       batchData.push(dataToInsert.slice(i, i + MAX_INSERT_BATCH_SIZE));

--- a/packages/core/src/storage/vectorStore/AstraDBVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/AstraDBVectorStore.ts
@@ -52,7 +52,6 @@ export class AstraDBVectorStore implements VectorStore {
    * Create a new collection in your Astra DB vector database.
    * You must still use connect() to connect to the collection.
    *
-   * @TODO align options type with the JSON API's expected format
    * @param collection your new colletion's name
    * @param options: CreateCollectionOptions used to set the number of vector dimensions and similarity metric
    * @returns Promise that resolves if the creation did not throw an error.

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -11,10 +11,8 @@ module.exports = {
           "ANTHROPIC_API_KEY",
           "ASSEMBLYAI_API_KEY",
 
-          "ASTRA_DB_ID",
-          "ASTRA_DB_REGION",
           "ASTRA_DB_APPLICATION_TOKEN",
-          "ASTRA_DB_NAMESPACE",
+          "ASTRA_DB_ENDPOINT",
 
           "AZURE_OPENAI_KEY",
           "AZURE_OPENAI_ENDPOINT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
   examples:
     dependencies:
       '@datastax/astra-db-ts':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.2
+        version: 0.1.2
       '@notionhq/client':
         specifier: ^2.2.13
         version: 2.2.13
@@ -141,8 +141,8 @@ importers:
         specifier: ^0.9.1
         version: 0.9.1
       '@datastax/astra-db-ts':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.2
+        version: 0.1.2
       '@mistralai/mistralai':
         specifier: ^0.0.7
         version: 0.0.7
@@ -2313,8 +2313,8 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@datastax/astra-db-ts@0.1.0:
-    resolution: {integrity: sha512-GnF+9ntFBnh7TfDjRQew8NB4FoXJOyt34K5RbY4M7aqKw87Mtp1hbttwMDsor/ouX+pqpnw7kSrVVyMHKmo8kQ==}
+  /@datastax/astra-db-ts@0.1.2:
+    resolution: {integrity: sha512-JfgQCjNuyqJ4ki38pWBBz9oR/UJHJDruqjSLAZp0sjFr17asr2QMNsNTiW30otNqjA+mWBy9lS6x+mFXESvr0Q==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
- Updates `@datastax/astra-db-ts` to `0.1.2`
- Connect to AstraDB with `ASTRA_DB_ENDPOINT` instead of DB ID and region
- Align `create` collection functions param `options` to be of type `CreateCollectionOptions`
- Update Readme and examples accordingly