### PR TITLE
Expose BaseExtractor Class

### DIFF
--- a/packages/core/src/extractors/index.ts
+++ b/packages/core/src/extractors/index.ts
@@ -4,3 +4,4 @@ export {
   SummaryExtractor,
   TitleExtractor,
 } from "./MetadataExtractors";
+export { BaseExtractor } from "./types";


### PR DESCRIPTION
This change exposes the BaseExtractor class, allowing you to define your own metadata extractors.