### PR TITLE
refactor: remove usage of `lodash`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,6 @@
     "chromadb": "^1.7.3",
     "file-type": "^18.7.0",
     "js-tiktoken": "^1.0.8",
-    "lodash": "npm:lodash-es@^4.17.21",
     "mammoth": "^1.6.0",
     "md-utils-ts": "^2.0.0",
     "mongodb": "^6.3.0",
@@ -47,6 +46,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
+      "edge-light": "./dist/index.edge.mjs",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "chromadb": "^1.7.3",
     "file-type": "^18.7.0",
     "js-tiktoken": "^1.0.8",
-    "lodash": "^4.17.21",
+    "lodash": "npm:lodash-es@^4.17.21",
     "mammoth": "^1.6.0",
     "md-utils-ts": "^2.0.0",
     "mongodb": "^6.3.0",

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 
@@ -159,7 +158,7 @@ export abstract class BaseNode<T extends Metadata = Metadata> {
    * @return {Record<string, any>} - The JSON representation of the object.
    */
   toMutableJSON(): Record<string, any> {
-    return _.cloneDeep(this.toJSON());
+    return structuredClone(this.toJSON());
   }
 }
 

--- a/packages/core/src/embeddings/utils.ts
+++ b/packages/core/src/embeddings/utils.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { ImageType } from "../Node";
 import { DEFAULT_SIMILARITY_TOP_K } from "../constants";
 import { DEFAULT_FS, VectorStoreQueryMode } from "../storage";
@@ -199,7 +198,7 @@ export async function readImage(input: ImageType) {
   const { RawImage } = await import("@xenova/transformers");
   if (input instanceof Blob) {
     return await RawImage.fromBlob(input);
-  } else if (_.isString(input) || input instanceof URL) {
+  } else if (typeof input === "string" || input instanceof URL) {
     return await RawImage.fromURL(input);
   } else {
     throw new Error(`Unsupported input type: ${typeof input}`);
@@ -210,7 +209,7 @@ export async function imageToString(input: ImageType): Promise<string> {
   if (input instanceof Blob) {
     // if the image is a Blob, convert it to a base64 data URL
     return await blobToDataUrl(input);
-  } else if (_.isString(input)) {
+  } else if (typeof input === "string") {
     return input;
   } else if (input instanceof URL) {
     return input.toString();
@@ -227,7 +226,7 @@ export function stringToImage(input: string): ImageType {
     return new Blob([byteArray]);
   } else if (input.startsWith("http://") || input.startsWith("https://")) {
     return new URL(input);
-  } else if (_.isString(input)) {
+  } else if (typeof input === "string") {
     return input;
   } else {
     throw new Error(`Unsupported input type: ${typeof input}`);
@@ -238,7 +237,7 @@ export async function imageToDataUrl(input: ImageType): Promise<string> {
   // first ensure, that the input is a Blob
   if (
     (input instanceof URL && input.protocol === "file:") ||
-    _.isString(input)
+    typeof input === "string"
   ) {
     // string or file URL
     const fs = DEFAULT_FS;

--- a/packages/core/src/indices/summary/SummaryIndex.ts
+++ b/packages/core/src/indices/summary/SummaryIndex.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { BaseNode, Document } from "../../Node";
 import { BaseQueryEngine, RetrieverQueryEngine } from "../../QueryEngine";
 import { BaseRetriever } from "../../Retriever";
@@ -245,13 +244,13 @@ export class SummaryIndex extends BaseIndex<IndexList> {
 
     for (const node of nodes) {
       const refNode = node.sourceNode;
-      if (_.isNil(refNode)) {
+      if (refNode == null) {
         continue;
       }
 
       const refDocInfo = await this.docStore.getRefDocInfo(refNode.nodeId);
 
-      if (_.isNil(refDocInfo)) {
+      if (refDocInfo == null) {
         continue;
       }
 

--- a/packages/core/src/indices/summary/SummaryIndexRetriever.ts
+++ b/packages/core/src/indices/summary/SummaryIndexRetriever.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { globalsHelper } from "../../GlobalsHelper";
 import { NodeWithScore } from "../../Node";
 import { ChoiceSelectPrompt, defaultChoiceSelectPrompt } from "../../Prompt";
@@ -106,7 +105,7 @@ export class SummaryIndexLLMRetriever implements BaseRetriever {
       const choiceNodes = await this.index.docStore.getNodes(choiceNodeIds);
       const nodeWithScores = choiceNodes.map((node, i) => ({
         node: node,
-        score: _.get(parseResult, `${i + 1}`, 1),
+        score: parseResult[`${i + 1}`] ?? 1,
       }));
 
       results.push(...nodeWithScores);

--- a/packages/core/src/indices/summary/utils.ts
+++ b/packages/core/src/indices/summary/utils.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { BaseNode, MetadataMode } from "../../Node";
 
 export type NodeFormatterFunction = (summaryNodes: BaseNode[]) => string;
@@ -44,7 +43,7 @@ export const defaultParseChoiceSelectAnswerFn: ChoiceSelectParserFunction = (
       }
       return lineTokens;
     })
-    .filter((lineTokens) => !_.isNil(lineTokens)) as string[][];
+    .filter((lineTokens): lineTokens is string[] => !lineTokens == null);
 
   // parse the answer number and relevance score
   return lineTokens.reduce(

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -3,7 +3,7 @@ import Anthropic, {
   ClientOptions,
   HUMAN_PROMPT,
 } from "@anthropic-ai/sdk";
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 
 export class AnthropicSession {
   anthropic: Anthropic;
@@ -39,7 +39,7 @@ let defaultAnthropicSession: {
  */
 export function getAnthropicSession(options: ClientOptions = {}) {
   let session = defaultAnthropicSession.find((session) => {
-    return _.isEqual(session.options, options);
+    return isEqual(session.options, options);
   })?.session;
 
   if (!session) {

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -3,7 +3,6 @@ import Anthropic, {
   ClientOptions,
   HUMAN_PROMPT,
 } from "@anthropic-ai/sdk";
-import isEqual from "lodash/isEqual";
 
 export class AnthropicSession {
   anthropic: Anthropic;
@@ -39,7 +38,7 @@ let defaultAnthropicSession: {
  */
 export function getAnthropicSession(options: ClientOptions = {}) {
   let session = defaultAnthropicSession.find((session) => {
-    return isEqual(session.options, options);
+    return session.options === options;
   })?.session;
 
   if (!session) {

--- a/packages/core/src/llm/openai.ts
+++ b/packages/core/src/llm/openai.ts
@@ -1,4 +1,3 @@
-import isEqual from "lodash/isEqual";
 import OpenAI, { ClientOptions } from "openai";
 
 export class AzureOpenAI extends OpenAI {
@@ -48,7 +47,7 @@ export function getOpenAISession(
   options: ClientOptions & { azure?: boolean } = {},
 ) {
   let session = defaultOpenAISession.find((session) => {
-    return isEqual(session.options, options);
+    return session.options === options;
   })?.session;
 
   if (!session) {

--- a/packages/core/src/llm/openai.ts
+++ b/packages/core/src/llm/openai.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import OpenAI, { ClientOptions } from "openai";
 
 export class AzureOpenAI extends OpenAI {
@@ -48,7 +48,7 @@ export function getOpenAISession(
   options: ClientOptions & { azure?: boolean } = {},
 ) {
   let session = defaultOpenAISession.find((session) => {
-    return _.isEqual(session.options, options);
+    return isEqual(session.options, options);
   })?.session;
 
   if (!session) {

--- a/packages/core/src/llm/portkey.ts
+++ b/packages/core/src/llm/portkey.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import isEqual from "lodash/isEqual";
 import { LLMOptions, Portkey } from "portkey-ai";
 
 export const readEnv = (
@@ -53,7 +53,7 @@ let defaultPortkeySession: {
  */
 export function getPortkeySession(options: PortkeyOptions = {}) {
   let session = defaultPortkeySession.find((session) => {
-    return _.isEqual(session.options, options);
+    return isEqual(session.options, options);
   })?.session;
 
   if (!session) {

--- a/packages/core/src/llm/portkey.ts
+++ b/packages/core/src/llm/portkey.ts
@@ -1,4 +1,3 @@
-import isEqual from "lodash/isEqual";
 import { LLMOptions, Portkey } from "portkey-ai";
 
 export const readEnv = (
@@ -53,7 +52,7 @@ let defaultPortkeySession: {
  */
 export function getPortkeySession(options: PortkeyOptions = {}) {
   let session = defaultPortkeySession.find((session) => {
-    return isEqual(session.options, options);
+    return session.options === options;
   })?.session;
 
   if (!session) {

--- a/packages/core/src/nodeParsers/utils.ts
+++ b/packages/core/src/nodeParsers/utils.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import {
   BaseNode,
   Document,
@@ -52,11 +51,13 @@ export function getNodesFromDocument(
   textSplits.forEach((textSplit) => {
     const node = new TextNode({
       text: textSplit,
-      metadata: includeMetadata ? _.cloneDeep(document.metadata) : {},
-      excludedEmbedMetadataKeys: _.cloneDeep(
+      metadata: includeMetadata ? structuredClone(document.metadata) : {},
+      excludedEmbedMetadataKeys: structuredClone(
         document.excludedEmbedMetadataKeys,
       ),
-      excludedLlmMetadataKeys: _.cloneDeep(document.excludedLlmMetadataKeys),
+      excludedLlmMetadataKeys: structuredClone(
+        document.excludedLlmMetadataKeys,
+      ),
     });
     node.relationships[NodeRelationship.SOURCE] = document.asRelatedNodeInfo();
     nodes.push(node);

--- a/packages/core/src/readers/SimpleDirectoryReader.ts
+++ b/packages/core/src/readers/SimpleDirectoryReader.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { Document } from "../Node";
 import { CompleteFileSystem, walk } from "../storage/FileSystem";
 import { DEFAULT_FS } from "../storage/constants";
@@ -80,7 +79,7 @@ export class SimpleDirectoryReader implements BaseReader {
     let docs: Document[] = [];
     for await (const filePath of walk(fs, directoryPath)) {
       try {
-        const fileExt = _.last(filePath.split(".")) || "";
+        const fileExt = filePath.split(".").at(-1) || "";
 
         // Observer can decide to skip each file
         if (!this.doObserverCheck("file", filePath, ReaderStatus.STARTED)) {
@@ -92,7 +91,7 @@ export class SimpleDirectoryReader implements BaseReader {
 
         if (fileExt in fileExtToReader) {
           reader = fileExtToReader[fileExt];
-        } else if (!_.isNil(defaultReader)) {
+        } else if (!(defaultReader == null)) {
           reader = defaultReader;
         } else {
           const msg = `No reader for file extension of ${filePath}`;

--- a/packages/core/src/storage/FileSystem.ts
+++ b/packages/core/src/storage/FileSystem.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 /**
  * A filesystem interface that is meant to be compatible with
  * the 'fs' module from Node.js.
@@ -25,14 +24,14 @@ export class InMemoryFileSystem implements GenericFileSystem {
   private files: Record<string, any> = {};
 
   async writeFile(path: string, content: string, options?: any): Promise<void> {
-    this.files[path] = _.cloneDeep(content);
+    this.files[path] = structuredClone(content);
   }
 
   async readFile(path: string, options?: any): Promise<string> {
     if (!(path in this.files)) {
       throw new Error(`File ${path} does not exist`);
     }
-    return _.cloneDeep(this.files[path]);
+    return structuredClone(this.files[path]);
   }
 
   async access(path: string): Promise<void> {
@@ -42,7 +41,7 @@ export class InMemoryFileSystem implements GenericFileSystem {
   }
 
   async mkdir(path: string, options?: any): Promise<void> {
-    this.files[path] = _.get(this.files, path, null);
+    this.files[path] = this.files[path] ?? null;
   }
 }
 

--- a/packages/core/src/storage/docStore/SimpleDocumentStore.ts
+++ b/packages/core/src/storage/docStore/SimpleDocumentStore.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import * as path from "path";
 import { GenericFileSystem } from "../FileSystem";
 import {
@@ -58,7 +57,8 @@ export class SimpleDocumentStore extends KVDocumentStore {
   ): Promise<void> {
     fs = fs || DEFAULT_FS;
     if (
-      _.isObject(this.kvStore) &&
+      typeof this.kvStore === "object" &&
+      this.kvStore !== null &&
       this.kvStore instanceof BaseInMemoryKVStore
     ) {
       await this.kvStore.persist(persistPath, fs);
@@ -71,7 +71,11 @@ export class SimpleDocumentStore extends KVDocumentStore {
   }
 
   toDict(): SaveDict {
-    if (_.isObject(this.kvStore) && this.kvStore instanceof SimpleKVStore) {
+    if (
+      typeof this.kvStore === "object" &&
+      this.kvStore !== null &&
+      this.kvStore instanceof SimpleKVStore
+    ) {
       return this.kvStore.toDict();
     }
     // If the kvstore is not a SimpleKVStore, you might want to throw an error or return a default value.

--- a/packages/core/src/storage/indexStore/KVIndexStore.ts
+++ b/packages/core/src/storage/indexStore/KVIndexStore.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { IndexStruct, jsonToIndexStruct } from "../../indices/BaseIndex";
 import { DEFAULT_NAMESPACE } from "../constants";
 import { BaseKVStore } from "../kvStore/types";
@@ -25,7 +24,7 @@ export class KVIndexStore extends BaseIndexStore {
   }
 
   async getIndexStruct(structId?: string): Promise<IndexStruct | undefined> {
-    if (_.isNil(structId)) {
+    if (structId == null) {
       let structs = await this.getIndexStructs();
       if (structs.length !== 1) {
         throw new Error("More than one index struct found");
@@ -33,7 +32,7 @@ export class KVIndexStore extends BaseIndexStore {
       return structs[0];
     } else {
       let json = await this._kvStore.get(structId, this._collection);
-      if (_.isNil(json)) {
+      if (json == null) {
         return;
       }
       return jsonToIndexStruct(json);
@@ -44,6 +43,6 @@ export class KVIndexStore extends BaseIndexStore {
     let jsons = (await this._kvStore.getAll(this._collection)) as {
       [key: string]: any;
     };
-    return _.values(jsons).map((json) => jsonToIndexStruct(json));
+    return Object.values(jsons).map((json) => jsonToIndexStruct(json));
   }
 }

--- a/packages/core/src/storage/kvStore/SimpleKVStore.ts
+++ b/packages/core/src/storage/kvStore/SimpleKVStore.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import * as path from "path";
 import { GenericFileSystem, exists } from "../FileSystem";
 import { DEFAULT_COLLECTION, DEFAULT_FS } from "../constants";
@@ -24,7 +23,7 @@ export class SimpleKVStore extends BaseKVStore {
     if (!(collection in this.data)) {
       this.data[collection] = {};
     }
-    this.data[collection][key] = _.clone(val); // Creating a shallow copy of the object
+    this.data[collection][key] = structuredClone(val); // Creating a shallow copy of the object
 
     if (this.persistPath) {
       await this.persist(this.persistPath, this.fs);
@@ -36,17 +35,17 @@ export class SimpleKVStore extends BaseKVStore {
     collection: string = DEFAULT_COLLECTION,
   ): Promise<any> {
     let collectionData = this.data[collection];
-    if (_.isNil(collectionData)) {
+    if (collectionData == null) {
       return null;
     }
     if (!(key in collectionData)) {
       return null;
     }
-    return _.clone(collectionData[key]); // Creating a shallow copy of the object
+    return structuredClone(collectionData[key]); // Creating a shallow copy of the object
   }
 
   async getAll(collection: string = DEFAULT_COLLECTION): Promise<DataType> {
-    return _.clone(this.data[collection]); // Creating a shallow copy of the object
+    return structuredClone(this.data[collection]); // Creating a shallow copy of the object
   }
 
   async delete(

--- a/packages/core/src/storage/vectorStore/SimpleVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/SimpleVectorStore.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import * as path from "path";
 import { BaseNode } from "../../Node";
 import {
@@ -86,7 +85,7 @@ export class SimpleVectorStore implements VectorStore {
   }
 
   async query(query: VectorStoreQuery): Promise<VectorStoreQueryResult> {
-    if (!_.isNil(query.filters)) {
+    if (!(query.filters == null)) {
       throw new Error(
         "Metadata filters not implemented for SimpleVectorStore yet.",
       );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
       lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+        specifier: npm:lodash-es@^4.17.21
+        version: /lodash-es@4.17.21
       mammoth:
         specifier: ^1.6.0
         version: 1.6.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,9 +179,6 @@ importers:
       js-tiktoken:
         specifier: ^1.0.8
         version: 1.0.8
-      lodash:
-        specifier: npm:lodash-es@^4.17.21
-        version: /lodash-es@4.17.21
       mammoth:
         specifier: ^1.6.0
         version: 1.6.0
@@ -5314,7 +5311,7 @@ packages:
       define-properties: 1.2.0
       es-abstract: 1.21.2
       es-shim-unscopables: 1.0.0
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.2
     dev: false
 
   /arraybuffer.prototype.slice@1.0.2:
@@ -5328,7 +5325,6 @@ packages:
       get-intrinsic: 1.2.2
       is-array-buffer: 3.0.2
       is-shared-array-buffer: 1.0.2
-    dev: true
 
   /arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
@@ -5995,8 +5991,9 @@ packages:
   /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
-      function-bind: 1.1.1
-      get-intrinsic: 1.2.1
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.2
+    dev: false
 
   /call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
@@ -7112,14 +7109,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /define-data-property@1.1.0:
-    resolution: {integrity: sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: 1.2.2
-      gopd: 1.0.1
-      has-property-descriptors: 1.0.0
-
   /define-data-property@1.1.1:
     resolution: {integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==}
     engines: {node: '>= 0.4'}
@@ -7149,8 +7138,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-data-property: 1.1.0
-      has-property-descriptors: 1.0.0
+      define-data-property: 1.1.1
+      has-property-descriptors: 1.0.1
       object-keys: 1.1.1
 
   /degenerator@5.0.1:
@@ -7537,11 +7526,11 @@ packages:
     dependencies:
       array-buffer-byte-length: 1.0.0
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.2
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
@@ -7558,7 +7547,7 @@ packages:
       is-string: 1.0.7
       is-typed-array: 1.1.12
       is-weakref: 1.0.2
-      object-inspect: 1.12.3
+      object-inspect: 1.13.1
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.5.0
@@ -7614,7 +7603,6 @@ packages:
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.13
-    dev: true
 
   /es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
@@ -7640,7 +7628,7 @@ packages:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.2
       has: 1.0.3
       has-tostringtag: 1.0.0
     dev: false
@@ -7652,7 +7640,6 @@ packages:
       get-intrinsic: 1.2.2
       has-tostringtag: 1.0.0
       hasown: 2.0.0
-    dev: true
 
   /es-shim-unscopables@1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
@@ -8588,9 +8575,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -8598,9 +8582,9 @@ packages:
     resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
       functions-have-names: 1.2.3
     dev: false
 
@@ -8612,7 +8596,6 @@ packages:
       define-properties: 1.2.1
       es-abstract: 1.22.3
       functions-have-names: 1.2.3
-    dev: true
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -8651,17 +8634,10 @@ packages:
   /get-intrinsic@1.2.0:
     resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
-      function-bind: 1.1.1
-      has: 1.0.3
-      has-symbols: 1.0.3
-
-  /get-intrinsic@1.2.1:
-    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
-    dependencies:
       function-bind: 1.1.2
       has: 1.0.3
-      has-proto: 1.0.1
       has-symbols: 1.0.3
+    dev: false
 
   /get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
@@ -8995,7 +8971,8 @@ packages:
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.2
+    dev: false
 
   /has-property-descriptors@1.0.1:
     resolution: {integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==}
@@ -9030,7 +9007,8 @@ packages:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
-      function-bind: 1.1.1
+      function-bind: 1.1.2
+    dev: false
 
   /hash-base@3.1.0:
     resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
@@ -9481,7 +9459,7 @@ packages:
     resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.2
       has: 1.0.3
       side-channel: 1.0.4
     dev: false
@@ -9493,7 +9471,6 @@ packages:
       get-intrinsic: 1.2.2
       hasown: 2.0.0
       side-channel: 1.0.4
-    dev: true
 
   /interpret@1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
@@ -11531,12 +11508,8 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  /object-inspect@1.12.3:
-    resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
-
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
-    dev: true
 
   /object-is@1.1.5:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
@@ -11566,7 +11539,6 @@ packages:
       define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
-    dev: true
 
   /object.entries@1.1.6:
     resolution: {integrity: sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==}
@@ -13324,7 +13296,7 @@ packages:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       define-properties: 1.2.0
       functions-have-names: 1.2.3
     dev: false
@@ -13336,7 +13308,6 @@ packages:
       call-bind: 1.0.5
       define-properties: 1.2.1
       set-function-name: 2.0.1
-    dev: true
 
   /regexpu-core@5.3.2:
     resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
@@ -13706,7 +13677,6 @@ packages:
       get-intrinsic: 1.2.2
       has-symbols: 1.0.3
       isarray: 2.0.5
-    dev: true
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -13911,7 +13881,6 @@ packages:
       define-data-property: 1.1.1
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.1
-    dev: true
 
   /setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -14000,9 +13969,9 @@ packages:
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      object-inspect: 1.12.3
+      call-bind: 1.0.5
+      get-intrinsic: 1.2.2
+      object-inspect: 1.13.1
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -14273,7 +14242,7 @@ packages:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      internal-slot: 1.0.5
+      internal-slot: 1.0.6
     dev: false
 
   /stream-browserify@3.0.0:
@@ -14396,9 +14365,9 @@ packages:
     resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: false
 
   /string.prototype.trim@1.2.8:
@@ -14408,14 +14377,13 @@ packages:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
-    dev: true
 
   /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: false
 
   /string.prototype.trimend@1.0.7:
@@ -14424,14 +14392,13 @@ packages:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
-    dev: true
 
   /string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.21.2
+      call-bind: 1.0.5
+      define-properties: 1.2.1
+      es-abstract: 1.22.3
     dev: false
 
   /string.prototype.trimstart@1.0.7:
@@ -14440,7 +14407,6 @@ packages:
       call-bind: 1.0.5
       define-properties: 1.2.1
       es-abstract: 1.22.3
-    dev: true
 
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -15181,7 +15147,6 @@ packages:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
       is-typed-array: 1.1.12
-    dev: true
 
   /typed-array-byte-length@1.0.0:
     resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
@@ -15191,7 +15156,6 @@ packages:
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.12
-    dev: true
 
   /typed-array-byte-offset@1.0.0:
     resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
@@ -15202,7 +15166,6 @@ packages:
       for-each: 0.3.3
       has-proto: 1.0.1
       is-typed-array: 1.1.12
-    dev: true
 
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
@@ -15264,7 +15227,7 @@ packages:
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
@@ -15951,7 +15914,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
+      call-bind: 1.0.5
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0


### PR DESCRIPTION
BREAKING:
- _.isEqual is replaced by `===` so object equal will be checked by reference.
- will drop node.js 16 support