### PR TITLE
fix: align separator with llama_index

### DIFF
--- a/packages/core/src/TextSplitter.ts
+++ b/packages/core/src/TextSplitter.ts
@@ -1,5 +1,5 @@
+import { EOL } from 'node:os'
 // GitHub translated
-
 import { globalsHelper } from "./GlobalsHelper";
 import { DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE } from "./constants";
 
@@ -41,11 +41,7 @@ export const cjkSentenceTokenizer = (text: string) => {
   );
 };
 
-export const unixLineSeparator = "\n";
-export const windowsLineSeparator = "\r\n";
-export const unixParagraphSeparator = unixLineSeparator + unixLineSeparator;
-export const windowsParagraphSeparator =
-  windowsLineSeparator + windowsLineSeparator;
+export const defaultParagraphSeparator = EOL + EOL + EOL
 
 // In theory there's also Mac style \r only, but it's pre-OSX and I don't think
 // many documents will use it.
@@ -78,7 +74,7 @@ export class SentenceSplitter {
       chunkOverlap = DEFAULT_CHUNK_OVERLAP,
       tokenizer = null,
       tokenizerDecoder = null,
-      paragraphSeparator = unixParagraphSeparator,
+      paragraphSeparator = defaultParagraphSeparator,
       chunkingTokenizerFn = undefined,
       splitLongSentences = false,
     } = options ?? {};

--- a/packages/core/src/tests/TextSplitter.test.ts
+++ b/packages/core/src/tests/TextSplitter.test.ts
@@ -10,7 +10,7 @@ describe("SentenceSplitter", () => {
     const sentenceSplitter = new SentenceSplitter({});
     // generate the same line as above but correct syntax errors
     let splits = sentenceSplitter.getParagraphSplits(
-      "This is a paragraph.\n\nThis is another paragraph.",
+      "This is a paragraph.\n\n\nThis is another paragraph.",
       undefined,
     );
     expect(splits).toEqual([


### PR DESCRIPTION
https://github.com/run-llama/llama_index/blob/df9a30d63d402a21ccbbf5948afc68f057d913f2/llama_index/node_parser/text/sentence.py#L20

BREAKING:

remove `unixLineSeparator` and `windowsLineSeparator`, use `EOL` from `node:os` instead