### PR TITLE
docs: add local model API guide + qdrant improvement

### DIFF
--- a/apps/docs/docs/modules/embedding.md
+++ b/apps/docs/docs/modules/embedding.md
@@ -15,6 +15,15 @@ const openaiEmbeds = new OpenAIEmbedding();
 
 const serviceContext = serviceContextFromDefaults({ embedModel: openaiEmbeds });
 ```
+You can use local embedding services based on OpenAI, such as Ollama or Llama.cpp by changing baseURL property:
+
+```typescript
+const openaiEmbeds = new OpenAIEmbedding({
+  additionalSessionOptions: {
+    baseURL: "http://127.0.0.1:8080/v1"
+  }
+});
+```
 
 ## API Reference
 

--- a/apps/docs/docs/modules/llm.md
+++ b/apps/docs/docs/modules/llm.md
@@ -16,6 +16,18 @@ const openaiLLM = new OpenAI({ model: "gpt-3.5-turbo", temperature: 0 });
 const serviceContext = serviceContextFromDefaults({ llm: openaiLLM });
 ```
 
+You can use local services based on OpenAI, such as Ollama or Llama.cpp by changing baseURL property:
+
+```typescript
+const openaiLLM = new OpenAI({ 
+  model: "gpt-3.5-turbo", 
+  temperature: 0, 
+  additionalSessionOptions: {
+    baseURL: "http://127.0.0.1:8080/v1"
+  }
+});
+```
+
 ## API Reference
 
 - [OpenAI](../../api/classes/OpenAI.md)

--- a/apps/docs/docs/modules/vectorStores/qdrant.md
+++ b/apps/docs/docs/modules/vectorStores/qdrant.md
@@ -25,8 +25,7 @@ const essay = await fs.readFile(path, "utf-8");
 
 ```ts
 const vectorStore = new QdrantVectorStore({
-  url: "http://localhost:6333",
-  port: 6333,
+  url: "http://localhost:6333"
 });
 ```
 
@@ -64,8 +63,7 @@ async function main() {
   const essay = await fs.readFile(path, "utf-8");
 
   const vectorStore = new QdrantVectorStore({
-    url: "http://localhost:6333",
-    port: 6333,
+    url: "http://localhost:6333"
   });
 
   const document = new Document({ text: essay, id_: path });
@@ -85,4 +83,19 @@ async function main() {
 }
 
 main().catch(console.error);
+```
+
+## Known issues
+
+### Wrong input: Vector inserting error: expected dim: 1536, got 384
+If you not mention the collection name, the database store created the collection name `default` each time you make query.
+If you change the embedding model, you will get error at the database like: `Wrong input: Vector inserting error: expected dim: 1536, got 384`
+It because, first time it is using the OpenAI embedding (dimension 1536) and then the next time query, you're using another embedding model with dimension 384.
+
+Solution: add new collection by give the collection name and the dimension will auto create include with new collection for the first time will fix this error.
+```
+const vectorStore = new QdrantVectorStore({
+    url: "http://localhost:6333",
+    collectionName: 'qdrant-test' <--- new name to create new collection to fix error
+});
 ```

--- a/packages/core/src/storage/vectorStore/QdrantVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/QdrantVectorStore.ts
@@ -184,9 +184,14 @@ export class QdrantVectorStore implements VectorStore {
     const { points, ids } = await this.buildPoints(embeddingResults);
 
     const batchUpsert = async (points: PointStruct[]) => {
-      await this.db.upsert(this.collectionName, {
-        points: points,
-      });
+      try {
+        await this.db.upsert(this.collectionName, {
+          points: points,
+        });
+      } catch (error: any) {
+        console.error(error);
+        throw new Error("QdrantVectorStore upsert error: " + error.message);
+      }
     };
 
     for (let i = 0; i < points.length; i += this.batchSize) {


### PR DESCRIPTION
Since it take me too long to find out how to run local service with llamaIndex I add this to docs.
fix #293 

add improvement for qdrantVectorStore since I'm testing it  https://github.com/run-llama/LlamaIndexTS/pull/408#issuecomment-1911453524