### PR TITLE
ChromaDB can't resolve 'chromadb-default-embed'

### DIFF
--- a/packages/create-llama/templates/types/simple/express/package.json
+++ b/packages/create-llama/templates/types/simple/express/package.json
@@ -14,9 +14,6 @@
     "express": "^4.18.2",
     "llamaindex": "0.0.37"
   },
-  "overrides": {
-    "chromadb": "1.7.3"
-  },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/packages/create-llama/templates/types/streaming/express/package.json
+++ b/packages/create-llama/templates/types/streaming/express/package.json
@@ -15,9 +15,6 @@
     "express": "^4.18.2",
     "llamaindex": "0.0.37"
   },
-  "overrides": {
-    "chromadb": "1.7.3"
-  },
   "devDependencies": {
     "@types/cors": "^2.8.16",
     "@types/express": "^4.17.21",

--- a/packages/create-llama/templates/types/streaming/nextjs/package.json
+++ b/packages/create-llama/templates/types/streaming/nextjs/package.json
@@ -27,9 +27,6 @@
     "supports-color": "^9.4.0",
     "tailwind-merge": "^2.1.0"
   },
-  "overrides": {
-    "chromadb": "1.7.3"
-  },
   "devDependencies": {
     "@types/node": "^20.10.3",
     "@types/react": "^18.2.42",


### PR DESCRIPTION
ChromaDB version `1.8.1` cannot resolve `chromadb-default-embed` when compiling create-llama project.
Log:
```
•/node_modules/chromadb/dist/chromadb.mjs:2431:33
Module not found: Can't resolve 'chromadb-default-embed'
https://nextjs.org/docs/messages/module-not-found
Import trace for requested module:
/node_modules/llamaindex/dist/index.mjs
• /app/api/chat/route.ts
```

This PR reverts commit ae13525bd618495ba2ce8661ffc55b624d9a7240.



## Fail test case:
The issue only occurs in NextJS when user access the UI then send a chat message.
The `Frontend should be able to submit a message and receive a response` already cover this issue.

**Run a NextJS test case:**
```shell
npx playwright test -g "nextjs.*shadcn.*Frontend should be able to submit a message and receive a response"
```
-> Failure log:
```
Connected!
 ✓ Ready in 2.9s

 ○ Compiling / ...

 ✓ Compiled / in 5.3s (2298 modules)

 ✓ Compiled in 479ms (1140 modules)

 ○ Compiling /api/chat ...

Killing app processes...

  1) [chromium] › basic.spec.ts:82:15 › try create-llama streaming nextjs simple shadcn  › Frontend should be able to submit a message and receive a response 

    Error: page.waitForResponse: Timeout 60000ms exceeded while waiting for event "response"

      87 |             await page.fill("form input", "hello");
      88 |             await page.click("form button[type=submit]");
    > 89 |             const response = await page.waitForResponse(
         |                                         ^
      90 |               (res) => {
      91 |                 return res.url().includes("/api/chat") && res.status() === 200;
      92 |               },

        at /Users/huu/Developments/schiesser-it/llama-index/myself/LlamaIndexTS/packages/create-llama/e2e/basic.spec.ts:89:41

  1 failed
    [chromium] › basic.spec.ts:82:15 › try create-llama streaming nextjs simple shadcn  › Frontend should be able to submit a message and receive a response 
```

Reason:
NextJs did not compiling `/api/chat` successfully!

## Reproduce issue to see the compiling error:
-> Create a NextJS app with these options below:
```shell
✔ What is your project named? … my-app
✔ Which template would you like to use? › Chat with streaming
✔ Which framework would you like to use? › NextJS
✔ Which UI would you like to use? › Shadcn
✔ Which model would you like to use? › gpt-3.5-turbo
✔ Which data source would you like to use? › Use an example PDF
✔ Would you like to use a vector database? › No, just store the data in the file system
✔ Please provide your OpenAI API key (leave blank to skip): … 
✔ Would you like to use ESLint? … No / Yes
✔ How would you like to proceed? › Generate code, install dependencies, and run the app (~2 min)
```

Once it run the app successfully, 
```
Success! Created my-app at /Users/huu/Developments/schiesser-it/llama-index/myself/LlamaIndexTS/packages/create-llama/my-app
Now have a look at the README.md and learn how to get started.

Running app...

> my-app@0.1.0 dev
> next dev

   ▲ Next.js 14.1.0
   - Local:        http://localhost:3000
   - Environments: .env

 ✓ Ready in 2.8s
```

we gonna access the UI and send a message:
<img width="910" alt="image" src="https://github.com/run-llama/LlamaIndexTS/assets/39040748/67ac1006-fff3-4994-bfb8-36d1e266d269">

Then it will throw a error there:
<img width="849" alt="image" src="https://github.com/run-llama/LlamaIndexTS/assets/39040748/2565e338-42a6-4203-a2dc-c88fab4c6603">




