### PR TITLE
Draft: Add poetry installation support for FastAPI

### DIFF
--- a/.changeset/silly-bugs-fold.md
+++ b/.changeset/silly-bugs-fold.md
@@ -1,0 +1,7 @@
+---
+"create-llama": patch
+---
+
+- Add support to install python dependencies
+- Add new create-llama option: `--install-dependencies`:
+  This option allows the user to choose whether to install the dependencies automatically or manually when creating a llama project. This improves the development experience of the tool.

--- a/.changeset/silly-bugs-fold.md
+++ b/.changeset/silly-bugs-fold.md
@@ -2,6 +2,4 @@
 "create-llama": patch
 ---
 
-- Add support to install python dependencies
-- Add new create-llama option: `--install-dependencies`:
-  This option allows the user to choose whether to install the dependencies automatically or manually when creating a llama project. This improves the development experience of the tool.
+Added option to automatically install dependencies (for Python and TS)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/e2e.yml"
     branches: [main]
 
+env:
+  POETRY_VERSION: "1.6.1"
+
 jobs:
   e2e:
     name: create-llama
@@ -16,10 +19,19 @@ jobs:
       fail-fast: true
       matrix:
         node-version: [18, 20]
+        python-version: ["3.11"]
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: ${{ env.POETRY_VERSION }}
       - uses: pnpm/action-setup@v2
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/packages/create-llama/create-app.ts
+++ b/packages/create-llama/create-app.ts
@@ -34,6 +34,7 @@ export async function createApp({
   communityProjectPath,
   vectorDb,
   externalPort,
+  isPoetryInstall,
 }: InstallAppArgs): Promise<void> {
   const root = path.resolve(appPath);
 
@@ -75,6 +76,7 @@ export async function createApp({
     communityProjectPath,
     vectorDb,
     externalPort,
+    isPoetryInstall,
   };
 
   if (frontend) {

--- a/packages/create-llama/create-app.ts
+++ b/packages/create-llama/create-app.ts
@@ -34,7 +34,7 @@ export async function createApp({
   communityProjectPath,
   vectorDb,
   externalPort,
-  isPoetryInstall,
+  installDependencies,
 }: InstallAppArgs): Promise<void> {
   const root = path.resolve(appPath);
 
@@ -76,7 +76,7 @@ export async function createApp({
     communityProjectPath,
     vectorDb,
     externalPort,
-    isPoetryInstall,
+    installDependencies,
   };
 
   if (frontend) {

--- a/packages/create-llama/e2e/utils.ts
+++ b/packages/create-llama/e2e/utils.ts
@@ -104,6 +104,7 @@ export function runCreateLlama(
     "--use-npm",
     "--external-port",
     externalPort,
+    "--install-dependencies",
   ].join(" ");
   console.log(`running command '${command}' in ${cwd}`);
   execSync(command, {

--- a/packages/create-llama/helpers/poetry.ts
+++ b/packages/create-llama/helpers/poetry.ts
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { execSync } from "child_process";
+import fs from "fs";
+
+export function isPoetryAvailable(): boolean {
+  try {
+    execSync("poetry --version", { stdio: "ignore" });
+    return true;
+  } catch (_) {}
+  return false;
+}
+
+export function tryPoetryInstall(): boolean {
+  try {
+    execSync("poetry install", { stdio: "ignore" });
+    return true;
+  } catch (_) {}
+  return false;
+}
+
+export function tryPoetryRun(command: string): boolean {
+  try {
+    execSync(`poetry run ${command}`);
+    return true;
+  } catch (_) {}
+  return false;
+}
+
+export function isHavingPoetryLockFile(): boolean {
+  try {
+    return fs.existsSync("poetry.lock");
+  } catch (_) {}
+  return false;
+}

--- a/packages/create-llama/helpers/poetry.ts
+++ b/packages/create-llama/helpers/poetry.ts
@@ -12,7 +12,7 @@ export function isPoetryAvailable(): boolean {
 
 export function tryPoetryInstall(): boolean {
   try {
-    execSync("poetry install", { stdio: "ignore" });
+    execSync("poetry install", { stdio: "inherit" });
     return true;
   } catch (_) {}
   return false;
@@ -20,7 +20,7 @@ export function tryPoetryInstall(): boolean {
 
 export function tryPoetryRun(command: string): boolean {
   try {
-    execSync(`poetry run ${command}`);
+    execSync(`poetry run ${command}`, { stdio: "inherit" });
     return true;
   } catch (_) {}
   return false;

--- a/packages/create-llama/helpers/python.ts
+++ b/packages/create-llama/helpers/python.ts
@@ -1,8 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
-import { cyan } from "picocolors";
+import { cyan, yellow } from "picocolors";
 import { parse, stringify } from "smol-toml";
+import terminalLink from "terminal-link";
 import { copy } from "./copy";
+import { isPoetryAvailable, tryPoetryInstall } from "./poetry";
 import { InstallTemplateArgs, TemplateVectorDB } from "./types";
 
 interface Dependency {
@@ -96,9 +98,10 @@ export const installPythonTemplate = async ({
   framework,
   engine,
   vectorDb,
+  isPoetryInstall,
 }: Pick<
   InstallTemplateArgs,
-  "root" | "framework" | "template" | "engine" | "vectorDb"
+  "root" | "framework" | "template" | "engine" | "vectorDb" | "isPoetryInstall"
 >) => {
   console.log("\nInitializing Python project with template:", template, "\n");
   const templatePath = path.join(
@@ -146,7 +149,28 @@ export const installPythonTemplate = async ({
   const addOnDependencies = getAdditionalDependencies(vectorDb);
   await addDependencies(root, addOnDependencies);
 
-  console.log(
-    "\nPython project, dependencies won't be installed automatically.\n",
-  );
+  // install python dependencies
+  if (isPoetryInstall) {
+    if (isPoetryAvailable()) {
+      console.log(
+        `Installing python dependencies using poetry. This may take a while...`,
+      );
+      const installSuccessful = tryPoetryInstall();
+      if (!installSuccessful) {
+        console.warn(
+          yellow("Install failed. Please install dependencies manually."),
+        );
+      }
+    } else {
+      console.warn(
+        yellow(
+          `Poetry is not available in the current environment. The Python dependencies will not be installed automatically.
+Please check ${terminalLink(
+            "Poetry Installation",
+            `https://python-poetry.org/docs/#installation`,
+          )} to install poetry first, then install the dependencies manually.`,
+        ),
+      );
+    }
+  }
 };

--- a/packages/create-llama/helpers/python.ts
+++ b/packages/create-llama/helpers/python.ts
@@ -98,10 +98,15 @@ export const installPythonTemplate = async ({
   framework,
   engine,
   vectorDb,
-  isPoetryInstall,
+  installDependencies,
 }: Pick<
   InstallTemplateArgs,
-  "root" | "framework" | "template" | "engine" | "vectorDb" | "isPoetryInstall"
+  | "root"
+  | "framework"
+  | "template"
+  | "engine"
+  | "vectorDb"
+  | "installDependencies"
 >) => {
   console.log("\nInitializing Python project with template:", template, "\n");
   const templatePath = path.join(
@@ -150,7 +155,7 @@ export const installPythonTemplate = async ({
   await addDependencies(root, addOnDependencies);
 
   // install python dependencies
-  if (isPoetryInstall) {
+  if (installDependencies) {
     if (isPoetryAvailable()) {
       console.log(
         `Installing python dependencies using poetry. This may take a while...`,

--- a/packages/create-llama/helpers/types.ts
+++ b/packages/create-llama/helpers/types.ts
@@ -23,4 +23,5 @@ export interface InstallTemplateArgs {
   communityProjectPath?: string;
   vectorDb?: TemplateVectorDB;
   externalPort?: number;
+  isPoetryInstall?: boolean;
 }

--- a/packages/create-llama/helpers/types.ts
+++ b/packages/create-llama/helpers/types.ts
@@ -23,5 +23,5 @@ export interface InstallTemplateArgs {
   communityProjectPath?: string;
   vectorDb?: TemplateVectorDB;
   externalPort?: number;
-  isPoetryInstall?: boolean;
+  installDependencies?: boolean;
 }

--- a/packages/create-llama/helpers/typescript.ts
+++ b/packages/create-llama/helpers/typescript.ts
@@ -39,6 +39,7 @@ export const installTSTemplate = async ({
   customApiPath,
   forBackend,
   vectorDb,
+  installDependencies,
 }: InstallTemplateArgs) => {
   console.log(bold(`Using ${packageManager}.`));
 
@@ -210,15 +211,17 @@ export const installTSTemplate = async ({
     JSON.stringify(packageJson, null, 2) + os.EOL,
   );
 
-  console.log("\nInstalling dependencies:");
-  for (const dependency in packageJson.dependencies)
-    console.log(`- ${cyan(dependency)}`);
+  if (installDependencies) {
+    console.log("\nInstalling dependencies:");
+    for (const dependency in packageJson.dependencies)
+      console.log(`- ${cyan(dependency)}`);
 
-  console.log("\nInstalling devDependencies:");
-  for (const dependency in packageJson.devDependencies)
-    console.log(`- ${cyan(dependency)}`);
+    console.log("\nInstalling devDependencies:");
+    for (const dependency in packageJson.devDependencies)
+      console.log(`- ${cyan(dependency)}`);
 
-  console.log();
+    console.log();
 
-  await callPackageManager(packageManager, isOnline);
+    await callPackageManager(packageManager, isOnline);
+  }
 };

--- a/packages/create-llama/index.ts
+++ b/packages/create-llama/index.ts
@@ -119,6 +119,13 @@ const program = new Commander.Command(packageJson.name)
 Select external port.
 `,
   )
+  .option(
+    "--install-dependencies",
+    `
+
+Whether install dependencies (backend/frontend) automatically or not.
+`,
+  )
   .allowUnknownOption()
   .parse(process.argv);
 if (process.argv.includes("--no-frontend")) {
@@ -224,7 +231,7 @@ async function run(): Promise<void> {
     communityProjectPath: program.communityProjectPath,
     vectorDb: program.vectorDb,
     externalPort: program.externalPort,
-    isPoetryInstall: program.isPoetryInstall,
+    installDependencies: program.installDependencies,
   });
   conf.set("preferences", preferences);
 }

--- a/packages/create-llama/index.ts
+++ b/packages/create-llama/index.ts
@@ -224,6 +224,7 @@ async function run(): Promise<void> {
     communityProjectPath: program.communityProjectPath,
     vectorDb: program.vectorDb,
     externalPort: program.externalPort,
+    isPoetryInstall: program.isPoetryInstall,
   });
   conf.set("preferences", preferences);
 }

--- a/packages/create-llama/questions.ts
+++ b/packages/create-llama/questions.ts
@@ -152,6 +152,21 @@ export const askQuestions = async (
     }
   }
 
+  if (program.framework === "fastapi") {
+    // if backend framework is fastapi
+    // then we would ask the user whether they want to install the python dependencies automatically by using poetry or not
+    const { isPoetryInstall } = await prompts({
+      onState: onPromptState,
+      type: "toggle",
+      name: "isPoetryInstall",
+      message: `Would you like to install python dependencies automatically? This may take a while`,
+      initial: getPrefOrDefault("isPoetryInstall"),
+      active: "Yes",
+      inactive: "No",
+    });
+    program.isPoetryInstall = Boolean(isPoetryInstall);
+  }
+
   if (
     program.template === "streaming" &&
     (program.framework === "express" || program.framework === "fastapi")

--- a/packages/create-llama/questions.ts
+++ b/packages/create-llama/questions.ts
@@ -152,21 +152,6 @@ export const askQuestions = async (
     }
   }
 
-  if (program.framework === "fastapi") {
-    // if backend framework is fastapi
-    // then we would ask the user whether they want to install the python dependencies automatically by using poetry or not
-    const { isPoetryInstall } = await prompts({
-      onState: onPromptState,
-      type: "toggle",
-      name: "isPoetryInstall",
-      message: `Would you like to install python dependencies automatically? This may take a while`,
-      initial: getPrefOrDefault("isPoetryInstall"),
-      active: "Yes",
-      inactive: "No",
-    });
-    program.isPoetryInstall = Boolean(isPoetryInstall);
-  }
-
   if (
     program.template === "streaming" &&
     (program.framework === "express" || program.framework === "fastapi")
@@ -224,6 +209,19 @@ export const askQuestions = async (
         preferences.ui = ui;
       }
     }
+  }
+
+  if (program.installDependencies === undefined) {
+    const { installDependencies } = await prompts({
+      onState: onPromptState,
+      type: "toggle",
+      name: "installDependencies",
+      message: `Would you like to install dependencies automatically? This may take a while`,
+      initial: getPrefOrDefault("installDependencies"),
+      active: "Yes",
+      inactive: "No",
+    });
+    program.installDependencies = Boolean(installDependencies);
   }
 
   if (!program.model) {


### PR DESCRIPTION
- Add checking is poetry installed (using `poetry --version`).
- Add installing python dependencies (using `poetry install`).
- Add generating index in FastAPI app if the environment was set-up correctly (`poetry run python app/engine/generate.py`).
