### PR TITLE
Add node_modules to gitignore in Express backends

### DIFF
--- a/.changeset/shy-cars-know.md
+++ b/.changeset/shy-cars-know.md
@@ -1,0 +1,5 @@
+---
+"create-llama": patch
+---
+
+Add node_modules to gitignore in Express backends

--- a/packages/create-llama/templates/types/simple/express/gitignore
+++ b/packages/create-llama/templates/types/simple/express/gitignore
@@ -1,2 +1,3 @@
 # local env files
 .env
+node_modules/

--- a/packages/create-llama/templates/types/streaming/express/gitignore
+++ b/packages/create-llama/templates/types/streaming/express/gitignore
@@ -1,2 +1,3 @@
 # local env files
 .env
+node_modules/


### PR DESCRIPTION
## About
As the title says

## Test plan
Locally ran the CLI 2x:
* Express + Chat without streaming 
* Express + Chat with streaming
Saw that the output had the updated .gitignore file.