### PR TITLE
feat: create-llama - add local pdf file option

### DIFF
--- a/.changeset/stale-geckos-bathe.md
+++ b/.changeset/stale-geckos-bathe.md
@@ -2,4 +2,4 @@
 "create-llama": patch
 ---
 
-add a new option to select local PDF file
+Add an option to select a local PDF file as data source

--- a/.changeset/stale-geckos-bathe.md
+++ b/.changeset/stale-geckos-bathe.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+add a new option to select local PDF file

--- a/packages/create-llama/create-app.ts
+++ b/packages/create-llama/create-app.ts
@@ -35,6 +35,7 @@ export async function createApp({
   vectorDb,
   externalPort,
   postInstallAction,
+  contextFile,
 }: InstallAppArgs): Promise<void> {
   const root = path.resolve(appPath);
 
@@ -77,6 +78,7 @@ export async function createApp({
     vectorDb,
     externalPort,
     postInstallAction,
+    contextFile,
   };
 
   if (frontend) {

--- a/packages/create-llama/helpers/index.ts
+++ b/packages/create-llama/helpers/index.ts
@@ -70,22 +70,32 @@ const copyTestData = async (
   engine?: TemplateEngine,
   openAiKey?: string,
   vectorDb?: TemplateVectorDB,
+  contextFile?: string,
   // eslint-disable-next-line max-params
 ) => {
   if (engine === "context") {
-    const srcPath = path.join(
-      __dirname,
-      "..",
-      "templates",
-      "components",
-      "data",
-    );
     const destPath = path.join(root, "data");
-    console.log(`\nCopying test data to ${cyan(destPath)}\n`);
-    await copy("**", destPath, {
-      parents: true,
-      cwd: srcPath,
-    });
+    if (contextFile) {
+      console.log(`\nCopying provided file to ${cyan(destPath)}\n`);
+      await fs.mkdir(destPath, { recursive: true });
+      await fs.copyFile(
+        contextFile,
+        path.join(destPath, path.basename(contextFile)),
+      );
+    } else {
+      const srcPath = path.join(
+        __dirname,
+        "..",
+        "templates",
+        "components",
+        "data",
+      );
+      console.log(`\nCopying test data to ${cyan(destPath)}\n`);
+      await copy("**", destPath, {
+        parents: true,
+        cwd: srcPath,
+      });
+    }
   }
 
   if (packageManager && engine === "context") {
@@ -168,6 +178,7 @@ export const installTemplate = async (
       props.engine,
       props.openAiKey,
       props.vectorDb,
+      props.contextFile,
     );
   } else {
     // this is a frontend for a full-stack app, create .env file with model information

--- a/packages/create-llama/helpers/types.ts
+++ b/packages/create-llama/helpers/types.ts
@@ -15,6 +15,7 @@ export interface InstallTemplateArgs {
   template: TemplateType;
   framework: TemplateFramework;
   engine: TemplateEngine;
+  contextFile?: string;
   ui: TemplateUI;
   eslint: boolean;
   customApiPath?: string;

--- a/packages/create-llama/index.ts
+++ b/packages/create-llama/index.ts
@@ -240,6 +240,7 @@ async function run(): Promise<void> {
     vectorDb: program.vectorDb,
     externalPort: program.externalPort,
     postInstallAction: program.postInstallAction,
+    contextFile: program.contextFile,
   });
   conf.set("preferences", preferences);
 

--- a/packages/create-llama/questions.ts
+++ b/packages/create-llama/questions.ts
@@ -299,22 +299,23 @@ export const askQuestions = async (
     if (ciInfo.isCI) {
       program.engine = getPrefOrDefault("engine");
     } else {
+      let choices = [
+        {
+          title: "No data, just a simple chat",
+          value: "simple",
+        },
+        { title: "Use an example PDF", value: "exampleFile" },
+      ];
+      if (process.platform === "win32" || process.platform === "darwin") {
+        choices.push({ title: "Use a local PDF file", value: "localFile" });
+      }
+
       const { dataSource } = await prompts(
         {
           type: "select",
           name: "dataSource",
           message: "Which data source would you like to use?",
-          choices: [
-            {
-              title: "No data, just a simple chat",
-              value: "simple",
-            },
-            { title: "Use an example PDF", value: "exampleFile" },
-            {
-              title: "Select a local PDF file",
-              value: "localFile",
-            },
-          ],
+          choices: choices,
           initial: 1,
         },
         handlers,


### PR DESCRIPTION
Introduce a new option: `Select another PDF file` to select another pdf file located in local machine. (**Support for Windows and MacOS**)
```
? Which data source would you like to use? › - Use arrow-keys. Return to submit.
   No data, just a simple chat
   Use an example PDF
❯  Select another PDF file
```
Flow:
- If user chose `Select another PDF file` then:
+ Show a popup to select a file (macos native window)
+ User only allowed to choose a file. 
    1. If it's a PDF file, then go to the next question. 
    2. If they cancel the selection, we will exit the app. 
    3. If the file is not a PDF file, we will show an error message and exit the app.
 
