### PR TITLE
docs: fix broken relative links in docs

### DIFF
--- a/apps/docs/docs/getting_started/concepts.md
+++ b/apps/docs/docs/getting_started/concepts.md
@@ -35,7 +35,7 @@ LlamaIndex.TS help you prepare the knowledge base with a suite of data connector
 [**Data Loaders**](../modules/data_loader.md):
 A data connector (i.e. `Reader`) ingest data from different data sources and data formats into a simple `Document` representation (text and simple metadata).
 
-[**Documents / Nodes**](../modules/documents_and_nodes.md): A `Document` is a generic container around any data source - for instance, a PDF, an API output, or retrieved data from a database. A `Node` is the atomic unit of data in LlamaIndex and represents a "chunk" of a source `Document`. It's a rich representation that includes metadata and relationships (to other nodes) to enable accurate and expressive retrieval operations.
+[**Documents / Nodes**](../modules/documents_and_nodes/index.md): A `Document` is a generic container around any data source - for instance, a PDF, an API output, or retrieved data from a database. A `Node` is the atomic unit of data in LlamaIndex and represents a "chunk" of a source `Document`. It's a rich representation that includes metadata and relationships (to other nodes) to enable accurate and expressive retrieval operations.
 
 [**Data Indexes**](../modules/data_index.md):
 Once you've ingested your data, LlamaIndex helps you index data into a format that's easy to retrieve.

--- a/apps/docs/docs/getting_started/installation.mdx
+++ b/apps/docs/docs/getting_started/installation.mdx
@@ -58,6 +58,6 @@ Our examples use OpenAI by default. You'll need to set up your Open AI key like 
 export OPENAI_API_KEY="sk-......" # Replace with your key from https://platform.openai.com/account/api-keys
 ```
 
-If you want to have it automatically loaded every time, add it to your .zshrc/.bashrc.
+If you want to have it automatically loaded every time, add it to your `.zshrc/.bashrc`.
 
 WARNING: do not check in your OpenAI key into version control.

--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -37,7 +37,7 @@ For more complex applications, our lower-level APIs allow advanced users to cust
 
 `npm install llamaindex`
 
-Our documentation includes [Installation Instructions](./installation.mdx) and a [Starter Tutorial](./starter.md) to build your first application.
+Our documentation includes [Installation Instructions](./getting_started/installation.mdx) and a [Starter Tutorial](./getting_started/starter.md) to build your first application.
 
 Once you're up and running, [High-Level Concepts](./getting_started/concepts.md) has an overview of LlamaIndex's modular architecture. For more hands-on practical examples, look through our [End-to-End Tutorials](./end_to_end.md).
 

--- a/apps/docs/docs/modules/agent/index.md
+++ b/apps/docs/docs/modules/agent/index.md
@@ -11,4 +11,4 @@ An “agent” is an automated reasoning and decision engine. It takes in a user
 
 LlamaIndex.TS comes with a few built-in agents, but you can also create your own. The built-in agents include:
 
-- [OpenAI Agent](./openai.md)
+- [OpenAI Agent](./openai.mdx)

--- a/apps/docs/docs/modules/query_engines/index.md
+++ b/apps/docs/docs/modules/query_engines/index.md
@@ -36,6 +36,6 @@ You can learn more about Tools by taking a look at the LlamaIndex Python documen
 
 ## API Reference
 
-- [RetrieverQueryEngine](../api/classes/RetrieverQueryEngine.md)
-- [SubQuestionQueryEngine](../api/classes/SubQuestionQueryEngine.md)
-- [QueryEngineTool](../api/interfaces//QueryEngineTool.md)
+- [RetrieverQueryEngine](../../api/classes/RetrieverQueryEngine.md)
+- [SubQuestionQueryEngine](../../api/classes/SubQuestionQueryEngine.md)
+- [QueryEngineTool](../../api/interfaces/QueryEngineTool.md)


### PR DESCRIPTION
Hello!

I discovered that several of the links in the docs are broken and simply redirect to a 404 page. This pull request fixes most of the broken links that I found. I also updated one of the file references, `.zshrc/.bashrc`, to be formatted as inline code.

It also appears that the "End-to-End Tutorials" link is broken in `apps/docs/introduction.md` (the docs home page). However, I couldn't find the correct URL for this. Any ideas as to what the correct URL is?