### PR TITLE
Consistent Document IDs in NotionReader.ts

### DIFF
--- a/packages/core/src/readers/NotionReader.ts
+++ b/packages/core/src/readers/NotionReader.ts
@@ -42,7 +42,11 @@ export class NotionReader implements BaseReader {
   toDocuments(pages: Pages): Document[] {
     return Object.values(pages).map((page) => {
       const text = pageToString(page);
-      return new Document({ text, metadata: page.metadata });
+      return new Document({
+        id_: page.metadata.id, // Use the Notion-provided UUID for the document
+        text,
+        metadata: page.metadata,
+      });
     });
   }
 


### PR DESCRIPTION
## Problem

When using the NotionReader `Document` objects do not have the same ID as the Notion document they represent. This looks to simply be an oversight, rather than intended behavior. The Notion document ID is available.

## Solution

Use the Notion document ID as the ID of the `Document` object. This ensures consistent `id_`s for each ingestion run.