### PR TITLE
feat: enable `verbatimModuleSyntax`

### DIFF
--- a/.changeset/pink-bulldogs-exist.md
+++ b/.changeset/pink-bulldogs-exist.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+build: improve tree-shake & reduce unused package import

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,5 @@ module.exports = {
     "max-params": ["error", 4],
     "prefer-const": "error",
   },
-  ignorePatterns: ["dist/"],
+  ignorePatterns: ["dist/", "lib/"],
 };

--- a/packages/core/src/ChatHistory.ts
+++ b/packages/core/src/ChatHistory.ts
@@ -1,10 +1,7 @@
 import { OpenAI } from "./llm/LLM.js";
-import { ChatMessage, LLM, MessageType } from "./llm/types.js";
-import {
-  defaultSummaryPrompt,
-  messagesToHistoryStr,
-  SummaryPrompt,
-} from "./Prompt.js";
+import type { ChatMessage, LLM, MessageType } from "./llm/types.js";
+import type { SummaryPrompt } from "./Prompt.js";
+import { defaultSummaryPrompt, messagesToHistoryStr } from "./Prompt.js";
 
 /**
  * A ChatHistory is used to keep the state of back and forth chat messages
@@ -50,7 +47,7 @@ export class SimpleChatHistory extends ChatHistory {
   }
 
   async requestMessages(transientMessages?: ChatMessage[]) {
-    return [...(transientMessages ?? []), ...this.messages];
+    return Promise.resolve([...(transientMessages ?? []), ...this.messages]);
   }
 
   reset() {

--- a/packages/core/src/ChatHistory.ts
+++ b/packages/core/src/ChatHistory.ts
@@ -47,7 +47,7 @@ export class SimpleChatHistory extends ChatHistory {
   }
 
   async requestMessages(transientMessages?: ChatMessage[]) {
-    return Promise.resolve([...(transientMessages ?? []), ...this.messages]);
+    return [...(transientMessages ?? []), ...this.messages];
   }
 
   reset() {

--- a/packages/core/src/GlobalsHelper.ts
+++ b/packages/core/src/GlobalsHelper.ts
@@ -1,7 +1,11 @@
 import { encodingForModel } from "js-tiktoken";
 
 import { randomUUID } from "@llamaindex/env";
-import { Event, EventTag, EventType } from "./callbacks/CallbackManager.js";
+import type {
+  Event,
+  EventTag,
+  EventType,
+} from "./callbacks/CallbackManager.js";
 
 export enum Tokenizers {
   CL100K_BASE = "cl100k_base",
@@ -32,7 +36,7 @@ class GlobalsHelper {
     };
   }
 
-  tokenizer(encoding?: string) {
+  tokenizer(encoding?: Tokenizers) {
     if (encoding && encoding !== Tokenizers.CL100K_BASE) {
       throw new Error(`Tokenizer encoding ${encoding} not yet supported`);
     }
@@ -43,7 +47,7 @@ class GlobalsHelper {
     return this.defaultTokenizer!.encode.bind(this.defaultTokenizer);
   }
 
-  tokenizerDecoder(encoding?: string) {
+  tokenizerDecoder(encoding?: Tokenizers) {
     if (encoding && encoding !== Tokenizers.CL100K_BASE) {
       throw new Error(`Tokenizer encoding ${encoding} not yet supported`);
     }

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -24,7 +24,7 @@ export enum MetadataMode {
   NONE = "NONE",
 }
 
-export type Metadata = Record<string, unknown>;
+export type Metadata = Record<string, any>;
 
 export interface RelatedNodeInfo<T extends Metadata = Metadata> {
   nodeId: string;
@@ -40,10 +40,7 @@ export type RelatedNodeType<T extends Metadata = Metadata> =
 /**
  * Generic abstract class for retrievable nodes
  */
-export abstract class BaseNode<
-  Content = string,
-  T extends Metadata = Metadata,
-> {
+export abstract class BaseNode<T extends Metadata = Metadata> {
   /**
    * The unique ID of the Node/Document. The trailing underscore is here
    * to avoid collisions with the id keyword in Python.

--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -24,7 +24,7 @@ export enum MetadataMode {
   NONE = "NONE",
 }
 
-export type Metadata = Record<string, any>;
+export type Metadata = Record<string, unknown>;
 
 export interface RelatedNodeInfo<T extends Metadata = Metadata> {
   nodeId: string;
@@ -40,7 +40,10 @@ export type RelatedNodeType<T extends Metadata = Metadata> =
 /**
  * Generic abstract class for retrievable nodes
  */
-export abstract class BaseNode<T extends Metadata = Metadata> {
+export abstract class BaseNode<
+  Content = string,
+  T extends Metadata = Metadata,
+> {
   /**
    * The unique ID of the Node/Document. The trailing underscore is here
    * to avoid collisions with the id keyword in Python.
@@ -65,7 +68,8 @@ export abstract class BaseNode<T extends Metadata = Metadata> {
 
   abstract getContent(metadataMode: MetadataMode): string;
   abstract getMetadataStr(metadataMode: MetadataMode): string;
-  abstract setContent(value: any): void;
+  // todo: set value as a generic type
+  abstract setContent(value: unknown): void;
 
   get sourceNode(): RelatedNodeInfo<T> | undefined {
     const relationship = this.relationships[NodeRelationship.SOURCE];

--- a/packages/core/src/OutputParser.ts
+++ b/packages/core/src/OutputParser.ts
@@ -1,5 +1,5 @@
-import { SubQuestion } from "./engines/query/types.js";
-import { BaseOutputParser, StructuredOutput } from "./types.js";
+import type { SubQuestion } from "./engines/query/types.js";
+import type { BaseOutputParser, StructuredOutput } from "./types.js";
 
 /**
  * Error class for output parsing. Due to the nature of LLMs, anytime we use LLM
@@ -44,8 +44,8 @@ export function parseJsonMarkdown(text: string) {
   const left_square = text.indexOf("[");
   const left_brace = text.indexOf("{");
 
-  var left: number;
-  var right: number;
+  let left: number;
+  let right: number;
   if (left_square < left_brace && left_square != -1) {
     left = left_square;
     right = text.lastIndexOf("]");

--- a/packages/core/src/Prompt.ts
+++ b/packages/core/src/Prompt.ts
@@ -1,6 +1,6 @@
-import { SubQuestion } from "./engines/query/types.js";
-import { ChatMessage } from "./llm/types.js";
-import { ToolMetadata } from "./types.js";
+import type { SubQuestion } from "./engines/query/types.js";
+import type { ChatMessage } from "./llm/types.js";
+import type { ToolMetadata } from "./types.js";
 
 /**
  * A SimplePrompt is a function that takes a dictionary of inputs and returns a string.

--- a/packages/core/src/PromptHelper.ts
+++ b/packages/core/src/PromptHelper.ts
@@ -1,5 +1,5 @@
 import { globalsHelper } from "./GlobalsHelper.js";
-import { SimplePrompt } from "./Prompt.js";
+import type { SimplePrompt } from "./Prompt.js";
 import { SentenceSplitter } from "./TextSplitter.js";
 import {
   DEFAULT_CHUNK_OVERLAP_RATIO,

--- a/packages/core/src/QuestionGenerator.ts
+++ b/packages/core/src/QuestionGenerator.ts
@@ -1,14 +1,18 @@
 import { SubQuestionOutputParser } from "./OutputParser.js";
-import {
-  SubQuestionPrompt,
-  buildToolsText,
-  defaultSubQuestionPrompt,
-} from "./Prompt.js";
-import { BaseQuestionGenerator, SubQuestion } from "./engines/query/types.js";
+import type { SubQuestionPrompt } from "./Prompt.js";
+import { buildToolsText, defaultSubQuestionPrompt } from "./Prompt.js";
+import type {
+  BaseQuestionGenerator,
+  SubQuestion,
+} from "./engines/query/types.js";
 import { OpenAI } from "./llm/LLM.js";
-import { LLM } from "./llm/types.js";
+import type { LLM } from "./llm/types.js";
 import { PromptMixin } from "./prompts/index.js";
-import { BaseOutputParser, StructuredOutput, ToolMetadata } from "./types.js";
+import type {
+  BaseOutputParser,
+  StructuredOutput,
+  ToolMetadata,
+} from "./types.js";
 
 /**
  * LLMQuestionGenerator uses the LLM to generate new questions for the LLM using tools and a user query.

--- a/packages/core/src/Response.ts
+++ b/packages/core/src/Response.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from "./Node.js";
+import type { BaseNode } from "./Node.js";
 
 /**
  * Response is the output of a LLM

--- a/packages/core/src/Retriever.ts
+++ b/packages/core/src/Retriever.ts
@@ -1,6 +1,6 @@
-import { Event } from "./callbacks/CallbackManager.js";
-import { NodeWithScore } from "./Node.js";
-import { ServiceContext } from "./ServiceContext.js";
+import type { Event } from "./callbacks/CallbackManager.js";
+import type { NodeWithScore } from "./Node.js";
+import type { ServiceContext } from "./ServiceContext.js";
 
 /**
  * Retrievers retrieve the nodes that most closely match our query in similarity.

--- a/packages/core/src/ServiceContext.ts
+++ b/packages/core/src/ServiceContext.ts
@@ -1,10 +1,11 @@
 import { PromptHelper } from "./PromptHelper.js";
 import { CallbackManager } from "./callbacks/CallbackManager.js";
 import { OpenAIEmbedding } from "./embeddings/OpenAIEmbedding.js";
-import { BaseEmbedding } from "./embeddings/types.js";
-import { LLM, OpenAI } from "./llm/index.js";
+import type { BaseEmbedding } from "./embeddings/types.js";
+import type { LLM } from "./llm/index.js";
+import { OpenAI } from "./llm/index.js";
 import { SimpleNodeParser } from "./nodeParsers/SimpleNodeParser.js";
-import { NodeParser } from "./nodeParsers/types.js";
+import type { NodeParser } from "./nodeParsers/types.js";
 
 /**
  * The ServiceContext is a collection of components that are used in different parts of the application.

--- a/packages/core/src/agent/openai/base.ts
+++ b/packages/core/src/agent/openai/base.ts
@@ -1,7 +1,8 @@
-import { CallbackManager } from "../../callbacks/CallbackManager.js";
-import { ChatMessage, OpenAI } from "../../llm/index.js";
-import { ObjectRetriever } from "../../objects/base.js";
-import { BaseTool } from "../../types.js";
+import type { CallbackManager } from "../../callbacks/CallbackManager.js";
+import type { ChatMessage } from "../../llm/index.js";
+import { OpenAI } from "../../llm/index.js";
+import type { ObjectRetriever } from "../../objects/base.js";
+import type { BaseTool } from "../../types.js";
 import { AgentRunner } from "../runner/base.js";
 import { OpenAIAgentWorker } from "./worker.js";
 

--- a/packages/core/src/agent/openai/utils.ts
+++ b/packages/core/src/agent/openai/utils.ts
@@ -1,4 +1,4 @@
-import { ToolMetadata } from "../../types.js";
+import type { ToolMetadata } from "../../types.js";
 
 export type OpenAIFunction = {
   type: "function";

--- a/packages/core/src/agent/openai/worker.ts
+++ b/packages/core/src/agent/openai/worker.ts
@@ -1,25 +1,26 @@
 // Assuming that the necessary interfaces and classes (like BaseTool, OpenAI, ChatMessage, CallbackManager, etc.) are defined elsewhere
 
 import { randomUUID } from "@llamaindex/env";
-import { CallbackManager } from "../../callbacks/CallbackManager.js";
+import type { CallbackManager } from "../../callbacks/CallbackManager.js";
 import {
   AgentChatResponse,
   ChatResponseMode,
 } from "../../engines/chat/types.js";
-import {
+import type {
   ChatMessage,
   ChatResponse,
   ChatResponseChunk,
-  OpenAI,
 } from "../../llm/index.js";
+import { OpenAI } from "../../llm/index.js";
 import { ChatMemoryBuffer } from "../../memory/ChatMemoryBuffer.js";
-import { ObjectRetriever } from "../../objects/base.js";
-import { ToolOutput } from "../../tools/types.js";
+import type { ObjectRetriever } from "../../objects/base.js";
+import type { ToolOutput } from "../../tools/types.js";
 import { callToolWithErrorHandling } from "../../tools/utils.js";
-import { BaseTool } from "../../types.js";
-import { AgentWorker, Task, TaskStep, TaskStepOutput } from "../types.js";
+import type { BaseTool } from "../../types.js";
+import type { AgentWorker, Task } from "../types.js";
+import { TaskStep, TaskStepOutput } from "../types.js";
 import { addUserStepToMemory, getFunctionByName } from "../utils.js";
-import { OpenAIToolCall } from "./types/chat.js";
+import type { OpenAIToolCall } from "./types/chat.js";
 import { toOpenAiTool } from "./utils.js";
 
 const DEFAULT_MAX_FUNCTION_CALLS = 5;

--- a/packages/core/src/agent/react/base.ts
+++ b/packages/core/src/agent/react/base.ts
@@ -1,7 +1,7 @@
-import { CallbackManager } from "../../callbacks/CallbackManager.js";
-import { ChatMessage, LLM } from "../../llm/index.js";
-import { ObjectRetriever } from "../../objects/base.js";
-import { BaseTool } from "../../types.js";
+import type { CallbackManager } from "../../callbacks/CallbackManager.js";
+import type { ChatMessage, LLM } from "../../llm/index.js";
+import type { ObjectRetriever } from "../../objects/base.js";
+import type { BaseTool } from "../../types.js";
 import { AgentRunner } from "../runner/base.js";
 import { ReActAgentWorker } from "./worker.js";
 

--- a/packages/core/src/agent/react/formatter.ts
+++ b/packages/core/src/agent/react/formatter.ts
@@ -1,7 +1,8 @@
-import { ChatMessage } from "../../llm/index.js";
-import { BaseTool } from "../../types.js";
+import type { ChatMessage } from "../../llm/index.js";
+import type { BaseTool } from "../../types.js";
 import { getReactChatSystemHeader } from "./prompts.js";
-import { BaseReasoningStep, ObservationReasoningStep } from "./types.js";
+import type { BaseReasoningStep } from "./types.js";
+import { ObservationReasoningStep } from "./types.js";
 
 function getReactToolDescriptions(tools: BaseTool[]): string[] {
   const toolDescs: string[] = [];

--- a/packages/core/src/agent/react/outputParser.ts
+++ b/packages/core/src/agent/react/outputParser.ts
@@ -1,7 +1,7 @@
+import type { BaseReasoningStep } from "./types.js";
 import {
   ActionReasoningStep,
   BaseOutputParser,
-  BaseReasoningStep,
   ResponseReasoningStep,
 } from "./types.js";
 

--- a/packages/core/src/agent/react/types.ts
+++ b/packages/core/src/agent/react/types.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from "../../llm/index.js";
+import type { ChatMessage } from "../../llm/index.js";
 
 export interface BaseReasoningStep {
   getContent(): string;

--- a/packages/core/src/agent/react/worker.ts
+++ b/packages/core/src/agent/react/worker.ts
@@ -1,17 +1,19 @@
 import { randomUUID } from "crypto";
 import { CallbackManager } from "../../callbacks/CallbackManager.js";
 import { AgentChatResponse } from "../../engines/chat/index.js";
-import { ChatResponse, LLM, OpenAI } from "../../llm/index.js";
+import type { ChatResponse, LLM } from "../../llm/index.js";
+import { OpenAI } from "../../llm/index.js";
 import { ChatMemoryBuffer } from "../../memory/ChatMemoryBuffer.js";
-import { ObjectRetriever } from "../../objects/base.js";
+import type { ObjectRetriever } from "../../objects/base.js";
 import { ToolOutput } from "../../tools/index.js";
-import { BaseTool } from "../../types.js";
-import { AgentWorker, Task, TaskStep, TaskStepOutput } from "../types.js";
+import type { BaseTool } from "../../types.js";
+import type { AgentWorker, Task } from "../types.js";
+import { TaskStep, TaskStepOutput } from "../types.js";
 import { ReActChatFormatter } from "./formatter.js";
 import { ReActOutputParser } from "./outputParser.js";
+import type { BaseReasoningStep } from "./types.js";
 import {
   ActionReasoningStep,
-  BaseReasoningStep,
   ObservationReasoningStep,
   ResponseReasoningStep,
 } from "./types.js";

--- a/packages/core/src/agent/runner/base.ts
+++ b/packages/core/src/agent/runner/base.ts
@@ -1,14 +1,15 @@
 import { randomUUID } from "crypto";
 import { CallbackManager } from "../../callbacks/CallbackManager.js";
+import type { ChatEngineAgentParams } from "../../engines/chat/index.js";
 import {
   AgentChatResponse,
-  ChatEngineAgentParams,
   ChatResponseMode,
 } from "../../engines/chat/index.js";
-import { ChatMessage, LLM } from "../../llm/index.js";
+import type { ChatMessage, LLM } from "../../llm/index.js";
 import { ChatMemoryBuffer } from "../../memory/ChatMemoryBuffer.js";
-import { BaseMemory } from "../../memory/types.js";
-import { AgentWorker, Task, TaskStep, TaskStepOutput } from "../types.js";
+import type { BaseMemory } from "../../memory/types.js";
+import type { AgentWorker, TaskStepOutput } from "../types.js";
+import { Task, TaskStep } from "../types.js";
 import { AgentState, BaseAgentRunner, TaskState } from "./types.js";
 
 const validateStepFromArgs = (

--- a/packages/core/src/agent/runner/types.ts
+++ b/packages/core/src/agent/runner/types.ts
@@ -1,5 +1,6 @@
-import { AgentChatResponse } from "../../engines/chat/index.js";
-import { BaseAgent, Task, TaskStep, TaskStepOutput } from "../types.js";
+import type { AgentChatResponse } from "../../engines/chat/index.js";
+import type { Task, TaskStep, TaskStepOutput } from "../types.js";
+import { BaseAgent } from "../types.js";
 
 export class TaskState {
   task!: Task;

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,8 +1,8 @@
-import {
+import type {
   AgentChatResponse,
   ChatEngineAgentParams,
 } from "../engines/chat/index.js";
-import { QueryEngineParamsNonStreaming } from "../types.js";
+import type { QueryEngineParamsNonStreaming } from "../types.js";
 
 export interface AgentWorker {
   initializeStep(task: Task, kwargs?: any): TaskStep;

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -1,7 +1,7 @@
-import { ChatMessage } from "../llm/index.js";
-import { ChatMemoryBuffer } from "../memory/ChatMemoryBuffer.js";
-import { BaseTool } from "../types.js";
-import { TaskStep } from "./types.js";
+import type { ChatMessage } from "../llm/index.js";
+import type { ChatMemoryBuffer } from "../memory/ChatMemoryBuffer.js";
+import type { BaseTool } from "../types.js";
+import type { TaskStep } from "./types.js";
 
 /**
  * Adds the user's input to the memory.

--- a/packages/core/src/callbacks/CallbackManager.ts
+++ b/packages/core/src/callbacks/CallbackManager.ts
@@ -1,5 +1,5 @@
 import type { Anthropic } from "@anthropic-ai/sdk";
-import { NodeWithScore } from "../Node.js";
+import type { NodeWithScore } from "../Node.js";
 
 /*
   An event is a wrapper that groups related operations.

--- a/packages/core/src/cloud/LlamaCloudIndex.ts
+++ b/packages/core/src/cloud/LlamaCloudIndex.ts
@@ -1,10 +1,11 @@
-import { BaseRetriever } from "../Retriever.js";
+import type { BaseRetriever } from "../Retriever.js";
 import { RetrieverQueryEngine } from "../engines/query/RetrieverQueryEngine.js";
-import { BaseNodePostprocessor } from "../postprocessors/types.js";
-import { BaseSynthesizer } from "../synthesizers/types.js";
-import { BaseQueryEngine } from "../types.js";
-import { LlamaCloudRetriever, RetrieveParams } from "./LlamaCloudRetriever.js";
-import { CloudConstructorParams } from "./types.js";
+import type { BaseNodePostprocessor } from "../postprocessors/types.js";
+import type { BaseSynthesizer } from "../synthesizers/types.js";
+import type { BaseQueryEngine } from "../types.js";
+import type { RetrieveParams } from "./LlamaCloudRetriever.js";
+import { LlamaCloudRetriever } from "./LlamaCloudRetriever.js";
+import type { CloudConstructorParams } from "./types.js";
 
 export class LlamaCloudIndex {
   params: CloudConstructorParams;

--- a/packages/core/src/cloud/LlamaCloudRetriever.ts
+++ b/packages/core/src/cloud/LlamaCloudRetriever.ts
@@ -1,17 +1,13 @@
-import { PlatformApi, PlatformApiClient } from "@llamaindex/cloud";
+import type { PlatformApi, PlatformApiClient } from "@llamaindex/cloud";
 import { globalsHelper } from "../GlobalsHelper.js";
-import { NodeWithScore, ObjectType, jsonToNode } from "../Node.js";
-import { BaseRetriever } from "../Retriever.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../ServiceContext.js";
-import { Event } from "../callbacks/CallbackManager.js";
-import {
-  ClientParams,
-  CloudConstructorParams,
-  DEFAULT_PROJECT_NAME,
-} from "./types.js";
+import type { NodeWithScore } from "../Node.js";
+import { ObjectType, jsonToNode } from "../Node.js";
+import type { BaseRetriever } from "../Retriever.js";
+import type { ServiceContext } from "../ServiceContext.js";
+import { serviceContextFromDefaults } from "../ServiceContext.js";
+import type { Event } from "../callbacks/CallbackManager.js";
+import type { ClientParams, CloudConstructorParams } from "./types.js";
+import { DEFAULT_PROJECT_NAME } from "./types.js";
 import { getClient } from "./utils.js";
 
 export type RetrieveParams = Omit<

--- a/packages/core/src/cloud/types.ts
+++ b/packages/core/src/cloud/types.ts
@@ -1,4 +1,4 @@
-import { ServiceContext } from "../ServiceContext.js";
+import type { ServiceContext } from "../ServiceContext.js";
 
 export const DEFAULT_PROJECT_NAME = "default";
 export const DEFAULT_BASE_URL = "https://api.cloud.llamaindex.ai";

--- a/packages/core/src/cloud/utils.ts
+++ b/packages/core/src/cloud/utils.ts
@@ -1,5 +1,6 @@
-import { PlatformApiClient } from "@llamaindex/cloud";
-import { ClientParams, DEFAULT_BASE_URL } from "./types.js";
+import type { PlatformApiClient } from "@llamaindex/cloud";
+import type { ClientParams } from "./types.js";
+import { DEFAULT_BASE_URL } from "./types.js";
 
 export async function getClient({
   apiKey,

--- a/packages/core/src/embeddings/ClipEmbedding.ts
+++ b/packages/core/src/embeddings/ClipEmbedding.ts
@@ -1,4 +1,4 @@
-import { ImageType } from "../Node.js";
+import type { ImageType } from "../Node.js";
 import { MultiModalEmbedding } from "./MultiModalEmbedding.js";
 import { readImage } from "./utils.js";
 

--- a/packages/core/src/embeddings/MultiModalEmbedding.ts
+++ b/packages/core/src/embeddings/MultiModalEmbedding.ts
@@ -1,4 +1,4 @@
-import { ImageType } from "../Node.js";
+import type { ImageType } from "../Node.js";
 import { BaseEmbedding } from "./types.js";
 
 /*

--- a/packages/core/src/embeddings/OllamaEmbedding.ts
+++ b/packages/core/src/embeddings/OllamaEmbedding.ts
@@ -1,5 +1,5 @@
 import { Ollama } from "../llm/ollama.js";
-import { BaseEmbedding } from "./types.js";
+import type { BaseEmbedding } from "./types.js";
 
 /**
  * OllamaEmbedding is an alias for Ollama that implements the BaseEmbedding interface.

--- a/packages/core/src/embeddings/OpenAIEmbedding.ts
+++ b/packages/core/src/embeddings/OpenAIEmbedding.ts
@@ -1,12 +1,13 @@
-import { ClientOptions as OpenAIClientOptions } from "openai";
+import type { ClientOptions as OpenAIClientOptions } from "openai";
+import type { AzureOpenAIConfig } from "../llm/azure.js";
 import {
-  AzureOpenAIConfig,
   getAzureBaseUrl,
   getAzureConfigFromEnv,
   getAzureModel,
   shouldUseAzure,
 } from "../llm/azure.js";
-import { OpenAISession, getOpenAISession } from "../llm/open_ai.js";
+import type { OpenAISession } from "../llm/open_ai.js";
+import { getOpenAISession } from "../llm/open_ai.js";
 import { BaseEmbedding } from "./types.js";
 
 export const ALL_OPENAI_EMBEDDING_MODELS = {

--- a/packages/core/src/embeddings/types.ts
+++ b/packages/core/src/embeddings/types.ts
@@ -1,5 +1,6 @@
-import { BaseNode, MetadataMode } from "../Node.js";
-import { TransformComponent } from "../ingestion/types.js";
+import type { BaseNode } from "../Node.js";
+import { MetadataMode } from "../Node.js";
+import type { TransformComponent } from "../ingestion/types.js";
 import { SimilarityType, similarity } from "./utils.js";
 
 const DEFAULT_EMBED_BATCH_SIZE = 10;

--- a/packages/core/src/embeddings/utils.ts
+++ b/packages/core/src/embeddings/utils.ts
@@ -1,6 +1,6 @@
 import { defaultFS } from "@llamaindex/env";
 import _ from "lodash";
-import { ImageType } from "../Node.js";
+import type { ImageType } from "../Node.js";
 import { DEFAULT_SIMILARITY_TOP_K } from "../constants.js";
 import { VectorStoreQueryMode } from "../storage/vectorStore/types.js";
 
@@ -171,13 +171,13 @@ export function getTopKMMREmbeddings(
 
   while (results.length < Math.min(similarityTopKCount, embeddingLength)) {
     results.push([score, highScoreId]);
-    embedMap.delete(highScoreId!);
+    embedMap.delete(highScoreId);
     const recentEmbeddingId = highScoreId;
     score = Number.NEGATIVE_INFINITY;
     for (const embedId of Array.from(embedMap.keys())) {
       const overlapWithRecent = similarityFn(
         embeddings[embedMap.get(embedId)!],
-        embeddings[fullEmbedMap.get(recentEmbeddingId!)!],
+        embeddings[fullEmbedMap.get(recentEmbeddingId)!],
       );
       if (
         threshold * embedSimilarity.get(embedId)! -

--- a/packages/core/src/engines/chat/CondenseQuestionChatEngine.ts
+++ b/packages/core/src/engines/chat/CondenseQuestionChatEngine.ts
@@ -1,19 +1,18 @@
-import { ChatHistory, getHistory } from "../../ChatHistory.js";
+import type { ChatHistory } from "../../ChatHistory.js";
+import { getHistory } from "../../ChatHistory.js";
+import type { CondenseQuestionPrompt } from "../../Prompt.js";
 import {
-  CondenseQuestionPrompt,
   defaultCondenseQuestionPrompt,
   messagesToHistoryStr,
 } from "../../Prompt.js";
-import { Response } from "../../Response.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../../ServiceContext.js";
-import { ChatMessage, LLM } from "../../llm/index.js";
+import type { Response } from "../../Response.js";
+import type { ServiceContext } from "../../ServiceContext.js";
+import { serviceContextFromDefaults } from "../../ServiceContext.js";
+import type { ChatMessage, LLM } from "../../llm/index.js";
 import { extractText, streamReducer } from "../../llm/utils.js";
 import { PromptMixin } from "../../prompts/index.js";
-import { BaseQueryEngine } from "../../types.js";
-import {
+import type { BaseQueryEngine } from "../../types.js";
+import type {
   ChatEngine,
   ChatEngineParamsNonStreaming,
   ChatEngineParamsStreaming,

--- a/packages/core/src/engines/chat/ContextChatEngine.ts
+++ b/packages/core/src/engines/chat/ContextChatEngine.ts
@@ -1,25 +1,22 @@
 import { randomUUID } from "@llamaindex/env";
-import { ChatHistory, getHistory } from "../../ChatHistory.js";
-import { ContextSystemPrompt } from "../../Prompt.js";
+import type { ChatHistory } from "../../ChatHistory.js";
+import { getHistory } from "../../ChatHistory.js";
+import type { ContextSystemPrompt } from "../../Prompt.js";
 import { Response } from "../../Response.js";
-import { BaseRetriever } from "../../Retriever.js";
-import { Event } from "../../callbacks/CallbackManager.js";
-import {
-  ChatMessage,
-  ChatResponseChunk,
-  LLM,
-  OpenAI,
-} from "../../llm/index.js";
-import { MessageContent } from "../../llm/types.js";
+import type { BaseRetriever } from "../../Retriever.js";
+import type { Event } from "../../callbacks/CallbackManager.js";
+import type { ChatMessage, ChatResponseChunk, LLM } from "../../llm/index.js";
+import { OpenAI } from "../../llm/index.js";
+import type { MessageContent } from "../../llm/types.js";
 import {
   extractText,
   streamConverter,
   streamReducer,
 } from "../../llm/utils.js";
-import { BaseNodePostprocessor } from "../../postprocessors/index.js";
+import type { BaseNodePostprocessor } from "../../postprocessors/index.js";
 import { PromptMixin } from "../../prompts/Mixin.js";
 import { DefaultContextGenerator } from "./DefaultContextGenerator.js";
-import {
+import type {
   ChatEngine,
   ChatEngineParamsNonStreaming,
   ChatEngineParamsStreaming,

--- a/packages/core/src/engines/chat/DefaultContextGenerator.ts
+++ b/packages/core/src/engines/chat/DefaultContextGenerator.ts
@@ -1,14 +1,12 @@
 import { randomUUID } from "@llamaindex/env";
-import { NodeWithScore, TextNode } from "../../Node.js";
-import {
-  ContextSystemPrompt,
-  defaultContextSystemPrompt,
-} from "../../Prompt.js";
-import { BaseRetriever } from "../../Retriever.js";
-import { Event } from "../../callbacks/CallbackManager.js";
-import { BaseNodePostprocessor } from "../../postprocessors/index.js";
+import type { NodeWithScore, TextNode } from "../../Node.js";
+import type { ContextSystemPrompt } from "../../Prompt.js";
+import { defaultContextSystemPrompt } from "../../Prompt.js";
+import type { BaseRetriever } from "../../Retriever.js";
+import type { Event } from "../../callbacks/CallbackManager.js";
+import type { BaseNodePostprocessor } from "../../postprocessors/index.js";
 import { PromptMixin } from "../../prompts/index.js";
-import { Context, ContextGenerator } from "./types.js";
+import type { Context, ContextGenerator } from "./types.js";
 
 export class DefaultContextGenerator
   extends PromptMixin

--- a/packages/core/src/engines/chat/SimpleChatEngine.ts
+++ b/packages/core/src/engines/chat/SimpleChatEngine.ts
@@ -1,8 +1,10 @@
-import { ChatHistory, getHistory } from "../../ChatHistory.js";
+import type { ChatHistory } from "../../ChatHistory.js";
+import { getHistory } from "../../ChatHistory.js";
 import { Response } from "../../Response.js";
-import { ChatResponseChunk, LLM, OpenAI } from "../../llm/index.js";
+import type { ChatResponseChunk, LLM } from "../../llm/index.js";
+import { OpenAI } from "../../llm/index.js";
 import { streamConverter, streamReducer } from "../../llm/utils.js";
-import {
+import type {
   ChatEngine,
   ChatEngineParamsNonStreaming,
   ChatEngineParamsStreaming,

--- a/packages/core/src/engines/chat/types.ts
+++ b/packages/core/src/engines/chat/types.ts
@@ -1,10 +1,10 @@
-import { ChatHistory } from "../../ChatHistory.js";
-import { BaseNode, NodeWithScore } from "../../Node.js";
-import { Response } from "../../Response.js";
-import { Event } from "../../callbacks/CallbackManager.js";
-import { ChatMessage } from "../../llm/index.js";
-import { MessageContent } from "../../llm/types.js";
-import { ToolOutput } from "../../tools/types.js";
+import type { ChatHistory } from "../../ChatHistory.js";
+import type { BaseNode, NodeWithScore } from "../../Node.js";
+import type { Response } from "../../Response.js";
+import type { Event } from "../../callbacks/CallbackManager.js";
+import type { ChatMessage } from "../../llm/index.js";
+import type { MessageContent } from "../../llm/types.js";
+import type { ToolOutput } from "../../tools/types.js";
 
 /**
  * Represents the base parameters for ChatEngine.

--- a/packages/core/src/engines/query/RetrieverQueryEngine.ts
+++ b/packages/core/src/engines/query/RetrieverQueryEngine.ts
@@ -1,16 +1,14 @@
 import { randomUUID } from "@llamaindex/env";
-import { NodeWithScore } from "../../Node.js";
-import { Response } from "../../Response.js";
-import { BaseRetriever } from "../../Retriever.js";
-import { ServiceContext } from "../../ServiceContext.js";
-import { Event } from "../../callbacks/CallbackManager.js";
-import { BaseNodePostprocessor } from "../../postprocessors/index.js";
+import type { NodeWithScore } from "../../Node.js";
+import type { Response } from "../../Response.js";
+import type { BaseRetriever } from "../../Retriever.js";
+import type { ServiceContext } from "../../ServiceContext.js";
+import type { Event } from "../../callbacks/CallbackManager.js";
+import type { BaseNodePostprocessor } from "../../postprocessors/index.js";
 import { PromptMixin } from "../../prompts/Mixin.js";
-import {
-  BaseSynthesizer,
-  ResponseSynthesizer,
-} from "../../synthesizers/index.js";
-import {
+import type { BaseSynthesizer } from "../../synthesizers/index.js";
+import { ResponseSynthesizer } from "../../synthesizers/index.js";
+import type {
   BaseQueryEngine,
   QueryEngineParamsNonStreaming,
   QueryEngineParamsStreaming,

--- a/packages/core/src/engines/query/RouterQueryEngine.ts
+++ b/packages/core/src/engines/query/RouterQueryEngine.ts
@@ -1,13 +1,12 @@
-import { BaseNode } from "../../Node.js";
+import type { BaseNode } from "../../Node.js";
 import { Response } from "../../Response.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../../ServiceContext.js";
+import type { ServiceContext } from "../../ServiceContext.js";
+import { serviceContextFromDefaults } from "../../ServiceContext.js";
 import { PromptMixin } from "../../prompts/index.js";
-import { BaseSelector, LLMSingleSelector } from "../../selectors/index.js";
+import type { BaseSelector } from "../../selectors/index.js";
+import { LLMSingleSelector } from "../../selectors/index.js";
 import { TreeSummarize } from "../../synthesizers/index.js";
-import {
+import type {
   BaseQueryEngine,
   QueryBundle,
   QueryEngineParamsNonStreaming,

--- a/packages/core/src/engines/query/SubQuestionQueryEngine.ts
+++ b/packages/core/src/engines/query/SubQuestionQueryEngine.ts
@@ -1,20 +1,19 @@
 import { randomUUID } from "@llamaindex/env";
-import { NodeWithScore, TextNode } from "../../Node.js";
+import type { NodeWithScore } from "../../Node.js";
+import { TextNode } from "../../Node.js";
 import { LLMQuestionGenerator } from "../../QuestionGenerator.js";
-import { Response } from "../../Response.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../../ServiceContext.js";
-import { Event } from "../../callbacks/CallbackManager.js";
+import type { Response } from "../../Response.js";
+import type { ServiceContext } from "../../ServiceContext.js";
+import { serviceContextFromDefaults } from "../../ServiceContext.js";
+import type { Event } from "../../callbacks/CallbackManager.js";
 import { PromptMixin } from "../../prompts/Mixin.js";
+import type { BaseSynthesizer } from "../../synthesizers/index.js";
 import {
-  BaseSynthesizer,
   CompactAndRefine,
   ResponseSynthesizer,
 } from "../../synthesizers/index.js";
 
-import {
+import type {
   BaseQueryEngine,
   BaseTool,
   QueryEngineParamsNonStreaming,
@@ -22,7 +21,7 @@ import {
   ToolMetadata,
 } from "../../types.js";
 
-import { BaseQuestionGenerator, SubQuestion } from "./types.js";
+import type { BaseQuestionGenerator, SubQuestion } from "./types.js";
 
 /**
  * SubQuestionQueryEngine decomposes a question into subquestions and then

--- a/packages/core/src/engines/query/types.ts
+++ b/packages/core/src/engines/query/types.ts
@@ -1,4 +1,4 @@
-import { ToolMetadata } from "../../types.js";
+import type { ToolMetadata } from "../../types.js";
 
 /**
  * QuestionGenerators generate new questions for the LLM using tools and a user query.

--- a/packages/core/src/extractors/MetadataExtractors.ts
+++ b/packages/core/src/extractors/MetadataExtractors.ts
@@ -1,5 +1,7 @@
-import { BaseNode, MetadataMode, TextNode } from "../Node.js";
-import { LLM, OpenAI } from "../llm/index.js";
+import type { BaseNode } from "../Node.js";
+import { MetadataMode, TextNode } from "../Node.js";
+import type { LLM } from "../llm/index.js";
+import { OpenAI } from "../llm/index.js";
 import {
   defaultKeywordExtractorPromptTemplate,
   defaultQuestionAnswerPromptTemplate,

--- a/packages/core/src/extractors/types.ts
+++ b/packages/core/src/extractors/types.ts
@@ -1,5 +1,6 @@
-import { BaseNode, MetadataMode, TextNode } from "../Node.js";
-import { TransformComponent } from "../ingestion/types.js";
+import type { BaseNode } from "../Node.js";
+import { MetadataMode, TextNode } from "../Node.js";
+import type { TransformComponent } from "../ingestion/types.js";
 import { defaultNodeTextTemplate } from "./prompts.js";
 
 /*

--- a/packages/core/src/indices/BaseIndex.ts
+++ b/packages/core/src/indices/BaseIndex.ts
@@ -1,13 +1,13 @@
-import { BaseNode, Document } from "../Node.js";
-import { BaseRetriever } from "../Retriever.js";
-import { ServiceContext } from "../ServiceContext.js";
+import type { BaseNode, Document } from "../Node.js";
+import type { BaseRetriever } from "../Retriever.js";
+import type { ServiceContext } from "../ServiceContext.js";
 import { runTransformations } from "../ingestion/IngestionPipeline.js";
-import { StorageContext } from "../storage/StorageContext.js";
-import { BaseDocumentStore } from "../storage/docStore/types.js";
-import { BaseIndexStore } from "../storage/indexStore/types.js";
-import { VectorStore } from "../storage/vectorStore/types.js";
-import { BaseSynthesizer } from "../synthesizers/types.js";
-import { BaseQueryEngine } from "../types.js";
+import type { StorageContext } from "../storage/StorageContext.js";
+import type { BaseDocumentStore } from "../storage/docStore/types.js";
+import type { BaseIndexStore } from "../storage/indexStore/types.js";
+import type { VectorStore } from "../storage/vectorStore/types.js";
+import type { BaseSynthesizer } from "../synthesizers/types.js";
+import type { BaseQueryEngine } from "../types.js";
 import { IndexStruct } from "./IndexStruct.js";
 import { IndexStructType } from "./json-to-index-struct.js";
 

--- a/packages/core/src/indices/json-to-index-struct.ts
+++ b/packages/core/src/indices/json-to-index-struct.ts
@@ -1,4 +1,5 @@
-import { BaseNode, jsonToNode } from "../Node.js";
+import type { BaseNode } from "../Node.js";
+import { jsonToNode } from "../Node.js";
 import { IndexStruct } from "./IndexStruct.js";
 
 export enum IndexStructType {

--- a/packages/core/src/indices/keyword/index.ts
+++ b/packages/core/src/indices/keyword/index.ts
@@ -1,25 +1,24 @@
-import { BaseNode, Document, MetadataMode, NodeWithScore } from "../../Node.js";
-import {
+import type { BaseNode, Document, NodeWithScore } from "../../Node.js";
+import { MetadataMode } from "../../Node.js";
+import type {
   KeywordExtractPrompt,
   QueryKeywordExtractPrompt,
+} from "../../Prompt.js";
+import {
   defaultKeywordExtractPrompt,
   defaultQueryKeywordExtractPrompt,
 } from "../../Prompt.js";
-import { BaseRetriever } from "../../Retriever.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../../ServiceContext.js";
+import type { BaseRetriever } from "../../Retriever.js";
+import type { ServiceContext } from "../../ServiceContext.js";
+import { serviceContextFromDefaults } from "../../ServiceContext.js";
 import { RetrieverQueryEngine } from "../../engines/query/index.js";
-import { BaseNodePostprocessor } from "../../postprocessors/index.js";
-import {
-  BaseDocumentStore,
-  StorageContext,
-  storageContextFromDefaults,
-} from "../../storage/index.js";
-import { BaseSynthesizer } from "../../synthesizers/index.js";
-import { BaseQueryEngine } from "../../types.js";
-import { BaseIndex, BaseIndexInit, KeywordTable } from "../BaseIndex.js";
+import type { BaseNodePostprocessor } from "../../postprocessors/index.js";
+import type { BaseDocumentStore, StorageContext } from "../../storage/index.js";
+import { storageContextFromDefaults } from "../../storage/index.js";
+import type { BaseSynthesizer } from "../../synthesizers/index.js";
+import type { BaseQueryEngine } from "../../types.js";
+import type { BaseIndexInit } from "../BaseIndex.js";
+import { BaseIndex, KeywordTable } from "../BaseIndex.js";
 import { IndexStructType } from "../json-to-index-struct.js";
 import {
   extractKeywordsGivenResponse,

--- a/packages/core/src/indices/summary/index.ts
+++ b/packages/core/src/indices/summary/index.ts
@@ -1,32 +1,34 @@
 import _ from "lodash";
 import { globalsHelper } from "../../GlobalsHelper.js";
-import { BaseNode, Document, NodeWithScore } from "../../Node.js";
-import { ChoiceSelectPrompt, defaultChoiceSelectPrompt } from "../../Prompt.js";
-import { BaseRetriever } from "../../Retriever.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../../ServiceContext.js";
-import { Event } from "../../callbacks/CallbackManager.js";
+import type { BaseNode, Document, NodeWithScore } from "../../Node.js";
+import type { ChoiceSelectPrompt } from "../../Prompt.js";
+import { defaultChoiceSelectPrompt } from "../../Prompt.js";
+import type { BaseRetriever } from "../../Retriever.js";
+import type { ServiceContext } from "../../ServiceContext.js";
+import { serviceContextFromDefaults } from "../../ServiceContext.js";
+import type { Event } from "../../callbacks/CallbackManager.js";
 import { RetrieverQueryEngine } from "../../engines/query/index.js";
-import { BaseNodePostprocessor } from "../../postprocessors/index.js";
-import {
+import type { BaseNodePostprocessor } from "../../postprocessors/index.js";
+import type {
   BaseDocumentStore,
   RefDocInfo,
   StorageContext,
-  storageContextFromDefaults,
 } from "../../storage/index.js";
+import { storageContextFromDefaults } from "../../storage/index.js";
+import type { BaseSynthesizer } from "../../synthesizers/index.js";
 import {
-  BaseSynthesizer,
   CompactAndRefine,
   ResponseSynthesizer,
 } from "../../synthesizers/index.js";
-import { BaseQueryEngine } from "../../types.js";
-import { BaseIndex, BaseIndexInit } from "../BaseIndex.js";
+import type { BaseQueryEngine } from "../../types.js";
+import type { BaseIndexInit } from "../BaseIndex.js";
+import { BaseIndex } from "../BaseIndex.js";
 import { IndexList, IndexStructType } from "../json-to-index-struct.js";
-import {
+import type {
   ChoiceSelectParserFunction,
   NodeFormatterFunction,
+} from "./utils.js";
+import {
   defaultFormatNodeBatchFn,
   defaultParseChoiceSelectAnswerFn,
 } from "./utils.js";

--- a/packages/core/src/indices/summary/utils.ts
+++ b/packages/core/src/indices/summary/utils.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
-import { BaseNode, MetadataMode } from "../../Node.js";
+import type { BaseNode } from "../../Node.js";
+import { MetadataMode } from "../../Node.js";
 
 export type NodeFormatterFunction = (summaryNodes: BaseNode[]) => string;
 export const defaultFormatNodeBatchFn: NodeFormatterFunction = (

--- a/packages/core/src/indices/vectorStore/index.ts
+++ b/packages/core/src/indices/vectorStore/index.ts
@@ -1,42 +1,45 @@
 import { globalsHelper } from "../../GlobalsHelper.js";
-import {
+import type {
   BaseNode,
   Document,
-  ImageNode,
   Metadata,
-  MetadataMode,
   NodeWithScore,
+} from "../../Node.js";
+import {
+  ImageNode,
+  MetadataMode,
   ObjectType,
   splitNodesByType,
 } from "../../Node.js";
-import { BaseRetriever } from "../../Retriever.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../../ServiceContext.js";
-import { Event } from "../../callbacks/CallbackManager.js";
+import type { BaseRetriever } from "../../Retriever.js";
+import type { ServiceContext } from "../../ServiceContext.js";
+import { serviceContextFromDefaults } from "../../ServiceContext.js";
+import type { Event } from "../../callbacks/CallbackManager.js";
 import { DEFAULT_SIMILARITY_TOP_K } from "../../constants.js";
-import {
+import type {
   BaseEmbedding,
-  ClipEmbedding,
   MultiModalEmbedding,
 } from "../../embeddings/index.js";
+import { ClipEmbedding } from "../../embeddings/index.js";
 import { RetrieverQueryEngine } from "../../engines/query/RetrieverQueryEngine.js";
 import { runTransformations } from "../../ingestion/index.js";
-import { BaseNodePostprocessor } from "../../postprocessors/types.js";
-import {
+import type { BaseNodePostprocessor } from "../../postprocessors/types.js";
+import type {
   BaseIndexStore,
   MetadataFilters,
   StorageContext,
   VectorStore,
   VectorStoreQuery,
-  VectorStoreQueryMode,
   VectorStoreQueryResult,
+} from "../../storage/index.js";
+import {
+  VectorStoreQueryMode,
   storageContextFromDefaults,
 } from "../../storage/index.js";
-import { BaseSynthesizer } from "../../synthesizers/types.js";
-import { BaseQueryEngine } from "../../types.js";
-import { BaseIndex, BaseIndexInit } from "../BaseIndex.js";
+import type { BaseSynthesizer } from "../../synthesizers/types.js";
+import type { BaseQueryEngine } from "../../types.js";
+import type { BaseIndexInit } from "../BaseIndex.js";
+import { BaseIndex } from "../BaseIndex.js";
 import { IndexDict, IndexStructType } from "../json-to-index-struct.js";
 
 interface IndexStructOptions {
@@ -189,15 +192,12 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
   ) {
     // Check if the index already has nodes with the same hash
     const newNodes = nodes.filter((node) =>
-      Object.entries(this.indexStruct!.nodesDict).reduce(
-        (acc, [key, value]) => {
-          if (value.hash === node.hash) {
-            acc = false;
-          }
-          return acc;
-        },
-        true,
-      ),
+      Object.entries(this.indexStruct.nodesDict).reduce((acc, [key, value]) => {
+        if (value.hash === node.hash) {
+          acc = false;
+        }
+        return acc;
+      }, true),
     );
 
     await this.insertNodes(newNodes, options);

--- a/packages/core/src/ingestion/IngestionCache.ts
+++ b/packages/core/src/ingestion/IngestionCache.ts
@@ -1,9 +1,10 @@
 import { createSHA256 } from "@llamaindex/env";
-import { BaseNode, MetadataMode } from "../Node.js";
+import type { BaseNode } from "../Node.js";
+import { MetadataMode } from "../Node.js";
 import { docToJson, jsonToDoc } from "../storage/docStore/utils.js";
 import { SimpleKVStore } from "../storage/kvStore/SimpleKVStore.js";
-import { BaseKVStore } from "../storage/kvStore/types.js";
-import { TransformComponent } from "./types.js";
+import type { BaseKVStore } from "../storage/kvStore/types.js";
+import type { TransformComponent } from "./types.js";
 
 const transformToJSON = (obj: TransformComponent) => {
   const seen: any[] = [];

--- a/packages/core/src/ingestion/IngestionPipeline.ts
+++ b/packages/core/src/ingestion/IngestionPipeline.ts
@@ -1,13 +1,13 @@
-import { BaseNode, Document } from "../Node.js";
-import { BaseReader } from "../readers/type.js";
-import { BaseDocumentStore } from "../storage/docStore/types.js";
-import { VectorStore } from "../storage/vectorStore/types.js";
+import type { BaseNode, Document } from "../Node.js";
+import type { BaseReader } from "../readers/type.js";
+import type { BaseDocumentStore } from "../storage/docStore/types.js";
+import type { VectorStore } from "../storage/vectorStore/types.js";
 import { IngestionCache, getTransformationHash } from "./IngestionCache.js";
 import {
   DocStoreStrategy,
   createDocStoreStrategy,
 } from "./strategies/index.js";
-import { TransformComponent } from "./types.js";
+import type { TransformComponent } from "./types.js";
 
 type IngestionRunArgs = {
   documents?: Document[];

--- a/packages/core/src/ingestion/strategies/DuplicatesStrategy.ts
+++ b/packages/core/src/ingestion/strategies/DuplicatesStrategy.ts
@@ -1,6 +1,6 @@
-import { BaseNode } from "../../Node.js";
-import { BaseDocumentStore } from "../../storage/docStore/types.js";
-import { TransformComponent } from "../types.js";
+import type { BaseNode } from "../../Node.js";
+import type { BaseDocumentStore } from "../../storage/docStore/types.js";
+import type { TransformComponent } from "../types.js";
 
 /**
  * Handle doc store duplicates by checking all hashes.

--- a/packages/core/src/ingestion/strategies/UpsertsAndDeleteStrategy.ts
+++ b/packages/core/src/ingestion/strategies/UpsertsAndDeleteStrategy.ts
@@ -1,5 +1,5 @@
-import { BaseNode } from "../../Node.js";
-import { BaseDocumentStore, VectorStore } from "../../storage/index.js";
+import type { BaseNode } from "../../Node.js";
+import type { BaseDocumentStore, VectorStore } from "../../storage/index.js";
 import { classify } from "./classify.js";
 
 /**

--- a/packages/core/src/ingestion/strategies/UpsertsStrategy.ts
+++ b/packages/core/src/ingestion/strategies/UpsertsStrategy.ts
@@ -1,7 +1,7 @@
-import { BaseNode } from "../../Node.js";
-import { BaseDocumentStore } from "../../storage/docStore/types.js";
-import { VectorStore } from "../../storage/vectorStore/types.js";
-import { TransformComponent } from "../types.js";
+import type { BaseNode } from "../../Node.js";
+import type { BaseDocumentStore } from "../../storage/docStore/types.js";
+import type { VectorStore } from "../../storage/vectorStore/types.js";
+import type { TransformComponent } from "../types.js";
 import { classify } from "./classify.js";
 
 /**

--- a/packages/core/src/ingestion/strategies/classify.ts
+++ b/packages/core/src/ingestion/strategies/classify.ts
@@ -1,5 +1,5 @@
-import { BaseNode } from "../../Node.js";
-import { BaseDocumentStore } from "../../storage/docStore/types.js";
+import type { BaseNode } from "../../Node.js";
+import type { BaseDocumentStore } from "../../storage/docStore/types.js";
 
 export async function classify(docStore: BaseDocumentStore, nodes: BaseNode[]) {
   const existingDocIds = Object.values(await docStore.getAllDocumentHashes());

--- a/packages/core/src/ingestion/strategies/index.ts
+++ b/packages/core/src/ingestion/strategies/index.ts
@@ -1,6 +1,6 @@
-import { BaseDocumentStore } from "../../storage/docStore/types.js";
-import { VectorStore } from "../../storage/vectorStore/types.js";
-import { TransformComponent } from "../types.js";
+import type { BaseDocumentStore } from "../../storage/docStore/types.js";
+import type { VectorStore } from "../../storage/vectorStore/types.js";
+import type { TransformComponent } from "../types.js";
 import { DuplicatesStrategy } from "./DuplicatesStrategy.js";
 import { UpsertsStrategy } from "./UpsertsStrategy.js";
 

--- a/packages/core/src/ingestion/types.ts
+++ b/packages/core/src/ingestion/types.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from "../Node.js";
+import type { BaseNode } from "../Node.js";
 
 export interface TransformComponent {
   transform(nodes: BaseNode[], options?: any): Promise<BaseNode[]>;

--- a/packages/core/src/llm/LLM.ts
+++ b/packages/core/src/llm/LLM.ts
@@ -1,5 +1,6 @@
-import OpenAILLM, { ClientOptions as OpenAIClientOptions } from "openai";
-import {
+import type OpenAILLM from "openai";
+import type { ClientOptions as OpenAIClientOptions } from "openai";
+import type {
   AnthropicStreamToken,
   CallbackManager,
   Event,
@@ -8,27 +9,29 @@ import {
   StreamCallbackResponse,
 } from "../callbacks/CallbackManager.js";
 
-import { ChatCompletionMessageParam } from "openai/resources/index.js";
-import { LLMOptions } from "portkey-ai";
+import type { ChatCompletionMessageParam } from "openai/resources/index.js";
+import type { LLMOptions } from "portkey-ai";
 import { Tokenizers, globalsHelper } from "../GlobalsHelper.js";
+import type { AnthropicSession } from "./anthropic.js";
 import {
   ANTHROPIC_AI_PROMPT,
   ANTHROPIC_HUMAN_PROMPT,
-  AnthropicSession,
   getAnthropicSession,
 } from "./anthropic.js";
+import type { AzureOpenAIConfig } from "./azure.js";
 import {
-  AzureOpenAIConfig,
   getAzureBaseUrl,
   getAzureConfigFromEnv,
   getAzureModel,
   shouldUseAzure,
 } from "./azure.js";
 import { BaseLLM } from "./base.js";
-import { OpenAISession, getOpenAISession } from "./open_ai.js";
-import { PortkeySession, getPortkeySession } from "./portkey.js";
+import type { OpenAISession } from "./open_ai.js";
+import { getOpenAISession } from "./open_ai.js";
+import type { PortkeySession } from "./portkey.js";
+import { getPortkeySession } from "./portkey.js";
 import { ReplicateSession } from "./replicate_ai.js";
-import {
+import type {
   ChatMessage,
   ChatResponse,
   ChatResponseChunk,
@@ -313,7 +316,7 @@ export class OpenAI extends BaseLLM {
 
     // TODO: add callback to streamConverter and use streamConverter here
     //Indices
-    var idx_counter: number = 0;
+    let idx_counter: number = 0;
     for await (const part of chunk_stream) {
       if (!part.choices.length) continue;
 
@@ -732,7 +735,7 @@ export class Anthropic extends BaseLLM {
         stream: true,
       });
 
-    var idx_counter: number = 0;
+    let idx_counter: number = 0;
     for await (const part of stream) {
       //TODO: LLM Stream Callback, pending re-work.
 
@@ -821,7 +824,7 @@ export class Portkey extends BaseLLM {
         };
 
     //Indices
-    var idx_counter: number = 0;
+    let idx_counter: number = 0;
     for await (const part of chunkStream) {
       //Increment
       part.choices[0].index = idx_counter;

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -1,8 +1,5 @@
-import Anthropic, {
-  AI_PROMPT,
-  ClientOptions,
-  HUMAN_PROMPT,
-} from "@anthropic-ai/sdk";
+import type { ClientOptions } from "@anthropic-ai/sdk";
+import Anthropic, { AI_PROMPT, HUMAN_PROMPT } from "@anthropic-ai/sdk";
 import _ from "lodash";
 
 export class AnthropicSession {

--- a/packages/core/src/llm/base.ts
+++ b/packages/core/src/llm/base.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ChatMessage,
   ChatResponse,
   ChatResponseChunk,

--- a/packages/core/src/llm/mistral.ts
+++ b/packages/core/src/llm/mistral.ts
@@ -1,11 +1,11 @@
-import {
+import type {
   CallbackManager,
   Event,
   EventType,
   StreamCallbackResponse,
 } from "../callbacks/CallbackManager.js";
 import { BaseLLM } from "./base.js";
-import {
+import type {
   ChatMessage,
   ChatResponse,
   ChatResponseChunk,
@@ -141,7 +141,7 @@ export class MistralAI extends BaseLLM {
         };
 
     //Indices
-    var idx_counter: number = 0;
+    let idx_counter: number = 0;
     for await (const part of chunkStream) {
       if (!part.choices.length) continue;
 

--- a/packages/core/src/llm/ollama.ts
+++ b/packages/core/src/llm/ollama.ts
@@ -1,7 +1,7 @@
 import { ok } from "@llamaindex/env";
-import { CallbackManager, Event } from "../callbacks/CallbackManager.js";
+import type { CallbackManager, Event } from "../callbacks/CallbackManager.js";
 import { BaseEmbedding } from "../embeddings/types.js";
-import {
+import type {
   ChatMessage,
   ChatResponse,
   ChatResponseChunk,

--- a/packages/core/src/llm/open_ai.ts
+++ b/packages/core/src/llm/open_ai.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
-import OpenAI, { ClientOptions } from "openai";
+import type { ClientOptions } from "openai";
+import OpenAI from "openai";
 
 export class AzureOpenAI extends OpenAI {
   protected override authHeaders() {

--- a/packages/core/src/llm/portkey.ts
+++ b/packages/core/src/llm/portkey.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
-import { LLMOptions, Portkey } from "portkey-ai";
+import type { LLMOptions } from "portkey-ai";
+import { Portkey } from "portkey-ai";
 
 export const readEnv = (
   env: string,

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -1,5 +1,5 @@
-import { Tokenizers } from "../GlobalsHelper.js";
-import { Event } from "../callbacks/CallbackManager.js";
+import type { Tokenizers } from "../GlobalsHelper.js";
+import type { Event } from "../callbacks/CallbackManager.js";
 
 /**
  * Unified language model interface
@@ -44,7 +44,7 @@ export type MessageType =
 
 export interface ChatMessage {
   // TODO: use MessageContent
-  content: any;
+  content: MessageContent;
   role: MessageType;
   additionalKwargs?: Record<string, any>;
 }

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -44,7 +44,7 @@ export type MessageType =
 
 export interface ChatMessage {
   // TODO: use MessageContent
-  content: MessageContent;
+  content: any;
   role: MessageType;
   additionalKwargs?: Record<string, any>;
 }

--- a/packages/core/src/llm/utils.ts
+++ b/packages/core/src/llm/utils.ts
@@ -1,4 +1,4 @@
-import { MessageContent, MessageContentDetail } from "./types.js";
+import type { MessageContent } from "./types.js";
 
 export async function* streamConverter<S, D>(
   stream: AsyncIterable<S>,
@@ -35,7 +35,7 @@ export function extractText(message: MessageContent): string {
   if (Array.isArray(message)) {
     // message is of type MessageContentDetail[] - retrieve just the text parts and concatenate them
     // so we can pass them to the context generator
-    return (message as MessageContentDetail[])
+    return message
       .filter((c) => c.type === "text")
       .map((c) => c.text)
       .join("\n\n");

--- a/packages/core/src/memory/ChatMemoryBuffer.ts
+++ b/packages/core/src/memory/ChatMemoryBuffer.ts
@@ -1,7 +1,7 @@
-import { ChatMessage } from "../llm/index.js";
+import type { ChatMessage } from "../llm/index.js";
 import { SimpleChatStore } from "../storage/chatStore/SimpleChatStore.js";
-import { BaseChatStore } from "../storage/chatStore/types.js";
-import { BaseMemory } from "./types.js";
+import type { BaseChatStore } from "../storage/chatStore/types.js";
+import type { BaseMemory } from "./types.js";
 
 type ChatMemoryBufferParams = {
   tokenLimit?: number;

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from "../llm/index.js";
+import type { ChatMessage } from "../llm/index.js";
 
 export interface BaseMemory {
   /*

--- a/packages/core/src/nodeParsers/MarkdownNodeParser.ts
+++ b/packages/core/src/nodeParsers/MarkdownNodeParser.ts
@@ -1,5 +1,6 @@
-import { BaseNode, Metadata, MetadataMode, TextNode } from "../Node.js";
-import { NodeParser } from "./types.js";
+import type { BaseNode, Metadata } from "../Node.js";
+import { MetadataMode, TextNode } from "../Node.js";
+import type { NodeParser } from "./types.js";
 
 export class MarkdownNodeParser implements NodeParser {
   includeMetadata: boolean;

--- a/packages/core/src/nodeParsers/SentenceWindowNodeParser.ts
+++ b/packages/core/src/nodeParsers/SentenceWindowNodeParser.ts
@@ -1,6 +1,6 @@
-import { BaseNode } from "../Node.js";
+import type { BaseNode } from "../Node.js";
 import { SentenceSplitter } from "../TextSplitter.js";
-import { NodeParser } from "./types.js";
+import type { NodeParser } from "./types.js";
 import { getNodesFromDocument } from "./utils.js";
 
 export const DEFAULT_WINDOW_SIZE = 3;

--- a/packages/core/src/nodeParsers/SimpleNodeParser.ts
+++ b/packages/core/src/nodeParsers/SimpleNodeParser.ts
@@ -1,7 +1,7 @@
-import { BaseNode } from "../Node.js";
+import type { BaseNode } from "../Node.js";
 import { SentenceSplitter } from "../TextSplitter.js";
 import { DEFAULT_CHUNK_OVERLAP, DEFAULT_CHUNK_SIZE } from "../constants.js";
-import { NodeParser } from "./types.js";
+import type { NodeParser } from "./types.js";
 import { getNodesFromDocument } from "./utils.js";
 
 /**

--- a/packages/core/src/nodeParsers/types.ts
+++ b/packages/core/src/nodeParsers/types.ts
@@ -1,5 +1,5 @@
-import { BaseNode } from "../Node.js";
-import { TransformComponent } from "../ingestion/types.js";
+import type { BaseNode } from "../Node.js";
+import type { TransformComponent } from "../ingestion/types.js";
 
 /**
  * A NodeParser generates Nodes from Documents

--- a/packages/core/src/nodeParsers/utils.ts
+++ b/packages/core/src/nodeParsers/utils.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
+import type { BaseNode } from "../Node.js";
 import {
-  BaseNode,
   Document,
   ImageDocument,
   NodeRelationship,

--- a/packages/core/src/objects/base.ts
+++ b/packages/core/src/objects/base.ts
@@ -1,7 +1,8 @@
-import { BaseNode, Metadata, TextNode } from "../Node.js";
-import { BaseRetriever } from "../Retriever.js";
-import { VectorStoreIndex } from "../indices/index.js";
-import { BaseTool } from "../types.js";
+import type { BaseNode, Metadata } from "../Node.js";
+import { TextNode } from "../Node.js";
+import type { BaseRetriever } from "../Retriever.js";
+import type { VectorStoreIndex } from "../indices/index.js";
+import type { BaseTool } from "../types.js";
 
 // Assuming that necessary interfaces and classes (like OT, TextNode, BaseNode, etc.) are defined elsewhere
 // Import statements (e.g., for TextNode, BaseNode) should be added based on your project's structure

--- a/packages/core/src/outputParsers/selectors.ts
+++ b/packages/core/src/outputParsers/selectors.ts
@@ -1,5 +1,5 @@
 import { parseJsonMarkdown } from "../OutputParser.js";
-import { BaseOutputParser, StructuredOutput } from "../types.js";
+import type { BaseOutputParser, StructuredOutput } from "../types.js";
 
 export type Answer = {
   choice: number;

--- a/packages/core/src/postprocessors/MetadataReplacementPostProcessor.ts
+++ b/packages/core/src/postprocessors/MetadataReplacementPostProcessor.ts
@@ -1,5 +1,6 @@
-import { MetadataMode, NodeWithScore } from "../Node.js";
-import { BaseNodePostprocessor } from "./types.js";
+import type { NodeWithScore } from "../Node.js";
+import { MetadataMode } from "../Node.js";
+import type { BaseNodePostprocessor } from "./types.js";
 
 export class MetadataReplacementPostProcessor implements BaseNodePostprocessor {
   targetMetadataKey: string;

--- a/packages/core/src/postprocessors/SimilarityPostprocessor.ts
+++ b/packages/core/src/postprocessors/SimilarityPostprocessor.ts
@@ -1,5 +1,5 @@
-import { NodeWithScore } from "../Node.js";
-import { BaseNodePostprocessor } from "./types.js";
+import type { NodeWithScore } from "../Node.js";
+import type { BaseNodePostprocessor } from "./types.js";
 
 export class SimilarityPostprocessor implements BaseNodePostprocessor {
   similarityCutoff?: number;

--- a/packages/core/src/postprocessors/rerankers/CohereRerank.ts
+++ b/packages/core/src/postprocessors/rerankers/CohereRerank.ts
@@ -1,7 +1,8 @@
 import { CohereClient } from "cohere-ai";
 
-import { MetadataMode, NodeWithScore } from "../../Node.js";
-import { BaseNodePostprocessor } from "../types.js";
+import type { NodeWithScore } from "../../Node.js";
+import { MetadataMode } from "../../Node.js";
+import type { BaseNodePostprocessor } from "../types.js";
 
 type CohereRerankOptions = {
   topN?: number;

--- a/packages/core/src/postprocessors/types.ts
+++ b/packages/core/src/postprocessors/types.ts
@@ -1,4 +1,4 @@
-import { NodeWithScore } from "../Node.js";
+import type { NodeWithScore } from "../Node.js";
 
 export interface BaseNodePostprocessor {
   /**

--- a/packages/core/src/readers/AssemblyAIReader.ts
+++ b/packages/core/src/readers/AssemblyAIReader.ts
@@ -1,13 +1,13 @@
-import {
-  AssemblyAI,
+import type {
   BaseServiceParams,
   SubtitleFormat,
   TranscribeParams,
   TranscriptParagraph,
   TranscriptSentence,
 } from "assemblyai";
+import { AssemblyAI } from "assemblyai";
 import { Document } from "../Node.js";
-import { BaseReader } from "./type.js";
+import type { BaseReader } from "./type.js";
 
 type AssemblyAIOptions = Partial<BaseServiceParams>;
 

--- a/packages/core/src/readers/CSVReader.ts
+++ b/packages/core/src/readers/CSVReader.ts
@@ -1,8 +1,9 @@
 import { defaultFS } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
-import Papa, { ParseConfig } from "papaparse";
+import type { GenericFileSystem } from "@llamaindex/env/type";
+import type { ParseConfig } from "papaparse";
+import Papa from "papaparse";
 import { Document } from "../Node.js";
-import { FileReader } from "./type.js";
+import type { FileReader } from "./type.js";
 
 /**
  * papaparse-based csv parser

--- a/packages/core/src/readers/DocxReader.ts
+++ b/packages/core/src/readers/DocxReader.ts
@@ -1,8 +1,8 @@
 import { defaultFS } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import mammoth from "mammoth";
 import { Document } from "../Node.js";
-import { FileReader } from "./type.js";
+import type { FileReader } from "./type.js";
 
 export class DocxReader implements FileReader {
   /** DocxParser */

--- a/packages/core/src/readers/HTMLReader.ts
+++ b/packages/core/src/readers/HTMLReader.ts
@@ -1,7 +1,7 @@
 import { defaultFS } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import { Document } from "../Node.js";
-import { FileReader } from "./type.js";
+import type { FileReader } from "./type.js";
 
 /**
  * Extract the significant text from an arbitrary HTML document.

--- a/packages/core/src/readers/ImageReader.ts
+++ b/packages/core/src/readers/ImageReader.ts
@@ -1,7 +1,8 @@
 import { defaultFS } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
-import { Document, ImageDocument } from "../Node.js";
-import { FileReader } from "./type.js";
+import type { GenericFileSystem } from "@llamaindex/env/type";
+import type { Document } from "../Node.js";
+import { ImageDocument } from "../Node.js";
+import type { FileReader } from "./type.js";
 
 /**
  * Reads the content of an image file into a Document object (which stores the image file as a Blob).

--- a/packages/core/src/readers/LlamaParseReader.ts
+++ b/packages/core/src/readers/LlamaParseReader.ts
@@ -1,7 +1,7 @@
 import { defaultFS } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import { Document } from "../Node.js";
-import { FileReader } from "./type.js";
+import type { FileReader } from "./type.js";
 
 type ResultType = "text" | "markdown";
 

--- a/packages/core/src/readers/MarkdownReader.ts
+++ b/packages/core/src/readers/MarkdownReader.ts
@@ -1,7 +1,7 @@
 import { defaultFS } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import { Document } from "../Node.js";
-import { FileReader } from "./type.js";
+import type { FileReader } from "./type.js";
 
 type MarkdownTuple = [string | null, string];
 

--- a/packages/core/src/readers/NotionReader.ts
+++ b/packages/core/src/readers/NotionReader.ts
@@ -1,7 +1,8 @@
-import { Client } from "@notionhq/client";
-import { crawler, Crawler, Pages, pageToString } from "notion-md-crawler";
+import type { Client } from "@notionhq/client";
+import type { Crawler, Pages } from "notion-md-crawler";
+import { crawler, pageToString } from "notion-md-crawler";
 import { Document } from "../Node.js";
-import { BaseReader } from "./type.js";
+import type { BaseReader } from "./type.js";
 
 type OptionalSerializers = Parameters<Crawler>[number]["serializers"];
 

--- a/packages/core/src/readers/PDFReader.ts
+++ b/packages/core/src/readers/PDFReader.ts
@@ -1,7 +1,7 @@
 import { createSHA256, defaultFS } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import { Document } from "../Node.js";
-import { BaseReader } from "./type.js";
+import type { BaseReader } from "./type.js";
 
 /**
  * Read the text of a PDF

--- a/packages/core/src/readers/SimpleDirectoryReader.ts
+++ b/packages/core/src/readers/SimpleDirectoryReader.ts
@@ -1,5 +1,5 @@
 import { defaultFS, path } from "@llamaindex/env";
-import { CompleteFileSystem } from "@llamaindex/env/type";
+import type { CompleteFileSystem } from "@llamaindex/env/type";
 import { Document } from "../Node.js";
 import { walk } from "../storage/FileSystem.js";
 import { PapaCSVReader } from "./CSVReader.js";
@@ -8,7 +8,7 @@ import { HTMLReader } from "./HTMLReader.js";
 import { ImageReader } from "./ImageReader.js";
 import { MarkdownReader } from "./MarkdownReader.js";
 import { PDFReader } from "./PDFReader.js";
-import { BaseReader } from "./type.js";
+import type { BaseReader } from "./type.js";
 
 type ReaderCallback = (
   category: "file" | "directory",

--- a/packages/core/src/readers/SimpleMongoReader.ts
+++ b/packages/core/src/readers/SimpleMongoReader.ts
@@ -1,6 +1,7 @@
-import { MongoClient } from "mongodb";
-import { Document, Metadata } from "../Node.js";
-import { BaseReader } from "./type.js";
+import type { MongoClient } from "mongodb";
+import type { Metadata } from "../Node.js";
+import { Document } from "../Node.js";
+import type { BaseReader } from "./type.js";
 
 /**
  * Read in from MongoDB

--- a/packages/core/src/readers/type.ts
+++ b/packages/core/src/readers/type.ts
@@ -1,5 +1,5 @@
-import { CompleteFileSystem } from "@llamaindex/env/type";
-import { Document } from "../Node.js";
+import type { CompleteFileSystem } from "@llamaindex/env/type";
+import type { Document } from "../Node.js";
 
 /**
  * A reader takes imports data into Document objects.

--- a/packages/core/src/selectors/base.ts
+++ b/packages/core/src/selectors/base.ts
@@ -1,5 +1,5 @@
 import { PromptMixin } from "../prompts/Mixin.js";
-import { QueryBundle, ToolMetadataOnlyDescription } from "../types.js";
+import type { QueryBundle, ToolMetadataOnlyDescription } from "../types.js";
 
 export interface SingleSelection {
   index: number;

--- a/packages/core/src/selectors/llmSelectors.ts
+++ b/packages/core/src/selectors/llmSelectors.ts
@@ -1,15 +1,16 @@
-import { LLM } from "../llm/index.js";
-import { Answer, SelectionOutputParser } from "../outputParsers/selectors.js";
-import {
+import type { LLM } from "../llm/index.js";
+import type { Answer } from "../outputParsers/selectors.js";
+import { SelectionOutputParser } from "../outputParsers/selectors.js";
+import type {
   BaseOutputParser,
   QueryBundle,
   StructuredOutput,
   ToolMetadataOnlyDescription,
 } from "../types.js";
-import { BaseSelector, SelectorResult } from "./base.js";
+import type { SelectorResult } from "./base.js";
+import { BaseSelector } from "./base.js";
+import type { MultiSelectPrompt, SingleSelectPrompt } from "./prompts.js";
 import {
-  MultiSelectPrompt,
-  SingleSelectPrompt,
   defaultMultiSelectPrompt,
   defaultSingleSelectPrompt,
 } from "./prompts.js";

--- a/packages/core/src/selectors/utils.ts
+++ b/packages/core/src/selectors/utils.ts
@@ -1,5 +1,5 @@
-import { ServiceContext } from "../ServiceContext.js";
-import { BaseSelector } from "./base.js";
+import type { ServiceContext } from "../ServiceContext.js";
+import type { BaseSelector } from "./base.js";
 import { LLMMultiSelector, LLMSingleSelector } from "./llmSelectors.js";
 
 export const getSelectorFromContext = (

--- a/packages/core/src/storage/FileSystem.ts
+++ b/packages/core/src/storage/FileSystem.ts
@@ -1,4 +1,7 @@
-import { GenericFileSystem, WalkableFileSystem } from "@llamaindex/env/type";
+import type {
+  GenericFileSystem,
+  WalkableFileSystem,
+} from "@llamaindex/env/type";
 // FS utility functions
 
 /**

--- a/packages/core/src/storage/StorageContext.ts
+++ b/packages/core/src/storage/StorageContext.ts
@@ -1,15 +1,15 @@
 import { defaultFS, path } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import {
   DEFAULT_IMAGE_VECTOR_NAMESPACE,
   DEFAULT_NAMESPACE,
 } from "./constants.js";
 import { SimpleDocumentStore } from "./docStore/SimpleDocumentStore.js";
-import { BaseDocumentStore } from "./docStore/types.js";
+import type { BaseDocumentStore } from "./docStore/types.js";
 import { SimpleIndexStore } from "./indexStore/SimpleIndexStore.js";
-import { BaseIndexStore } from "./indexStore/types.js";
+import type { BaseIndexStore } from "./indexStore/types.js";
 import { SimpleVectorStore } from "./vectorStore/SimpleVectorStore.js";
-import { VectorStore } from "./vectorStore/types.js";
+import type { VectorStore } from "./vectorStore/types.js";
 
 export interface StorageContext {
   docStore: BaseDocumentStore;

--- a/packages/core/src/storage/chatStore/SimpleChatStore.ts
+++ b/packages/core/src/storage/chatStore/SimpleChatStore.ts
@@ -1,5 +1,5 @@
-import { ChatMessage } from "../../llm/index.js";
-import { BaseChatStore } from "./types.js";
+import type { ChatMessage } from "../../llm/index.js";
+import type { BaseChatStore } from "./types.js";
 
 /**
  * Simple chat store.

--- a/packages/core/src/storage/chatStore/types.ts
+++ b/packages/core/src/storage/chatStore/types.ts
@@ -1,4 +1,4 @@
-import { ChatMessage } from "../../llm/index.js";
+import type { ChatMessage } from "../../llm/index.js";
 
 export interface BaseChatStore {
   setMessages(key: string, messages: ChatMessage[]): void;

--- a/packages/core/src/storage/docStore/KVDocumentStore.ts
+++ b/packages/core/src/storage/docStore/KVDocumentStore.ts
@@ -1,8 +1,10 @@
 import _, * as lodash from "lodash";
-import { BaseNode, ObjectType } from "../../Node.js";
+import type { BaseNode } from "../../Node.js";
+import { ObjectType } from "../../Node.js";
 import { DEFAULT_NAMESPACE } from "../constants.js";
-import { BaseKVStore } from "../kvStore/types.js";
-import { BaseDocumentStore, RefDocInfo } from "./types.js";
+import type { BaseKVStore } from "../kvStore/types.js";
+import type { RefDocInfo } from "./types.js";
+import { BaseDocumentStore } from "./types.js";
 import { docToJson, jsonToDoc } from "./utils.js";
 
 type DocMetaData = { docHash: string; refDocId?: string };
@@ -34,7 +36,7 @@ export class KVDocumentStore extends BaseDocumentStore {
     docs: BaseNode[],
     allowUpdate: boolean = true,
   ): Promise<void> {
-    for (var idx = 0; idx < docs.length; idx++) {
+    for (let idx = 0; idx < docs.length; idx++) {
       const doc = docs[idx];
       if (doc.id_ === null) {
         throw new Error("doc_id not set");

--- a/packages/core/src/storage/docStore/SimpleDocumentStore.ts
+++ b/packages/core/src/storage/docStore/SimpleDocumentStore.ts
@@ -1,5 +1,5 @@
 import { defaultFS, path } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import _ from "lodash";
 import {
   DEFAULT_DOC_STORE_PERSIST_FILENAME,

--- a/packages/core/src/storage/docStore/types.ts
+++ b/packages/core/src/storage/docStore/types.ts
@@ -1,4 +1,4 @@
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import { BaseNode } from "../../Node.js";
 import {
   DEFAULT_DOC_STORE_PERSIST_FILENAME,

--- a/packages/core/src/storage/docStore/utils.ts
+++ b/packages/core/src/storage/docStore/utils.ts
@@ -1,4 +1,5 @@
-import { BaseNode, Document, ObjectType, TextNode } from "../../Node.js";
+import type { BaseNode } from "../../Node.js";
+import { Document, ObjectType, TextNode } from "../../Node.js";
 
 const TYPE_KEY = "__type__";
 const DATA_KEY = "__data__";

--- a/packages/core/src/storage/indexStore/KVIndexStore.ts
+++ b/packages/core/src/storage/indexStore/KVIndexStore.ts
@@ -1,8 +1,8 @@
 import _ from "lodash";
-import { IndexStruct } from "../../indices/IndexStruct.js";
+import type { IndexStruct } from "../../indices/IndexStruct.js";
 import { jsonToIndexStruct } from "../../indices/json-to-index-struct.js";
 import { DEFAULT_NAMESPACE } from "../constants.js";
-import { BaseKVStore } from "../kvStore/types.js";
+import type { BaseKVStore } from "../kvStore/types.js";
 import { BaseIndexStore } from "./types.js";
 
 export class KVIndexStore extends BaseIndexStore {

--- a/packages/core/src/storage/indexStore/SimpleIndexStore.ts
+++ b/packages/core/src/storage/indexStore/SimpleIndexStore.ts
@@ -1,11 +1,12 @@
 import { defaultFS, path } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import {
   DEFAULT_INDEX_STORE_PERSIST_FILENAME,
   DEFAULT_PERSIST_DIR,
 } from "../constants.js";
-import { DataType, SimpleKVStore } from "../kvStore/SimpleKVStore.js";
-import { BaseInMemoryKVStore } from "../kvStore/types.js";
+import type { DataType } from "../kvStore/SimpleKVStore.js";
+import { SimpleKVStore } from "../kvStore/SimpleKVStore.js";
+import type { BaseInMemoryKVStore } from "../kvStore/types.js";
 import { KVIndexStore } from "./KVIndexStore.js";
 
 export class SimpleIndexStore extends KVIndexStore {

--- a/packages/core/src/storage/indexStore/types.ts
+++ b/packages/core/src/storage/indexStore/types.ts
@@ -1,5 +1,5 @@
-import { GenericFileSystem } from "@llamaindex/env/type";
-import { IndexStruct } from "../../indices/IndexStruct.js";
+import type { GenericFileSystem } from "@llamaindex/env/type";
+import type { IndexStruct } from "../../indices/IndexStruct.js";
 import {
   DEFAULT_INDEX_STORE_PERSIST_FILENAME,
   DEFAULT_PERSIST_DIR,

--- a/packages/core/src/storage/kvStore/SimpleKVStore.ts
+++ b/packages/core/src/storage/kvStore/SimpleKVStore.ts
@@ -1,5 +1,5 @@
 import { defaultFS, path } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import _ from "lodash";
 import { exists } from "../FileSystem.js";
 import { DEFAULT_COLLECTION } from "../constants.js";

--- a/packages/core/src/storage/kvStore/types.ts
+++ b/packages/core/src/storage/kvStore/types.ts
@@ -1,4 +1,4 @@
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 const defaultCollection = "data";
 
 type StoredValue = Record<string, any> | null;

--- a/packages/core/src/storage/vectorStore/AstraDBVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/AstraDBVectorStore.ts
@@ -1,7 +1,8 @@
 import { AstraDB } from "@datastax/astra-db-ts";
-import { Collection } from "@datastax/astra-db-ts/dist/collections";
-import { BaseNode, MetadataMode } from "../../Node.js";
-import {
+import type { Collection } from "@datastax/astra-db-ts/dist/collections";
+import type { BaseNode } from "../../Node.js";
+import { MetadataMode } from "../../Node.js";
+import type {
   VectorStore,
   VectorStoreQuery,
   VectorStoreQueryResult,

--- a/packages/core/src/storage/vectorStore/ChromaVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/ChromaVectorStore.ts
@@ -1,20 +1,20 @@
-import {
+import type {
   AddParams,
-  ChromaClient,
   ChromaClientParams,
   Collection,
-  IncludeEnum,
   QueryResponse,
   Where,
   WhereDocument,
 } from "chromadb";
-import { BaseNode, MetadataMode } from "../../Node.js";
-import {
+import { ChromaClient, IncludeEnum } from "chromadb";
+import type { BaseNode } from "../../Node.js";
+import { MetadataMode } from "../../Node.js";
+import type {
   VectorStore,
   VectorStoreQuery,
-  VectorStoreQueryMode,
   VectorStoreQueryResult,
 } from "./types.js";
+import { VectorStoreQueryMode } from "./types.js";
 import { metadataDictToNode, nodeToMetadata } from "./utils.js";
 
 type ChromaDeleteOptions = {

--- a/packages/core/src/storage/vectorStore/MongoDBAtlasVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/MongoDBAtlasVectorStore.ts
@@ -1,6 +1,8 @@
-import { BulkWriteOptions, Collection, MongoClient } from "mongodb";
-import { BaseNode, MetadataMode } from "../../Node.js";
-import {
+import type { BulkWriteOptions, Collection } from "mongodb";
+import { MongoClient } from "mongodb";
+import type { BaseNode } from "../../Node.js";
+import { MetadataMode } from "../../Node.js";
+import type {
   MetadataFilters,
   VectorStore,
   VectorStoreQuery,

--- a/packages/core/src/storage/vectorStore/PGVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/PGVectorStore.ts
@@ -1,14 +1,15 @@
 import pg from "pg";
 import pgvector from "pgvector/pg";
 
-import {
+import type {
   VectorStore,
   VectorStoreQuery,
   VectorStoreQueryResult,
 } from "./types.js";
 
-import { GenericFileSystem } from "@llamaindex/env/type";
-import { BaseNode, Document, Metadata, MetadataMode } from "../../Node.js";
+import type { GenericFileSystem } from "@llamaindex/env/type";
+import type { BaseNode, Metadata } from "../../Node.js";
+import { Document, MetadataMode } from "../../Node.js";
 
 export const PGVECTOR_SCHEMA = "public";
 export const PGVECTOR_TABLE = "llamaindex_embedding";
@@ -147,7 +148,7 @@ export class PGVectorStore implements VectorStore {
     const sql: string = `DELETE FROM ${this.schemaName}.${this.tableName}
                          WHERE collection = $1`;
 
-    const db = (await this.getDb()) as pg.Client;
+    const db = await this.getDb();
     const ret = await db.query(sql, [this.collection]);
 
     return ret;
@@ -192,7 +193,7 @@ export class PGVectorStore implements VectorStore {
                            (id, external_id, collection, document, metadata, embeddings)
                          VALUES ($1, $2, $3, $4, $5, $6)`;
 
-    const db = (await this.getDb()) as pg.Client;
+    const db = await this.getDb();
     const data = this.getDataToInsert(embeddingResults);
 
     const ret: string[] = [];
@@ -227,7 +228,7 @@ export class PGVectorStore implements VectorStore {
     const sql: string = `DELETE FROM ${this.schemaName}.${this.tableName}
                          WHERE id = $1 ${collectionCriteria}`;
 
-    const db = (await this.getDb()) as pg.Client;
+    const db = await this.getDb();
     const params = this.collection.length
       ? [refDocId, this.collection]
       : [refDocId];
@@ -276,7 +277,7 @@ export class PGVectorStore implements VectorStore {
       LIMIT ${max}
     `;
 
-    const db = (await this.getDb()) as pg.Client;
+    const db = await this.getDb();
     const results = await db.query(sql, params);
 
     const nodes = results.rows.map((row) => {

--- a/packages/core/src/storage/vectorStore/PineconeVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/PineconeVectorStore.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ExactMatchFilter,
   MetadataFilters,
   VectorStore,
@@ -6,14 +6,14 @@ import {
   VectorStoreQueryResult,
 } from "./types.js";
 
-import { GenericFileSystem } from "@llamaindex/env/type";
-import {
+import type { GenericFileSystem } from "@llamaindex/env/type";
+import type {
   FetchResponse,
   Index,
-  Pinecone,
   ScoredPineconeRecord,
 } from "@pinecone-database/pinecone";
-import { BaseNode, Metadata } from "../../Node.js";
+import { Pinecone } from "@pinecone-database/pinecone";
+import type { BaseNode, Metadata } from "../../Node.js";
 import { metadataDictToNode, nodeToMetadata } from "./utils.js";
 
 type PineconeParams = {

--- a/packages/core/src/storage/vectorStore/QdrantVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/QdrantVectorStore.ts
@@ -1,5 +1,5 @@
-import { BaseNode } from "../../Node.js";
-import {
+import type { BaseNode } from "../../Node.js";
+import type {
   VectorStore,
   VectorStoreQuery,
   VectorStoreQueryResult,

--- a/packages/core/src/storage/vectorStore/SimpleVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/SimpleVectorStore.ts
@@ -1,7 +1,7 @@
 import { defaultFS, path } from "@llamaindex/env";
-import { GenericFileSystem } from "@llamaindex/env/type";
+import type { GenericFileSystem } from "@llamaindex/env/type";
 import _ from "lodash";
-import { BaseNode } from "../../Node.js";
+import type { BaseNode } from "../../Node.js";
 import {
   getTopKEmbeddings,
   getTopKEmbeddingsLearner,
@@ -9,12 +9,12 @@ import {
 } from "../../embeddings/utils.js";
 import { exists } from "../FileSystem.js";
 import { DEFAULT_PERSIST_DIR } from "../constants.js";
-import {
+import type {
   VectorStore,
   VectorStoreQuery,
-  VectorStoreQueryMode,
   VectorStoreQueryResult,
 } from "./types.js";
+import { VectorStoreQueryMode } from "./types.js";
 
 const LEARNER_MODES = new Set<VectorStoreQueryMode>([
   VectorStoreQueryMode.SVM,

--- a/packages/core/src/storage/vectorStore/types.ts
+++ b/packages/core/src/storage/vectorStore/types.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from "../../Node.js";
+import type { BaseNode } from "../../Node.js";
 
 export interface VectorStoreQueryResult {
   nodes?: BaseNode[];

--- a/packages/core/src/storage/vectorStore/utils.ts
+++ b/packages/core/src/storage/vectorStore/utils.ts
@@ -1,4 +1,5 @@
-import { BaseNode, jsonToNode, Metadata, ObjectType } from "../../Node.js";
+import type { BaseNode, Metadata } from "../../Node.js";
+import { ObjectType, jsonToNode } from "../../Node.js";
 
 const DEFAULT_TEXT_KEY = "text";
 

--- a/packages/core/src/synthesizers/MultiModalResponseSynthesizer.ts
+++ b/packages/core/src/synthesizers/MultiModalResponseSynthesizer.ts
@@ -1,14 +1,14 @@
-import { ImageNode, MetadataMode, splitNodesByType } from "../Node.js";
+import type { ImageNode } from "../Node.js";
+import { MetadataMode, splitNodesByType } from "../Node.js";
 import { Response } from "../Response.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../ServiceContext.js";
+import type { ServiceContext } from "../ServiceContext.js";
+import { serviceContextFromDefaults } from "../ServiceContext.js";
 import { imageToDataUrl } from "../embeddings/index.js";
-import { MessageContentDetail } from "../llm/types.js";
+import type { MessageContentDetail } from "../llm/types.js";
 import { PromptMixin } from "../prompts/Mixin.js";
-import { TextQaPrompt, defaultTextQaPrompt } from "./../Prompt.js";
-import {
+import type { TextQaPrompt } from "./../Prompt.js";
+import { defaultTextQaPrompt } from "./../Prompt.js";
+import type {
   BaseSynthesizer,
   SynthesizeParamsNonStreaming,
   SynthesizeParamsStreaming,

--- a/packages/core/src/synthesizers/ResponseSynthesizer.ts
+++ b/packages/core/src/synthesizers/ResponseSynthesizer.ts
@@ -1,13 +1,12 @@
 import { MetadataMode } from "../Node.js";
 import { Response } from "../Response.js";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "../ServiceContext.js";
+import type { ServiceContext } from "../ServiceContext.js";
+import { serviceContextFromDefaults } from "../ServiceContext.js";
 import { streamConverter } from "../llm/utils.js";
 import { PromptMixin } from "../prompts/Mixin.js";
-import { ResponseBuilderPrompts, getResponseBuilder } from "./builders.js";
-import {
+import type { ResponseBuilderPrompts } from "./builders.js";
+import { getResponseBuilder } from "./builders.js";
+import type {
   BaseSynthesizer,
   ResponseBuilder,
   SynthesizeParamsNonStreaming,

--- a/packages/core/src/synthesizers/builders.ts
+++ b/packages/core/src/synthesizers/builders.ts
@@ -1,19 +1,22 @@
-import { Event } from "../callbacks/CallbackManager.js";
-import { LLM } from "../llm/index.js";
+import type { Event } from "../callbacks/CallbackManager.js";
+import type { LLM } from "../llm/index.js";
 import { streamConverter } from "../llm/utils.js";
-import {
-  defaultRefinePrompt,
-  defaultTextQaPrompt,
-  defaultTreeSummarizePrompt,
+import type {
   RefinePrompt,
   SimplePrompt,
   TextQaPrompt,
   TreeSummarizePrompt,
 } from "../Prompt.js";
-import { getBiggestPrompt, PromptHelper } from "../PromptHelper.js";
-import { PromptMixin } from "../prompts/Mixin.js";
-import { ServiceContext } from "../ServiceContext.js";
 import {
+  defaultRefinePrompt,
+  defaultTextQaPrompt,
+  defaultTreeSummarizePrompt,
+} from "../Prompt.js";
+import type { PromptHelper } from "../PromptHelper.js";
+import { getBiggestPrompt } from "../PromptHelper.js";
+import { PromptMixin } from "../prompts/Mixin.js";
+import type { ServiceContext } from "../ServiceContext.js";
+import type {
   ResponseBuilder,
   ResponseBuilderParamsNonStreaming,
   ResponseBuilderParamsStreaming,

--- a/packages/core/src/synthesizers/types.ts
+++ b/packages/core/src/synthesizers/types.ts
@@ -1,7 +1,7 @@
-import { Event } from "../callbacks/CallbackManager.js";
-import { NodeWithScore } from "../Node.js";
-import { PromptMixin } from "../prompts/Mixin.js";
-import { Response } from "../Response.js";
+import type { Event } from "../callbacks/CallbackManager.js";
+import type { NodeWithScore } from "../Node.js";
+import type { PromptMixin } from "../prompts/Mixin.js";
+import type { Response } from "../Response.js";
 
 export interface SynthesizeParamsBase {
   query: string;

--- a/packages/core/src/tools/QueryEngineTool.ts
+++ b/packages/core/src/tools/QueryEngineTool.ts
@@ -1,4 +1,4 @@
-import { BaseQueryEngine, BaseTool, ToolMetadata } from "../types.js";
+import type { BaseQueryEngine, BaseTool, ToolMetadata } from "../types.js";
 
 export type QueryEngineToolParams = {
   queryEngine: BaseQueryEngine;

--- a/packages/core/src/tools/functionTool.ts
+++ b/packages/core/src/tools/functionTool.ts
@@ -1,4 +1,4 @@
-import { BaseTool, ToolMetadata } from "../types.js";
+import type { BaseTool, ToolMetadata } from "../types.js";
 
 type Metadata = {
   name: string;

--- a/packages/core/src/tools/utils.ts
+++ b/packages/core/src/tools/utils.ts
@@ -1,4 +1,4 @@
-import { BaseTool } from "../types.js";
+import type { BaseTool } from "../types.js";
 import { ToolOutput } from "./types.js";
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,8 +1,8 @@
 /**
  * Top level types to avoid circular dependencies
  */
-import { Event } from "./callbacks/CallbackManager.js";
-import { Response } from "./Response.js";
+import type { Event } from "./callbacks/CallbackManager.js";
+import type { Response } from "./Response.js";
 
 /**
  * Parameters for sending a query.

--- a/packages/core/tests/CallbackManager.test.ts
+++ b/packages/core/tests/CallbackManager.test.ts
@@ -9,15 +9,13 @@ import {
 } from "vitest";
 
 import { Document } from "llamaindex/Node";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "llamaindex/ServiceContext";
-import {
-  CallbackManager,
+import type { ServiceContext } from "llamaindex/ServiceContext";
+import { serviceContextFromDefaults } from "llamaindex/ServiceContext";
+import type {
   RetrievalCallbackResponse,
   StreamCallbackResponse,
 } from "llamaindex/callbacks/CallbackManager";
+import { CallbackManager } from "llamaindex/callbacks/CallbackManager";
 import { OpenAIEmbedding } from "llamaindex/embeddings/index";
 import { SummaryIndex } from "llamaindex/indices/summary/index";
 import { VectorStoreIndex } from "llamaindex/indices/vectorStore/index";

--- a/packages/core/tests/MetadataExtractors.test.ts
+++ b/packages/core/tests/MetadataExtractors.test.ts
@@ -1,13 +1,11 @@
 import { Document } from "llamaindex/Node";
-import {
-  ServiceContext,
-  serviceContextFromDefaults,
-} from "llamaindex/ServiceContext";
-import {
-  CallbackManager,
+import type { ServiceContext } from "llamaindex/ServiceContext";
+import { serviceContextFromDefaults } from "llamaindex/ServiceContext";
+import type {
   RetrievalCallbackResponse,
   StreamCallbackResponse,
 } from "llamaindex/callbacks/CallbackManager";
+import { CallbackManager } from "llamaindex/callbacks/CallbackManager";
 import { OpenAIEmbedding } from "llamaindex/embeddings/index";
 import {
   KeywordExtractor,

--- a/packages/core/tests/ingestion/IngestionCache.test.ts
+++ b/packages/core/tests/ingestion/IngestionCache.test.ts
@@ -1,9 +1,10 @@
-import { BaseNode, TextNode } from "llamaindex/Node";
+import type { BaseNode } from "llamaindex/Node";
+import { TextNode } from "llamaindex/Node";
 import {
   IngestionCache,
   getTransformationHash,
 } from "llamaindex/ingestion/IngestionCache";
-import { TransformComponent } from "llamaindex/ingestion/index";
+import type { TransformComponent } from "llamaindex/ingestion/index";
 import { SimpleNodeParser } from "llamaindex/nodeParsers/index";
 import { beforeAll, describe, expect, test } from "vitest";
 

--- a/packages/core/tests/mocks/TestableQdrantVectorStore.ts
+++ b/packages/core/tests/mocks/TestableQdrantVectorStore.ts
@@ -1,4 +1,4 @@
-import { BaseNode } from "llamaindex/Node";
+import type { BaseNode } from "llamaindex/Node";
 import { QdrantVectorStore } from "llamaindex/storage/index";
 
 export class TestableQdrantVectorStore extends QdrantVectorStore {

--- a/packages/core/tests/objects/ObjectIndex.test.ts
+++ b/packages/core/tests/objects/ObjectIndex.test.ts
@@ -1,9 +1,9 @@
+import type { ServiceContext } from "llamaindex";
 import {
   FunctionTool,
   ObjectIndex,
   OpenAI,
   OpenAIEmbedding,
-  ServiceContext,
   SimpleToolNodeMapping,
   VectorStoreIndex,
   serviceContextFromDefaults,

--- a/packages/core/tests/postprocessors/MetadataReplacementPostProcessor.test.ts
+++ b/packages/core/tests/postprocessors/MetadataReplacementPostProcessor.test.ts
@@ -1,4 +1,5 @@
-import { MetadataMode, NodeWithScore, TextNode } from "llamaindex/Node";
+import type { NodeWithScore } from "llamaindex/Node";
+import { MetadataMode, TextNode } from "llamaindex/Node";
 import { MetadataReplacementPostProcessor } from "llamaindex/postprocessors/index";
 import { beforeEach, describe, expect, test } from "vitest";
 

--- a/packages/core/tests/utility/mockOpenAI.ts
+++ b/packages/core/tests/utility/mockOpenAI.ts
@@ -1,8 +1,8 @@
 import { globalsHelper } from "llamaindex/GlobalsHelper";
-import { CallbackManager } from "llamaindex/callbacks/CallbackManager";
-import { OpenAIEmbedding } from "llamaindex/embeddings/index";
-import { OpenAI } from "llamaindex/llm/LLM";
-import { LLMChatParamsBase } from "llamaindex/llm/types";
+import type { CallbackManager } from "llamaindex/callbacks/CallbackManager";
+import type { OpenAIEmbedding } from "llamaindex/embeddings/index";
+import type { OpenAI } from "llamaindex/llm/LLM";
+import type { LLMChatParamsBase } from "llamaindex/llm/types";
 import { vi } from "vitest";
 
 export const DEFAULT_LLM_TEXT_OUTPUT = "MOCK_TOKEN_1-MOCK_TOKEN_2";

--- a/packages/core/tests/vectorStores/QdrantVectorStore.test.ts
+++ b/packages/core/tests/vectorStores/QdrantVectorStore.test.ts
@@ -1,5 +1,7 @@
-import { BaseNode, TextNode } from "llamaindex/Node";
-import { Mocked, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BaseNode } from "llamaindex/Node";
+import { TextNode } from "llamaindex/Node";
+import type { Mocked } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { QdrantClient } from "@qdrant/js-client-rest";
 import { VectorStoreQueryMode } from "llamaindex/storage/index";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,16 +1,13 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/type",
-    "declaration": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+    "emitDeclarationOnly": true,
     "module": "node16",
     "moduleResolution": "node16",
     "skipLibCheck": true,
-    "strict": true,
-    "lib": ["ESNext", "dom"],
-    "target": "ESNext"
+    "strict": true
   },
   "include": ["./src"],
   "exclude": ["node_modules"]

--- a/packages/env/src/index.polyfill.ts
+++ b/packages/env/src/index.polyfill.ts
@@ -1,6 +1,6 @@
 import { Sha256 } from "@aws-crypto/sha256-js";
 import pathe from "pathe";
-import { CompleteFileSystem, InMemoryFileSystem } from "./type.js";
+import { InMemoryFileSystem, type CompleteFileSystem } from "./type.js";
 
 export { pathe as path };
 

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,17 +1,12 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/type",
-    "declaration": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
+    "emitDeclarationOnly": true,
     "module": "node16",
     "moduleResolution": "node16",
-    "skipLibCheck": true,
-    "strict": true,
-    "lib": ["ESNext", "dom"],
-    "types": ["node"],
-    "target": "ESNext"
+    "types": ["node"]
   },
   "include": ["./src"],
   "exclude": ["node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2016",
     "module": "esnext",
     "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
By enabling `verbatimModuleSyntax`, would help on reduce used packages by importing the whole package
https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax

This will improve the tree-shake and speed up the code