### PR TITLE
bugfix: Issue #455: StorageContext not saving data after deleting document/ref info

### DIFF
--- a/packages/core/src/storage/kvStore/SimpleKVStore.ts
+++ b/packages/core/src/storage/kvStore/SimpleKVStore.ts
@@ -55,6 +55,11 @@ export class SimpleKVStore extends BaseKVStore {
   ): Promise<boolean> {
     if (key in this.data[collection]) {
       delete this.data[collection][key];
+
+      if (this.persistPath) {
+        await this.persist(this.persistPath, this.fs); // Save the data after deleting the key
+      }
+
       return true;
     }
     return false;


### PR DESCRIPTION
Issue #455: StorageContext not saving data after deleting document/ref info

Changes Proposed:
Execute persist after delete the key.

I hv tried to execute the below code after deleting the document, but nothing happened.
```
await storageContext.docStore.persist();
await storageContext.docStore.persist(
  path.join("storage", DEFAULT_DOC_STORE_PERSIST_FILENAME)
);
```