### PR TITLE
[WIP]: Add nodes parameter on fromVectorStore

### DIFF
--- a/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
+++ b/packages/core/src/indices/vectorStore/VectorStoreIndex.ts
@@ -233,7 +233,8 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
 
   static async fromVectorStore(
     vectorStore: VectorStore,
-    serviceContext: ServiceContext,
+    nodes?: BaseNode[],
+    serviceContext?: ServiceContext,
     imageVectorStore?: VectorStore,
   ) {
     if (!vectorStore.storesText) {
@@ -248,7 +249,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
     });
 
     const index = await this.init({
-      nodes: [],
+      nodes: nodes ?? [],
       storageContext,
       serviceContext,
     });


### PR DESCRIPTION
it have a breaking change, if we put as last parameter would make imageVectorStore required or any workaround to use it

https://github.com/run-llama/LlamaIndexTS/issues/410