### PR TITLE
fix: Add package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "llamaindex",
+  "name": "@llamaindex/monorepo",
   "private": true,
   "scripts": {
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "llamaindex",
   "private": true,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## What
add package name to top level package.json in order to enable checking out specific commits from npm/yarn/pnpm. Previously if you were referencing a specific commit in your package.json it would fail with the following error. 
` ERR_PNPM_MISSING_PACKAGE_NAME  Can't install git+https://github.com/run-llama/LlamaIndexTS.git#1bd47969b37c86a226f10d1e1a6498de798ca39c: Missing package name`. By adding the name property to the top level package.json this error goes away. 

<img width="1307" alt="Screenshot 2024-01-19 at 12 07 07 AM" src="https://github.com/run-llama/LlamaIndexTS/assets/22918444/c10cf0cf-ca29-416a-ac4e-9c266c9f375a">


## Why
This enables developers to experiment with features that are not yet published to NPM.

## Testing
- I created a test app to demonstrate this. clone this repo and checkout this branch: https://github.com/owencraston/test-app/pull/1
- checkout this commit: https://github.com/owencraston/test-app/pull/1/commits/48541659e5d7373b69357868708e8990322913b6
- run pnpm install
- you should get the error:  `ERR_PNPM_MISSING_PACKAGE_NAME  Can't install git+https://github.com/run-llama/LlamaIndexTS.git#1bd47969b37c86a226f10d1e1a6498de798ca39c: Missing package name`
- then checkout this commit: https://github.com/owencraston/test-app/pull/1/commits/4787248eb953dd8c2c51763c5e0ee07a53ac6d36. This is the commit hash for this PR.
- run `pnpm install`. there should be no errors
