### PR TITLE
fix: SummaryIndex and VectorStoreIndex must be able to share storage context

### DIFF
--- a/packages/core/src/indices/summary/index.ts
+++ b/packages/core/src/indices/summary/index.ts
@@ -75,7 +75,8 @@ export class SummaryIndex extends BaseIndex<IndexList> {
     if (options.indexStruct) {
       indexStruct = options.indexStruct;
     } else if (indexStructs.length == 1) {
-      indexStruct = indexStructs[0];
+      indexStruct =
+        indexStructs[0].type === IndexStructType.LIST ? indexStructs[0] : null;
     } else if (indexStructs.length > 1 && options.indexId) {
       indexStruct = (await indexStore.getIndexStruct(
         options.indexId,

--- a/packages/core/src/indices/vectorStore/index.ts
+++ b/packages/core/src/indices/vectorStore/index.ts
@@ -145,6 +145,10 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
     if (options.indexStruct) {
       indexStruct = options.indexStruct;
     } else if (indexStructs.length == 1) {
+      indexStruct =
+        indexStructs[0].type === IndexStructType.SIMPLE_DICT
+          ? indexStructs[0]
+          : undefined;
       indexStruct = indexStructs[0];
     } else if (indexStructs.length > 1 && options.indexId) {
       indexStruct = (await indexStore.getIndexStruct(

--- a/packages/core/tests/indices/SummaryIndex.test.ts
+++ b/packages/core/tests/indices/SummaryIndex.test.ts
@@ -1,0 +1,58 @@
+import type { ServiceContext } from "llamaindex";
+import {
+  Document,
+  OpenAI,
+  OpenAIEmbedding,
+  SummaryIndex,
+  VectorStoreIndex,
+  serviceContextFromDefaults,
+  storageContextFromDefaults,
+} from "llamaindex";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  mockEmbeddingModel,
+  mockLlmGeneration,
+} from "../utility/mockOpenAI.js";
+
+// Mock the OpenAI getOpenAISession function during testing
+vi.mock("llamaindex/llm/open_ai", () => {
+  return {
+    getOpenAISession: vi.fn().mockImplementation(() => null),
+  };
+});
+
+describe("SummaryIndex", () => {
+  let serviceContext: ServiceContext;
+
+  beforeAll(() => {
+    const embeddingModel = new OpenAIEmbedding();
+    const llm = new OpenAI();
+
+    mockEmbeddingModel(embeddingModel);
+    mockLlmGeneration({ languageModel: llm });
+
+    const ctx = serviceContextFromDefaults({
+      embedModel: embeddingModel,
+      llm,
+    });
+
+    serviceContext = ctx;
+  });
+
+  it("SummaryIndex and VectorStoreIndex must be able to share the same storage context", async () => {
+    const storageContext = await storageContextFromDefaults({
+      persistDir: "/tmp/test_dir",
+    });
+    const documents = [new Document({ text: "lorem ipsem", id_: "1" })];
+    const vectorIndex = await VectorStoreIndex.fromDocuments(documents, {
+      serviceContext,
+      storageContext,
+    });
+    expect(vectorIndex).toBeDefined();
+    const summaryIndex = await SummaryIndex.fromDocuments(documents, {
+      serviceContext,
+      storageContext,
+    });
+    expect(summaryIndex).toBeDefined();
+  });
+});


### PR DESCRIPTION
fixes: https://github.com/run-llama/LlamaIndexTS/discussions/547#discussioncomment-8465573 