### PR TITLE
fix: don't create new hash deserialization a node

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -183,7 +183,7 @@ export class TextNode<T extends Metadata = Metadata> extends BaseNode<T> {
     if (new.target === TextNode) {
       // Don't generate the hash repeatedly so only do it if this is
       // constructing the derived class
-      this.hash = this.generateHash();
+      this.hash = init?.hash ?? this.generateHash();
     }
   }
 
@@ -234,7 +234,6 @@ export class TextNode<T extends Metadata = Metadata> extends BaseNode<T> {
 
   setContent(value: string) {
     this.text = value;
-
     this.hash = this.generateHash();
   }
 
@@ -255,7 +254,7 @@ export class IndexNode<T extends Metadata = Metadata> extends TextNode<T> {
     Object.assign(this, init);
 
     if (new.target === IndexNode) {
-      this.hash = this.generateHash();
+      this.hash = init?.hash ?? this.generateHash();
     }
   }
 
@@ -273,7 +272,7 @@ export class Document<T extends Metadata = Metadata> extends TextNode<T> {
     Object.assign(this, init);
 
     if (new.target === Document) {
-      this.hash = this.generateHash();
+      this.hash = init?.hash ?? this.generateHash();
     }
   }
 
@@ -334,7 +333,7 @@ export class ImageDocument<T extends Metadata = Metadata> extends ImageNode<T> {
     super(init);
 
     if (new.target === ImageDocument) {
-      this.hash = this.generateHash();
+      this.hash = init?.hash ?? this.generateHash();
     }
   }
 

--- a/packages/core/src/tests/Node.test.ts
+++ b/packages/core/src/tests/Node.test.ts
@@ -7,9 +7,13 @@ describe("TextNode", () => {
     node = new TextNode({ text: "Hello World" });
   });
 
-  describe("generateHash", () => {
-    it("should generate a hash", () => {
-      expect(node.hash).toBe("nTSKdUTYqR52MPv/brvb4RTGeqedTEqG9QN8KSAj2Do=");
-    });
+  test("should generate a hash", () => {
+    expect(node.hash).toBe("nTSKdUTYqR52MPv/brvb4RTGeqedTEqG9QN8KSAj2Do=");
+  });
+
+  test("clone should have the same hash", () => {
+    const hash = node.hash;
+    const clone = node.clone();
+    expect(clone.hash).toBe(hash);
   });
 });


### PR DESCRIPTION
@yisding While having fun with https://github.com/run-llama/LlamaIndexTS/pull/306, I found something that looks wrong to me: deserialization of a `Node` generates a new hash. I didn't test this extensively so that I would merge it after the next release. Please have a look.