### PR TITLE
feat: Add doc store strategies to VectorStoreIndex.fromDocuments

### DIFF
--- a/.changeset/young-bananas-wave.md
+++ b/.changeset/young-bananas-wave.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+Add support for doc store strategies to VectorStoreIndex.fromDocuments

--- a/packages/core/src/indices/vectorStore/index.ts
+++ b/packages/core/src/indices/vectorStore/index.ts
@@ -230,10 +230,12 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       docStore,
       args.vectorStore,
     );
-    args.nodes = await runTransformations(documents, [
-      ...(docStoreStrategy ? [docStoreStrategy] : []),
-      args.serviceContext.nodeParser,
-    ]);
+    args.nodes = await runTransformations(
+      documents,
+      [args.serviceContext.nodeParser],
+      {},
+      { docStoreStrategy },
+    );
     if (args.logProgress) {
       console.log("Finished parsing documents.");
     }

--- a/packages/core/src/indices/vectorStore/index.ts
+++ b/packages/core/src/indices/vectorStore/index.ts
@@ -214,7 +214,12 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       docStoreStrategy?: DocStoreStrategy;
     } = {},
   ): Promise<VectorStoreIndex> {
-    args.docStoreStrategy = args.docStoreStrategy ?? DocStoreStrategy.UPSERTS;
+    args.docStoreStrategy =
+      args.docStoreStrategy ??
+      // set doc store strategy defaults to the same as for the IngestionPipeline
+      (args.vectorStore
+        ? DocStoreStrategy.UPSERTS
+        : DocStoreStrategy.DUPLICATES_ONLY);
     args.storageContext =
       args.storageContext ?? (await storageContextFromDefaults({}));
     args.serviceContext = args.serviceContext ?? serviceContextFromDefaults({});
@@ -224,7 +229,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       console.log("Using node parser on documents...");
     }
 
-    // run doc store strategy before other transformations
+    // use doc store strategy to avoid duplicates
     const docStoreStrategy = createDocStoreStrategy(
       args.docStoreStrategy,
       docStore,

--- a/packages/core/src/ingestion/IngestionPipeline.ts
+++ b/packages/core/src/ingestion/IngestionPipeline.ts
@@ -77,6 +77,9 @@ export class IngestionPipeline {
   constructor(init?: Partial<IngestionPipeline> & ClientParams) {
     Object.assign(this, init);
     this.clientParams = { apiKey: init?.apiKey, baseUrl: init?.baseUrl };
+    if (!this.docStore) {
+      this.docStoreStrategy = DocStoreStrategy.NONE;
+    }
     this._docStoreStrategy = createDocStoreStrategy(
       this.docStoreStrategy,
       this.docStore,

--- a/packages/core/src/ingestion/strategies/UpsertsAndDeleteStrategy.ts
+++ b/packages/core/src/ingestion/strategies/UpsertsAndDeleteStrategy.ts
@@ -1,13 +1,14 @@
 import type { BaseNode } from "../../Node.js";
 import type { BaseDocumentStore } from "../../storage/docStore/types.js";
 import type { VectorStore } from "../../storage/vectorStore/types.js";
+import type { TransformComponent } from "../types.js";
 import { classify } from "./classify.js";
 
 /**
  * Handle docstore upserts by checking hashes and ids.
  * Identify missing docs and delete them from docstore and vector store
  */
-export class UpsertsAndDeleteStrategy {
+export class UpsertsAndDeleteStrategy implements TransformComponent {
   protected docStore: BaseDocumentStore;
   protected vectorStore?: VectorStore;
 

--- a/packages/core/src/ingestion/strategies/index.ts
+++ b/packages/core/src/ingestion/strategies/index.ts
@@ -2,31 +2,44 @@ import type { BaseDocumentStore } from "../../storage/docStore/types.js";
 import type { VectorStore } from "../../storage/vectorStore/types.js";
 import type { TransformComponent } from "../types.js";
 import { DuplicatesStrategy } from "./DuplicatesStrategy.js";
+import { UpsertsAndDeleteStrategy } from "./UpsertsAndDeleteStrategy.js";
 import { UpsertsStrategy } from "./UpsertsStrategy.js";
 
 export enum DocStoreStrategy {
   UPSERTS = "upserts",
   DUPLICATES_ONLY = "duplicates_only",
   UPSERTS_AND_DELETE = "upserts_and_delete",
+  NONE = "none", // no-op strategy
+}
+
+class NoOpStrategy implements TransformComponent {
+  async transform(nodes: any[]): Promise<any[]> {
+    return nodes;
+  }
 }
 
 export function createDocStoreStrategy(
   docStoreStrategy: DocStoreStrategy,
   docStore?: BaseDocumentStore,
   vectorStore?: VectorStore,
-): TransformComponent | undefined {
-  if (docStore && vectorStore) {
-    if (
-      docStoreStrategy === DocStoreStrategy.UPSERTS ||
-      docStoreStrategy === DocStoreStrategy.UPSERTS_AND_DELETE
-    ) {
+): TransformComponent {
+  if (!docStore) {
+    throw new Error("docStore is required to create a doc store strategy.");
+  }
+  if (docStoreStrategy === DocStoreStrategy.NONE) {
+    return new NoOpStrategy();
+  }
+  if (vectorStore) {
+    if (docStoreStrategy === DocStoreStrategy.UPSERTS) {
       return new UpsertsStrategy(docStore, vectorStore);
+    } else if (docStoreStrategy === DocStoreStrategy.UPSERTS_AND_DELETE) {
+      return new UpsertsAndDeleteStrategy(docStore, vectorStore);
     } else if (docStoreStrategy === DocStoreStrategy.DUPLICATES_ONLY) {
       return new DuplicatesStrategy(docStore);
     } else {
       throw new Error(`Invalid docstore strategy: ${docStoreStrategy}`);
     }
-  } else if (docStore && !vectorStore) {
+  } else {
     if (docStoreStrategy === DocStoreStrategy.UPSERTS) {
       console.warn(
         "Docstore strategy set to upserts, but no vector store. Switching to duplicates_only strategy.",

--- a/packages/core/src/ingestion/strategies/index.ts
+++ b/packages/core/src/ingestion/strategies/index.ts
@@ -23,11 +23,11 @@ export function createDocStoreStrategy(
   docStore?: BaseDocumentStore,
   vectorStore?: VectorStore,
 ): TransformComponent {
-  if (!docStore) {
-    throw new Error("docStore is required to create a doc store strategy.");
-  }
   if (docStoreStrategy === DocStoreStrategy.NONE) {
     return new NoOpStrategy();
+  }
+  if (!docStore) {
+    throw new Error("docStore is required to create a doc store strategy.");
   }
   if (vectorStore) {
     if (docStoreStrategy === DocStoreStrategy.UPSERTS) {


### PR DESCRIPTION
- Adding the same doc store strategies from IngestionPipeline to VectorStoreIndex.fromDocuments
- Prevents duplicate issues like https://github.com/run-llama/LlamaIndexTS/issues/639