### PR TITLE
fix: allow passing model metadata

### DIFF
--- a/packages/core/src/llm/ollama.ts
+++ b/packages/core/src/llm/ollama.ts
@@ -37,14 +37,18 @@ export class Ollama extends BaseEmbedding implements LLM {
   additionalChatOptions?: Record<string, unknown>;
   callbackManager?: CallbackManager;
 
+  protected modelMetadata: Partial<LLMMetadata>;
+
   constructor(
     init: Partial<Ollama> & {
       // model is required
       model: string;
+      modelMetadata?: Partial<LLMMetadata>;
     },
   ) {
     super();
     this.model = init.model;
+    this.modelMetadata = init.modelMetadata ?? {};
     Object.assign(this, init);
   }
 
@@ -56,6 +60,7 @@ export class Ollama extends BaseEmbedding implements LLM {
       maxTokens: undefined,
       contextWindow: this.contextWindow,
       tokenizer: undefined,
+      ...this.modelMetadata,
     };
   }
 


### PR DESCRIPTION
Fixes: https://github.com/run-llama/LlamaIndexTS/issues/587

params like `maxTokens` is depends on model itself so we don't know