### PR TITLE
Update to latest supported version list as of 2024-04-02. 

### DIFF
--- a/.changeset/nine-fireants-bow.md
+++ b/.changeset/nine-fireants-bow.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+Update the list of supported Azure OpenAI API versions as of 2024-04-02.

--- a/packages/core/src/llm/azure.ts
+++ b/packages/core/src/llm/azure.ts
@@ -49,15 +49,15 @@ const ALL_AZURE_OPENAI_EMBEDDING_MODELS = {
   },
 };
 
+// Current version list found here - https://learn.microsoft.com/en-us/azure/ai-services/openai/reference
 const ALL_AZURE_API_VERSIONS = [
   "2022-12-01",
   "2023-05-15",
-  "2023-03-15-preview", // retiring 2024-04-02
-  "2023-06-01-preview", // retiring 2024-04-02
-  "2023-07-01-preview", // retiring 2024-04-02
-  "2023-08-01-preview", // retiring 2024-04-02
-  "2023-09-01-preview",
-  "2023-12-01-preview",
+  "2023-06-01-preview", // Maintained for DALL-E 2
+  "2023-10-01-preview",
+  "2024-02-01",
+  "2024-02-15-preview",
+  "2024-03-01-preview",
 ];
 
 const DEFAULT_API_VERSION = "2023-05-15";


### PR DESCRIPTION
This is an update to the list of Azure OpenAI versions.  While this constant appears to be purely informational, it would be good if it were kept up to date or removed.

This PR updates the list, adding several missing entries and removing entries being retired as of April 2, 2024 (next Tuesday)