### PR TITLE
Use parameter object for retrieve function of Retriever 

### DIFF
--- a/.changeset/strange-waves-sit.md
+++ b/.changeset/strange-waves-sit.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": minor
+---
+
+Use parameter object for retrieve function of Retriever (to align usage with query function of QueryEngine)

--- a/apps/docs/docs/modules/node_postprocessors/index.md
+++ b/apps/docs/docs/modules/node_postprocessors/index.md
@@ -100,7 +100,7 @@ const response = await queryEngine.query("<user_query>");
 ```ts
 import { SimilarityPostprocessor } from "llamaindex";
 
-nodes = await index.asRetriever().retrieve("test query str");
+nodes = await index.asRetriever().retrieve({ query: "test query str" });
 
 const processor = new SimilarityPostprocessor({
   similarityCutoff: 0.7,

--- a/apps/docs/docs/modules/retriever.md
+++ b/apps/docs/docs/modules/retriever.md
@@ -11,7 +11,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Fetch nodes!
-const nodesWithScore = await retriever.retrieve("query string");
+const nodesWithScore = await retriever.retrieve({ query: "query string" });
 ```
 
 ## API Reference

--- a/apps/docs/i18n/ar/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/ar/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // جلب العقد!
-const nodesWithScore = await retriever.retrieve("سلسلة الاستعلام");
+const nodesWithScore = await retriever.retrieve({ query: "سلسلة الاستعلام" });
 ```
 
 ## مرجع الواجهة البرمجية (API Reference)

--- a/apps/docs/i18n/bg/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/bg/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Извличане на върхове!
-const nodesWithScore = await retriever.retrieve("query string");
+const nodesWithScore = await retriever.retrieve({ query: "query string" });
 ```
 
 ## API Reference (API справка)

--- a/apps/docs/i18n/cat/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/cat/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const recuperador = vector_index.asRetriever();
 recuperador.similarityTopK = 3;
 
 // Obteniu els nodes!
-const nodesAmbPuntuació = await recuperador.retrieve("cadena de consulta");
+const nodesAmbPuntuació = await recuperador.retrieve({ query: "cadena de consulta" });
 ```
 
 ## Referència de l'API

--- a/apps/docs/i18n/cs/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/cs/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Získání uzlů!
-const nodesWithScore = await retriever.retrieve("dotazovací řetězec");
+const nodesWithScore = await retriever.retrieve({ query: "dotazovací řetězec" });
 ```
 
 ## API Reference (Odkazy na rozhraní)

--- a/apps/docs/i18n/da/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/da/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Hent noder!
-const nodesWithScore = await retriever.retrieve("forespørgselsstreng");
+const nodesWithScore = await retriever.retrieve({ query: "forespørgselsstreng" });
 ```
 
 ## API Reference

--- a/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/de/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Knoten abrufen!
-const nodesWithScore = await retriever.retrieve("Abfragezeichenfolge");
+const nodesWithScore = await retriever.retrieve({ query: "Abfragezeichenfolge" });
 ```
 
 ## API-Referenz

--- a/apps/docs/i18n/el/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/el/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Ανάκτηση κόμβων!
-const nodesWithScore = await retriever.retrieve("συμβολοσειρά ερωτήματος");
+const nodesWithScore = await retriever.retrieve({ query: "συμβολοσειρά ερωτήματος" });
 ```
 
 ## Αναφορά API

--- a/apps/docs/i18n/es/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/es/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const recuperador = vector_index.asRetriever();
 recuperador.similarityTopK = 3;
 
 // ¡Obtener nodos!
-const nodosConPuntuación = await recuperador.retrieve("cadena de consulta");
+const nodosConPuntuación = await recuperador.retrieve({ query: "cadena de consulta" });
 ```
 
 ## Referencia de la API

--- a/apps/docs/i18n/et/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/et/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Too sõlmed!
-const nodesWithScore = await retriever.retrieve("päringu string");
+const nodesWithScore = await retriever.retrieve({ query: "päringu string" });
 ```
 
 ## API viide

--- a/apps/docs/i18n/fa/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/fa/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // بازیابی گره ها!
-const nodesWithScore = await retriever.retrieve("رشته پرس و جو");
+const nodesWithScore = await retriever.retrieve({ query: "رشته پرس و جو" });
 ```
 
 ## مرجع API

--- a/apps/docs/i18n/fi/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/fi/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Hae solmut!
-const nodesWithScore = await retriever.retrieve("kyselymerkkijono");
+const nodesWithScore = await retriever.retrieve({ query: "kyselymerkkijono" });
 ```
 
 ## API-viite

--- a/apps/docs/i18n/fr/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/fr/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -11,7 +11,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Récupérer les nœuds !
-const nodesWithScore = await retriever.retrieve("chaîne de requête");
+const nodesWithScore = await retriever.retrieve({ query: "chaîne de requête" });
 ```
 
 ## Référence de l'API

--- a/apps/docs/i18n/he/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/he/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // אחזור צמתים!
-const nodesWithScore = await retriever.retrieve("מחרוזת שאילתה");
+const nodesWithScore = await retriever.retrieve({ query: "מחרוזת שאילתה" });
 ```
 
 ## מדריך לממשק API

--- a/apps/docs/i18n/hi/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/hi/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // नोड्स प्राप्त करें!
-const nodesWithScore = await retriever.retrieve("क्वेरी स्ट्रिंग");
+const nodesWithScore = await retriever.retrieve({ query: "क्वेरी स्ट्रिंग" });
 ```
 
 ## एपीआई संदर्भ (API Reference)

--- a/apps/docs/i18n/hr/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/hr/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const dohvatnik = vector_index.asRetriever();
 dohvatnik.similarityTopK = 3;
 
 // Dohvati čvorove!
-const čvoroviSaRezultatom = await dohvatnik.retrieve("upitni niz");
+const čvoroviSaRezultatom = await dohvatnik.retrieve({ query: "upitni niz" });
 ```
 
 ## API Referenca

--- a/apps/docs/i18n/hu/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/hu/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Node-ok lekérése!
-const nodesWithScore = await retriever.retrieve("lekérdezési karakterlánc");
+const nodesWithScore = await retriever.retrieve({ query: "lekérdezési karakterlánc" });
 ```
 
 ## API Referencia

--- a/apps/docs/i18n/in/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/in/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Mengambil node!
-const nodesWithScore = await retriever.retrieve("string query");
+const nodesWithScore = await retriever.retrieve({ query: "string query" });
 ```
 
 ## Referensi API

--- a/apps/docs/i18n/it/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/it/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Recupera i nodi!
-const nodesWithScore = await retriever.retrieve("stringa di query");
+const nodesWithScore = await retriever.retrieve({ query: "stringa di query" });
 ```
 
 ## Riferimento API

--- a/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/ja/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // ノードを取得します！
-const nodesWithScore = await retriever.retrieve("クエリ文字列");
+const nodesWithScore = await retriever.retrieve({ query: "クエリ文字列" });
 ```
 
 ## API リファレンス

--- a/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/ko/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // 노드를 가져옵니다!
-const nodesWithScore = await retriever.retrieve("쿼리 문자열");
+const nodesWithScore = await retriever.retrieve({ query: "쿼리 문자열" });
 ```
 
 ## API 참조

--- a/apps/docs/i18n/lt/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/lt/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const gavėjas = vector_index.asRetriever();
 gavėjas.similarityTopK = 3;
 
 // Išgaunami mazgai!
-const mazgaiSuRezultatu = await gavėjas.retrieve("užklausos eilutė");
+const mazgaiSuRezultatu = await gavėjas.retrieve({ query: "užklausos eilutė" });
 ```
 
 ## API nuorodos (API Reference)

--- a/apps/docs/i18n/nl/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/nl/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Haal knooppunten op!
-const nodesWithScore = await retriever.retrieve("zoekopdracht");
+const nodesWithScore = await retriever.retrieve({ query: "zoekopdracht" });
 ```
 
 ## API Referentie

--- a/apps/docs/i18n/no/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/no/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Hent noder!
-const nodesWithScore = await retriever.retrieve("spørringsstreng");
+const nodesWithScore = await retriever.retrieve({ query: "spørringsstreng" });
 ```
 
 ## API-referanse

--- a/apps/docs/i18n/pl/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/pl/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Pobierz węzły!
-const nodesWithScore = await retriever.retrieve("ciąg zapytania");
+const nodesWithScore = await retriever.retrieve({ query: "ciąg zapytania" });
 ```
 
 ## Dokumentacja interfejsu API

--- a/apps/docs/i18n/pt/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/pt/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const recuperador = vector_index.asRetriever();
 recuperador.similarityTopK = 3;
 
 // Buscar nós!
-const nósComPontuação = await recuperador.retrieve("string de consulta");
+const nósComPontuação = await recuperador.retrieve({ query: "string de consulta" });
 ```
 
 ## Referência da API

--- a/apps/docs/i18n/ro/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/ro/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const recuperator = vector_index.asRetriever();
 recuperator.similarityTopK = 3;
 
 // Preia nodurile!
-const noduriCuScor = await recuperator.retrieve("șir de interogare");
+const noduriCuScor = await recuperator.retrieve({ query: "șir de interogare" });
 ```
 
 ## Referință API

--- a/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/ru/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Получение узлов!
-const nodesWithScore = await retriever.retrieve("строка запроса");
+const nodesWithScore = await retriever.retrieve({ query: "строка запроса" });
 ```
 
 ## Справочник по API

--- a/apps/docs/i18n/se/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/se/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Dohvati čvorove!
-const nodesWithScore = await retriever.retrieve("upitni niz");
+const nodesWithScore = await retriever.retrieve({ query: "upitni niz" });
 ```
 
 ## API Referenca

--- a/apps/docs/i18n/sk/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/sk/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const pridobitelj = vector_index.asRetriever();
 pridobitelj.similarityTopK = 3;
 
 // Pridobivanje vozlišč!
-const vozliščaZRezultatom = await pridobitelj.retrieve("poizvedbeni niz");
+const vozliščaZRezultatom = await pridobitelj.retrieve({ query: "poizvedbeni niz" });
 ```
 
 ## API Sklic

--- a/apps/docs/i18n/sl/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/sl/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Získajte uzly!
-const nodesWithScore = await retriever.retrieve("reťazec dotazu");
+const nodesWithScore = await retriever.retrieve({ query: "reťazec dotazu" });
 ```
 
 ## API Referencia

--- a/apps/docs/i18n/sv/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/sv/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Hämta noder!
-const nodesWithScore = await retriever.retrieve("frågesträng");
+const nodesWithScore = await retriever.retrieve({ query: "frågesträng" });
 ```
 
 ## API-referens

--- a/apps/docs/i18n/th/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/th/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // เรียกคืนโหนด!
-const nodesWithScore = await retriever.retrieve("query string");
+const nodesWithScore = await retriever.retrieve({ query: "query string" });
 ```
 
 ## API Reference (การอ้างอิง API)

--- a/apps/docs/i18n/tr/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/tr/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Düğümleri getir!
-const nodesWithScore = await retriever.retrieve("sorgu dizesi");
+const nodesWithScore = await retriever.retrieve({ query: "sorgu dizesi" });
 ```
 
 ## API Referansı

--- a/apps/docs/i18n/uk/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/uk/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Отримати вузли!
-const nodesWithScore = await retriever.retrieve("рядок запиту");
+const nodesWithScore = await retriever.retrieve({ query: "рядок запиту" });
 ```
 
 ## Довідник API

--- a/apps/docs/i18n/vi/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/vi/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // Lấy các node!
-const nodesWithScore = await retriever.retrieve("chuỗi truy vấn");
+const nodesWithScore = await retriever.retrieve({ query: "chuỗi truy vấn" });
 ```
 
 ## Tài liệu tham khảo API

--- a/apps/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -11,7 +11,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // 获取节点！
-const nodesWithScore = await retriever.retrieve("查询字符串");
+const nodesWithScore = await retriever.retrieve({ query: "查询字符串" });
 ```
 
 ## API 参考

--- a/apps/docs/i18n/zh_tw/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
+++ b/apps/docs/i18n/zh_tw/docusaurus-plugin-content-docs/current/modules/low_level/retriever.md
@@ -13,7 +13,7 @@ const retriever = vector_index.asRetriever();
 retriever.similarityTopK = 3;
 
 // 提取節點！
-const nodesWithScore = await retriever.retrieve("查詢字串");
+const nodesWithScore = await retriever.retrieve({ query: "查詢字串" });
 ```
 
 ## API 參考

--- a/examples/multimodal/retrieve.ts
+++ b/examples/multimodal/retrieve.ts
@@ -27,9 +27,9 @@ async function main() {
   // retrieve documents using the index
   const index = await createIndex();
   const retriever = index.asRetriever({ similarityTopK: 3 });
-  const results = await retriever.retrieve(
-    "what are Vincent van Gogh's famous paintings",
-  );
+  const results = await retriever.retrieve({
+    query: "what are Vincent van Gogh's famous paintings",
+  });
   for (const result of results) {
     const node = result.node;
     if (!node) {

--- a/packages/core/src/Retriever.ts
+++ b/packages/core/src/Retriever.ts
@@ -2,14 +2,16 @@ import type { Event } from "./callbacks/CallbackManager.js";
 import type { NodeWithScore } from "./Node.js";
 import type { ServiceContext } from "./ServiceContext.js";
 
+export type RetrieveParams = {
+  query: string;
+  parentEvent?: Event;
+  preFilters?: unknown;
+};
+
 /**
  * Retrievers retrieve the nodes that most closely match our query in similarity.
  */
 export interface BaseRetriever {
-  retrieve(
-    query: string,
-    parentEvent?: Event,
-    preFilters?: unknown,
-  ): Promise<NodeWithScore[]>;
+  retrieve(params: RetrieveParams): Promise<NodeWithScore[]>;
   getServiceContext(): ServiceContext;
 }

--- a/packages/core/src/cloud/LlamaCloudIndex.ts
+++ b/packages/core/src/cloud/LlamaCloudIndex.ts
@@ -3,7 +3,7 @@ import { RetrieverQueryEngine } from "../engines/query/RetrieverQueryEngine.js";
 import type { BaseNodePostprocessor } from "../postprocessors/types.js";
 import type { BaseSynthesizer } from "../synthesizers/types.js";
 import type { BaseQueryEngine } from "../types.js";
-import type { RetrieveParams } from "./LlamaCloudRetriever.js";
+import type { CloudRetrieveParams } from "./LlamaCloudRetriever.js";
 import { LlamaCloudRetriever } from "./LlamaCloudRetriever.js";
 import type { CloudConstructorParams } from "./types.js";
 
@@ -14,7 +14,7 @@ export class LlamaCloudIndex {
     this.params = params;
   }
 
-  asRetriever(params: RetrieveParams = {}): BaseRetriever {
+  asRetriever(params: CloudRetrieveParams = {}): BaseRetriever {
     return new LlamaCloudRetriever({ ...this.params, ...params });
   }
 
@@ -23,7 +23,7 @@ export class LlamaCloudIndex {
       responseSynthesizer?: BaseSynthesizer;
       preFilters?: unknown;
       nodePostprocessors?: BaseNodePostprocessor[];
-    } & RetrieveParams,
+    } & CloudRetrieveParams,
   ): BaseQueryEngine {
     const retriever = new LlamaCloudRetriever({
       ...this.params,

--- a/packages/core/src/cloud/LlamaCloudRetriever.ts
+++ b/packages/core/src/cloud/LlamaCloudRetriever.ts
@@ -2,15 +2,14 @@ import type { PlatformApi, PlatformApiClient } from "@llamaindex/cloud";
 import { globalsHelper } from "../GlobalsHelper.js";
 import type { NodeWithScore } from "../Node.js";
 import { ObjectType, jsonToNode } from "../Node.js";
-import type { BaseRetriever } from "../Retriever.js";
+import type { BaseRetriever, RetrieveParams } from "../Retriever.js";
 import type { ServiceContext } from "../ServiceContext.js";
 import { serviceContextFromDefaults } from "../ServiceContext.js";
-import type { Event } from "../callbacks/CallbackManager.js";
 import type { ClientParams, CloudConstructorParams } from "./types.js";
 import { DEFAULT_PROJECT_NAME } from "./types.js";
 import { getClient } from "./utils.js";
 
-export type RetrieveParams = Omit<
+export type CloudRetrieveParams = Omit<
   PlatformApi.RetrievalParams,
   "query" | "searchFilters" | "pipelineId" | "className"
 > & { similarityTopK?: number };
@@ -18,7 +17,7 @@ export type RetrieveParams = Omit<
 export class LlamaCloudRetriever implements BaseRetriever {
   client?: PlatformApiClient;
   clientParams: ClientParams;
-  retrieveParams: RetrieveParams;
+  retrieveParams: CloudRetrieveParams;
   projectName: string = DEFAULT_PROJECT_NAME;
   pipelineName: string;
   serviceContext: ServiceContext;
@@ -35,7 +34,7 @@ export class LlamaCloudRetriever implements BaseRetriever {
     });
   }
 
-  constructor(params: CloudConstructorParams & RetrieveParams) {
+  constructor(params: CloudConstructorParams & CloudRetrieveParams) {
     this.clientParams = { apiKey: params.apiKey, baseUrl: params.baseUrl };
     if (params.similarityTopK) {
       params.denseSimilarityTopK = params.similarityTopK;
@@ -55,11 +54,11 @@ export class LlamaCloudRetriever implements BaseRetriever {
     return this.client;
   }
 
-  async retrieve(
-    query: string,
-    parentEvent?: Event | undefined,
-    preFilters?: unknown,
-  ): Promise<NodeWithScore[]> {
+  async retrieve({
+    query,
+    parentEvent,
+    preFilters,
+  }: RetrieveParams): Promise<NodeWithScore[]> {
     const pipelines = await (
       await this.getClient()
     ).pipeline.searchPipelines({

--- a/packages/core/src/engines/chat/DefaultContextGenerator.ts
+++ b/packages/core/src/engines/chat/DefaultContextGenerator.ts
@@ -64,10 +64,10 @@ export class DefaultContextGenerator
         tags: ["final"],
       };
     }
-    const sourceNodesWithScore = await this.retriever.retrieve(
-      message,
+    const sourceNodesWithScore = await this.retriever.retrieve({
+      query: message,
       parentEvent,
-    );
+    });
 
     const nodes = await this.applyNodePostprocessors(
       sourceNodesWithScore,

--- a/packages/core/src/engines/query/RetrieverQueryEngine.ts
+++ b/packages/core/src/engines/query/RetrieverQueryEngine.ts
@@ -63,11 +63,11 @@ export class RetrieverQueryEngine
   }
 
   private async retrieve(query: string, parentEvent: Event) {
-    const nodes = await this.retriever.retrieve(
+    const nodes = await this.retriever.retrieve({
       query,
       parentEvent,
-      this.preFilters,
-    );
+      preFilters: this.preFilters,
+    });
 
     return await this.applyNodePostprocessors(nodes, query);
   }

--- a/packages/core/src/indices/keyword/index.ts
+++ b/packages/core/src/indices/keyword/index.ts
@@ -8,7 +8,7 @@ import {
   defaultKeywordExtractPrompt,
   defaultQueryKeywordExtractPrompt,
 } from "../../Prompt.js";
-import type { BaseRetriever } from "../../Retriever.js";
+import type { BaseRetriever, RetrieveParams } from "../../Retriever.js";
 import type { ServiceContext } from "../../ServiceContext.js";
 import { serviceContextFromDefaults } from "../../ServiceContext.js";
 import { RetrieverQueryEngine } from "../../engines/query/index.js";
@@ -79,7 +79,7 @@ abstract class BaseKeywordTableRetriever implements BaseRetriever {
 
   abstract getKeywords(query: string): Promise<string[]>;
 
-  async retrieve(query: string): Promise<NodeWithScore[]> {
+  async retrieve({ query }: RetrieveParams): Promise<NodeWithScore[]> {
     const keywords = await this.getKeywords(query);
     const chunkIndicesCount: { [key: string]: number } = {};
     const filteredKeywords = keywords.filter((keyword) =>

--- a/packages/core/src/indices/summary/index.ts
+++ b/packages/core/src/indices/summary/index.ts
@@ -3,10 +3,9 @@ import { globalsHelper } from "../../GlobalsHelper.js";
 import type { BaseNode, Document, NodeWithScore } from "../../Node.js";
 import type { ChoiceSelectPrompt } from "../../Prompt.js";
 import { defaultChoiceSelectPrompt } from "../../Prompt.js";
-import type { BaseRetriever } from "../../Retriever.js";
+import type { BaseRetriever, RetrieveParams } from "../../Retriever.js";
 import type { ServiceContext } from "../../ServiceContext.js";
 import { serviceContextFromDefaults } from "../../ServiceContext.js";
-import type { Event } from "../../callbacks/CallbackManager.js";
 import { RetrieverQueryEngine } from "../../engines/query/index.js";
 import type { BaseNodePostprocessor } from "../../postprocessors/index.js";
 import type {
@@ -281,7 +280,10 @@ export class SummaryIndexRetriever implements BaseRetriever {
     this.index = index;
   }
 
-  async retrieve(query: string, parentEvent?: Event): Promise<NodeWithScore[]> {
+  async retrieve({
+    query,
+    parentEvent,
+  }: RetrieveParams): Promise<NodeWithScore[]> {
     const nodeIds = this.index.indexStruct.nodes;
     const nodes = await this.index.docStore.getNodes(nodeIds);
     const result = nodes.map((node) => ({
@@ -337,7 +339,10 @@ export class SummaryIndexLLMRetriever implements BaseRetriever {
     this.serviceContext = serviceContext || index.serviceContext;
   }
 
-  async retrieve(query: string, parentEvent?: Event): Promise<NodeWithScore[]> {
+  async retrieve({
+    query,
+    parentEvent,
+  }: RetrieveParams): Promise<NodeWithScore[]> {
     const nodeIds = this.index.indexStruct.nodes;
     const results: NodeWithScore[] = [];
 

--- a/packages/core/src/indices/vectorStore/index.ts
+++ b/packages/core/src/indices/vectorStore/index.ts
@@ -11,7 +11,7 @@ import {
   ObjectType,
   splitNodesByType,
 } from "../../Node.js";
-import type { BaseRetriever } from "../../Retriever.js";
+import type { BaseRetriever, RetrieveParams } from "../../Retriever.js";
 import type { ServiceContext } from "../../ServiceContext.js";
 import { serviceContextFromDefaults } from "../../ServiceContext.js";
 import type { Event } from "../../callbacks/CallbackManager.js";
@@ -426,14 +426,17 @@ export class VectorIndexRetriever implements BaseRetriever {
     this.imageSimilarityTopK = imageSimilarityTopK ?? DEFAULT_SIMILARITY_TOP_K;
   }
 
-  async retrieve(
-    query: string,
-    parentEvent?: Event,
-    preFilters?: MetadataFilters,
-  ): Promise<NodeWithScore[]> {
-    let nodesWithScores = await this.textRetrieve(query, preFilters);
+  async retrieve({
+    query,
+    parentEvent,
+    preFilters,
+  }: RetrieveParams): Promise<NodeWithScore[]> {
+    let nodesWithScores = await this.textRetrieve(
+      query,
+      preFilters as MetadataFilters,
+    );
     nodesWithScores = nodesWithScores.concat(
-      await this.textToImageRetrieve(query, preFilters),
+      await this.textToImageRetrieve(query, preFilters as MetadataFilters),
     );
     this.sendEvent(query, nodesWithScores, parentEvent);
     return nodesWithScores;

--- a/packages/core/src/objects/base.ts
+++ b/packages/core/src/objects/base.ts
@@ -69,7 +69,7 @@ export class ObjectRetriever {
 
   // Translating the retrieve method
   async retrieve(strOrQueryBundle: QueryType): Promise<any> {
-    const nodes = await this.retriever.retrieve(strOrQueryBundle);
+    const nodes = await this.retriever.retrieve({ query: strOrQueryBundle });
     const objs = nodes.map((n) => this._objectNodeMapping.fromNode(n.node));
     return objs;
   }


### PR DESCRIPTION
**Note**: As this is breaking, we're using a minor changeset
**Reason**: To align usage with `query` function of `QueryEngine`

This will align the LlamaCloud code, so we can do:

```
import { LlamaCloudIndex } from "llamaindex";

const index = new LlamaCloudIndex({
    name: "test",
    projectName: "default",
    apiKey: "llx-...",
  });
const nodes = await index.asRetriever().retrieve({ query });
const response = await index.asQueryEngine().query({ query });
```