### PR TITLE
fix: update deprecated pnpx to pnpm dlx

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ main();
 Then you can run it using
 
 ```bash
-pnpx ts-node example.ts
+pnpm dlx ts-node example.ts
 ```
 
 ## Playground

--- a/examples/chromadb/README.md
+++ b/examples/chromadb/README.md
@@ -6,7 +6,7 @@ Export your OpenAI API Key using `export OPEN_API_KEY=insert your api key here`
 
 If you haven't installed chromadb, run `pip install chromadb`. Start the server using `chroma run`.
 
-Now, open a new terminal window and inside `examples`, run `pnpx ts-node chromadb/test.ts`.
+Now, open a new terminal window and inside `examples`, run `pnpm dlx ts-node chromadb/test.ts`.
 
 Here's the output for the input query `Tell me about Godfrey Cheshire's rating of La Sapienza.`:
 


### PR DESCRIPTION
Hello!

This pull request updates two of the README files to use `pnpm dlx` instead of `pnpx`.

Due to the [deprecation/removal of `pnpx`](https://github.com/pnpm/pnpm/pull/3652), the current examples in the READMEs may not work for some users. There are also no docs for the `pnpx` command on pnpm.io now that it's removed. As of its deprecation in pnpm 6.x, it is now recommended to use [`pnpm dlx`](https://pnpm.io/cli/dlx) instead.