### PR TITLE
Feat: store images in docstore

### DIFF
--- a/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
+++ b/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
@@ -4,7 +4,6 @@ import {
   ImageNode,
   MetadataMode,
   ObjectType,
-  jsonToNode,
   splitNodesByType,
 } from "../../Node";
 import { BaseQueryEngine, RetrieverQueryEngine } from "../../QueryEngine";
@@ -24,7 +23,7 @@ import {
 } from "../../storage/StorageContext";
 import { BaseIndexStore } from "../../storage/indexStore/types";
 import { VectorStore } from "../../storage/vectorStore/types";
-import { ResponseSynthesizer, BaseSynthesizer } from "../../synthesizers";
+import { BaseSynthesizer } from "../../synthesizers";
 import {
   BaseIndex,
   BaseIndexInit,
@@ -276,9 +275,11 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       if (
         !vectorStore.storesText ||
         type === ObjectType.INDEX ||
-        type === ObjectType.IMAGE
+        type === ObjectType.IMAGE ||
+        type === ObjectType.IMAGE_DOCUMENT
       ) {
-        const nodeWithoutEmbedding = jsonToNode(nodes[i].toJSON());
+        // TODO: calling clone is inefficient for image nodes, optimize this later
+        const nodeWithoutEmbedding = await nodes[i].clone();
         nodeWithoutEmbedding.embedding = undefined;
         this.indexStruct.addNode(nodeWithoutEmbedding, newIds[i]);
         this.docStore.addDocuments([nodeWithoutEmbedding], true);

--- a/packages/core/src/storage/docStore/KVDocumentStore.ts
+++ b/packages/core/src/storage/docStore/KVDocumentStore.ts
@@ -45,7 +45,7 @@ export class KVDocumentStore extends BaseDocumentStore {
         );
       }
       let nodeKey = doc.id_;
-      let data = docToJson(doc);
+      let data = await docToJson(doc);
       await this.kvstore.put(nodeKey, data, this.nodeCollection);
       let metadata: DocMetaData = { docHash: doc.hash };
 

--- a/packages/core/src/storage/docStore/utils.ts
+++ b/packages/core/src/storage/docStore/utils.ts
@@ -1,11 +1,11 @@
-import { BaseNode, Document, ObjectType, TextNode } from "../../Node";
+import { BaseNode, jsonToNode } from "../../Node";
 
 const TYPE_KEY = "__type__";
 const DATA_KEY = "__data__";
 
-export function docToJson(doc: BaseNode): Record<string, any> {
+export async function docToJson(doc: BaseNode): Promise<Record<string, any>> {
   return {
-    [DATA_KEY]: JSON.stringify(doc),
+    [DATA_KEY]: JSON.stringify(await doc.aToJSON()),
     [TYPE_KEY]: doc.getType(),
   };
 }
@@ -13,26 +13,5 @@ export function docToJson(doc: BaseNode): Record<string, any> {
 export function jsonToDoc(docDict: Record<string, any>): BaseNode {
   let docType = docDict[TYPE_KEY];
   let dataDict = JSON.parse(docDict[DATA_KEY]);
-  let doc: BaseNode;
-
-  if (docType === ObjectType.DOCUMENT) {
-    doc = new Document({
-      text: dataDict.text,
-      id_: dataDict.id_,
-      embedding: dataDict.embedding,
-      hash: dataDict.hash,
-      metadata: dataDict.metadata,
-    });
-  } else if (docType === ObjectType.TEXT) {
-    doc = new TextNode({
-      text: dataDict.text,
-      id_: dataDict.id_,
-      hash: dataDict.hash,
-      metadata: dataDict.metadata,
-    });
-  } else {
-    throw new Error(`Unknown doc type: ${docType}`);
-  }
-
-  return doc;
+  return jsonToNode(dataDict, docType);
 }


### PR DESCRIPTION
In #280 the `VectorIndexRetriever` is retrieving image documents from the index and reconstructing their URL based on their ID (see https://github.com/run-llama/LlamaIndexTS/pull/280/files#r1427834636).

Suggestion:
1. Store the images in the doc store (This PR stores images of `ImageNode`s base64 encoded in the doc store)
2. Use the doc store to get the images in the `VectorIndexRetriever`

What are your thoughts?