### PR TITLE
Fix: Metadata filters doesn't seem to work for Qdrant

### DIFF
--- a/examples/qdrantdb/README.md
+++ b/examples/qdrantdb/README.md
@@ -8,4 +8,4 @@ Add your OpenAI API Key into a file called `.env` in the parent folder of this d
 OPEN_API_KEY=sk-you-key
 ```
 
-Now, open a new terminal window and inside `examples/qdrantdb`, run `npx ts-node preFilters.ts`.
+Now, open a new terminal window and inside `examples`, run `npx ts-node qdrantdb/preFilters.ts`.

--- a/examples/qdrantdb/README.md
+++ b/examples/qdrantdb/README.md
@@ -1,0 +1,11 @@
+# Qdrant Vector Store Example
+
+How to run `examples/qdrantdb/preFilters.ts`:
+
+Add your OpenAI API Key into a file called `.env` in the parent folder of this directory. It should look like this:
+
+```
+OPEN_API_KEY=sk-you-key
+```
+
+Now, open a new terminal window and inside `examples/qdrantdb`, run `npx ts-node preFilters.ts`.

--- a/examples/qdrantdb/preFilters.ts
+++ b/examples/qdrantdb/preFilters.ts
@@ -1,0 +1,61 @@
+import * as dotenv from "dotenv";
+import {
+  Document,
+  QdrantVectorStore,
+  VectorStoreIndex,
+  storageContextFromDefaults,
+} from "llamaindex";
+
+// Load environment variables from local .env file
+dotenv.config();
+
+const collectionName = "dog_colors";
+const qdrantUrl = "http://127.0.0.1:6333";
+
+async function main() {
+  try {
+    const docs = [
+      new Document({
+        text: "The dog is brown",
+        metadata: {
+          dogId: "1",
+        },
+      }),
+      new Document({
+        text: "The dog is red",
+        metadata: {
+          dogId: "2",
+        },
+      }),
+    ];
+    console.log("Creating QdrantDB vector store");
+    const qdrantVs = new QdrantVectorStore({ url: qdrantUrl, collectionName });
+    const ctx = await storageContextFromDefaults({ vectorStore: qdrantVs });
+
+    console.log("Embedding documents and adding to index");
+    const index = await VectorStoreIndex.fromDocuments(docs, {
+      storageContext: ctx,
+    });
+
+    console.log("Querying index");
+    const queryEngine = index.asQueryEngine({
+      preFilters: {
+        filters: [
+          {
+            key: "dogId",
+            value: "2",
+            filterType: "ExactMatch",
+          },
+        ],
+      },
+    });
+    const response = await queryEngine.query({
+      query: "What is the color of the dog?",
+    });
+    console.log(response.toString());
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+main();

--- a/packages/core/src/storage/vectorStore/QdrantVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/QdrantVectorStore.ts
@@ -289,7 +289,7 @@ export class QdrantVectorStore implements VectorStore {
    * @param query The VectorStoreQuery to be used
    */
   private async buildQueryFilter(query: VectorStoreQuery) {
-    if (!query.docIds && !query.queryStr) {
+    if (!query.docIds && !query.queryStr && !query.filters) {
       return null;
     }
 


### PR DESCRIPTION
While using Qdrant as a vectorstore in a query engine the filters didn't work. This is a fix for the same.