### PR TITLE
Add Pinecone support to create-llama (typescript)

### DIFF
--- a/packages/create-llama/questions.ts
+++ b/packages/create-llama/questions.ts
@@ -253,6 +253,7 @@ export const askQuestions = async (
                 value: "none",
               },
               { title: "MongoDB", value: "mongo" },
+              { title: "Pinecone", value: "pinecone" },
             ],
             initial: 0,
           },

--- a/packages/create-llama/templates/components/vectordbs/typescript/pinecone/generate.mjs
+++ b/packages/create-llama/templates/components/vectordbs/typescript/pinecone/generate.mjs
@@ -1,0 +1,35 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import * as dotenv from "dotenv";
+import {
+  SimpleDirectoryReader,
+  VectorStoreIndex,
+  PineconeVectorStore,
+  storageContextFromDefaults,
+} from "llamaindex";
+import { STORAGE_DIR, checkRequiredEnvVars } from "./shared.mjs";
+
+dotenv.config();
+
+async function loadAndIndex() {
+  // load objects from storage and convert them into LlamaIndex Document objects
+  const documents = await new SimpleDirectoryReader().loadData({
+    directoryPath: STORAGE_DIR,
+  });
+
+  // create vector store
+  const vectorStore = new PineconeVectorStore();
+
+  // now create an index from all the Documents and store them in Atlas
+  const storageContext = await storageContextFromDefaults({ vectorStore });
+  await VectorStoreIndex.fromDocuments(documents, { storageContext });
+  console.log(
+    `Successfully created embeddings in your Pinecone index.`,
+  );
+  await client.close();
+}
+
+(async () => {
+  checkRequiredEnvVars();
+  await loadAndIndex();
+  console.log("Finished generating storage.");
+})();

--- a/packages/create-llama/templates/components/vectordbs/typescript/pinecone/index.ts
+++ b/packages/create-llama/templates/components/vectordbs/typescript/pinecone/index.ts
@@ -1,0 +1,29 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import {
+  ContextChatEngine,
+  LLM,
+  serviceContextFromDefaults,
+  PineconeVectorStore,
+  VectorStoreIndex,
+} from "llamaindex";
+import { checkRequiredEnvVars, CHUNK_OVERLAP, CHUNK_SIZE } from "./shared.mjs";
+
+async function getDataSource(llm: LLM) {
+  checkRequiredEnvVars();
+  const serviceContext = serviceContextFromDefaults({
+    llm,
+    chunkSize: CHUNK_SIZE,
+    chunkOverlap: CHUNK_OVERLAP,
+  });
+  const store = new PineconeVectorStore();
+  return await VectorStoreIndex.fromVectorStore(store, serviceContext);
+}
+
+export async function createChatEngine(llm: LLM) {
+  const index = await getDataSource(llm);
+  const retriever = index.asRetriever({ similarityTopK: 5 });
+  return new ContextChatEngine({
+    chatModel: llm,
+    retriever,
+  });
+}

--- a/packages/create-llama/templates/components/vectordbs/typescript/pinecone/shared.mjs
+++ b/packages/create-llama/templates/components/vectordbs/typescript/pinecone/shared.mjs
@@ -1,0 +1,25 @@
+export const STORAGE_DIR = "./data";
+export const CHUNK_SIZE = 512;
+export const CHUNK_OVERLAP = 20;
+
+const REQUIRED_ENV_VARS = [
+  "PINECONE_ENVIRONMENT",
+  "PINECONE_API_KEY",
+];
+
+export function checkRequiredEnvVars() {
+  const missingEnvVars = REQUIRED_ENV_VARS.filter((envVar) => {
+    return !process.env[envVar];
+  });
+
+  if (missingEnvVars.length > 0) {
+    console.log(
+      `The following environment variables are required but missing: ${missingEnvVars.join(
+        ", ",
+      )}`,
+    );
+    throw new Error(
+      `Missing environment variables: ${missingEnvVars.join(", ")}`,
+    );
+  }
+}

--- a/packages/create-llama/templates/types.ts
+++ b/packages/create-llama/templates/types.ts
@@ -4,7 +4,7 @@ export type TemplateType = "simple" | "streaming" | "community";
 export type TemplateFramework = "nextjs" | "express" | "fastapi";
 export type TemplateEngine = "simple" | "context";
 export type TemplateUI = "html" | "shadcn";
-export type TemplateVectorDB = "none" | "mongo";
+export type TemplateVectorDB = "none" | "mongo" | "pinecone";
 
 export interface InstallTemplateArgs {
   appName: string;


### PR DESCRIPTION
Hey @marcusschiesser here's a new PR for the create-llama integration of Pinecone.  It's generating an Express app and compiling as expected, but I've got a runtime issue on which I could use some direction.

I got this stack trace when making a request from the generated UI to the generated backend.  My PINECONE_ vars are set and valid, and point to an index with data in it.

`/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/validator.js:207
[1]             throw new errors_1.PineconeArgumentError(msg);
[1]                   ^
[1] 
[1] PineconeArgumentError: The argument to query accepts multiple types. Either 1) must not have property: vector.  Must have required property: id. There were also validation errors: argument must NOT have additional properties, argument must NOT have additional properties. 2) had validation errors: argument must NOT have additional properties, argument must NOT have additional properties.
[1]     at QueryCommand.validator (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/validator.js:207:19)
[1]     at QueryCommand.<anonymous> (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/query.js:75:30)
[1]     at step (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/query.js:44:23)
[1]     at Object.next (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/query.js:25:53)
[1]     at /workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/query.js:19:71
[1]     at new Promise (<anonymous>)
[1]     at __awaiter (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/query.js:15:12)
[1]     at QueryCommand.run (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/query.js:70:16)
[1]     at Index.<anonymous> (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/index.js:348:69)
[1]     at step (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/index.js:33:23)
[1]     at Object.next (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/index.js:14:53)
[1]     at /workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/index.js:8:71
[1]     at new Promise (<anonymous>)
[1]     at __awaiter (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/index.js:4:12)
[1]     at Index.query (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/@pinecone-database/pinecone/dist/data/index.js:345:16)
[1]     at PineconeVectorStore.<anonymous> (/workspaces/LlamaIndexTS/pinecone-test/backend/node_modules/llamaindex/dist/index.js:2174:33) {
[1]   cause: undefined
[1] }`

I was able to trace it as far down as the `streamToResponse` function, it's the last thing called by chat.controller.ts.  I'm happy to help debug, let me know what else you'd like to see.