### PR TITLE
refactor: remove `llm.tokens` api

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -11,6 +11,7 @@
     "chromadb": "^1.8.1",
     "commander": "^11.1.0",
     "dotenv": "^16.4.1",
+    "js-tiktoken": "^1.0.10",
     "llamaindex": "latest",
     "mongodb": "^6.2.0",
     "pathe": "^1.1.2"

--- a/examples/recipes/cost-analysis.ts
+++ b/examples/recipes/cost-analysis.ts
@@ -1,5 +1,8 @@
+import { encodingForModel } from "js-tiktoken";
 import { OpenAI } from "llamaindex";
 import { Settings } from "llamaindex/Settings";
+
+const encoding = encodingForModel("gpt-4-0125-preview");
 
 const llm = new OpenAI({
   model: "gpt-4-0125-preview",
@@ -9,11 +12,21 @@ let tokenCount = 0;
 
 Settings.callbackManager.on("llm-start", (event) => {
   const { messages } = event.detail.payload;
-  tokenCount += llm.tokens(messages);
+  tokenCount += messages.reduce((count, message) => {
+    return count + encoding.encode(message.content).length;
+  }, 0);
   console.log("Token count:", tokenCount);
   // https://openai.com/pricing
   // $10.00 / 1M tokens
-  console.log(`Price: $${(tokenCount / 1000000) * 10}`);
+  console.log(`Price: $${(tokenCount / 1_000_000) * 10}`);
+});
+Settings.callbackManager.on("llm-end", (event) => {
+  const { response } = event.detail.payload;
+  tokenCount += encoding.encode(response.message.content).length;
+  console.log("Token count:", tokenCount);
+  // https://openai.com/pricing
+  // $30.00 / 1M tokens
+  console.log(`Price: $${(tokenCount / 1_000_000) * 30}`);
 });
 
 const question = "Hello, how are you?";

--- a/packages/core/src/GlobalsHelper.ts
+++ b/packages/core/src/GlobalsHelper.ts
@@ -18,9 +18,9 @@ class GlobalsHelper {
   defaultTokenizer: {
     encode: (text: string) => Uint32Array;
     decode: (tokens: Uint32Array) => string;
-  } | null = null;
+  };
 
-  private initDefaultTokenizer() {
+  constructor() {
     const encoding = encodingForModel("text-embedding-ada-002"); // cl100k_base
 
     this.defaultTokenizer = {
@@ -40,9 +40,6 @@ class GlobalsHelper {
     if (encoding && encoding !== Tokenizers.CL100K_BASE) {
       throw new Error(`Tokenizer encoding ${encoding} not yet supported`);
     }
-    if (!this.defaultTokenizer) {
-      this.initDefaultTokenizer();
-    }
 
     return this.defaultTokenizer!.encode.bind(this.defaultTokenizer);
   }
@@ -50,9 +47,6 @@ class GlobalsHelper {
   tokenizerDecoder(encoding?: Tokenizers) {
     if (encoding && encoding !== Tokenizers.CL100K_BASE) {
       throw new Error(`Tokenizer encoding ${encoding} not yet supported`);
-    }
-    if (!this.defaultTokenizer) {
-      this.initDefaultTokenizer();
     }
 
     return this.defaultTokenizer!.decode.bind(this.defaultTokenizer);

--- a/packages/core/src/llm/LLM.ts
+++ b/packages/core/src/llm/LLM.ts
@@ -9,7 +9,7 @@ import {
 
 import type { ChatCompletionMessageParam } from "openai/resources/index.js";
 import type { LLMOptions } from "portkey-ai";
-import { Tokenizers, globalsHelper } from "../GlobalsHelper.js";
+import { Tokenizers } from "../GlobalsHelper.js";
 import { getCallbackManager } from "../internal/settings/CallbackManager.js";
 import type { AnthropicSession } from "./anthropic.js";
 import { getAnthropicSession } from "./anthropic.js";
@@ -169,21 +169,6 @@ export class OpenAI extends BaseLLM {
       tokenizer: Tokenizers.CL100K_BASE,
       isFunctionCallingModel: isFunctionCallingModel(this.model),
     };
-  }
-
-  tokens(messages: ChatMessage[]): number {
-    // for latest OpenAI models, see https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
-    const tokenizer = globalsHelper.tokenizer(this.metadata.tokenizer);
-    const tokensPerMessage = 3;
-    let numTokens = 0;
-    for (const message of messages) {
-      numTokens += tokensPerMessage;
-      for (const value of Object.values(message)) {
-        numTokens += tokenizer(value).length;
-      }
-    }
-    numTokens += 3; // every reply is primed with <|im_start|>assistant<|im_sep|>
-    return numTokens;
   }
 
   mapMessageType(
@@ -412,10 +397,6 @@ export class LlamaDeuce extends BaseLLM {
       init?.maxTokens ??
       ALL_AVAILABLE_LLAMADEUCE_MODELS[this.model].contextWindow; // For Replicate, the default is 500 tokens which is too low.
     this.replicateSession = init?.replicateSession ?? new ReplicateSession();
-  }
-
-  tokens(messages: ChatMessage[]): number {
-    throw new Error("Method not implemented.");
   }
 
   get metadata() {
@@ -667,10 +648,6 @@ export class Anthropic extends BaseLLM {
       });
   }
 
-  tokens(messages: ChatMessage[]): number {
-    throw new Error("Method not implemented.");
-  }
-
   get metadata() {
     return {
       model: this.model,
@@ -795,10 +772,6 @@ export class Portkey extends BaseLLM {
       llms: this.llms,
       mode: this.mode,
     });
-  }
-
-  tokens(messages: ChatMessage[]): number {
-    throw new Error("Method not implemented.");
   }
 
   get metadata(): LLMMetadata {

--- a/packages/core/src/llm/base.ts
+++ b/packages/core/src/llm/base.ts
@@ -1,5 +1,4 @@
 import type {
-  ChatMessage,
   ChatResponse,
   ChatResponseChunk,
   CompletionResponse,
@@ -48,6 +47,4 @@ export abstract class BaseLLM implements LLM {
     params: LLMChatParamsStreaming,
   ): Promise<AsyncIterable<ChatResponseChunk>>;
   abstract chat(params: LLMChatParamsNonStreaming): Promise<ChatResponse>;
-
-  abstract tokens(messages: ChatMessage[]): number;
 }

--- a/packages/core/src/llm/mistral.ts
+++ b/packages/core/src/llm/mistral.ts
@@ -81,10 +81,6 @@ export class MistralAI extends BaseLLM {
     };
   }
 
-  tokens(messages: ChatMessage[]): number {
-    throw new Error("Method not implemented.");
-  }
-
   private buildParams(messages: ChatMessage[]): any {
     return {
       model: this.model,

--- a/packages/core/src/llm/ollama.ts
+++ b/packages/core/src/llm/ollama.ts
@@ -2,7 +2,6 @@ import { ok } from "@llamaindex/env";
 import type { Event } from "../callbacks/CallbackManager.js";
 import { BaseEmbedding } from "../embeddings/types.js";
 import type {
-  ChatMessage,
   ChatResponse,
   ChatResponseChunk,
   CompletionResponse,
@@ -180,10 +179,6 @@ export class Ollama extends BaseEmbedding implements LLM {
       ok(stream instanceof ReadableStream, "stream is not readable");
       return this.streamChat(stream, completionAccessor, parentEvent);
     }
-  }
-
-  tokens(messages: ChatMessage[]): number {
-    throw new Error("Method not implemented.");
   }
 
   private async getEmbedding(prompt: string): Promise<number[]> {

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -59,11 +59,6 @@ export interface LLM extends LLMChat {
   complete(
     params: LLMCompletionParamsNonStreaming,
   ): Promise<CompletionResponse>;
-
-  /**
-   * Calculates the number of tokens needed for the given chat messages
-   */
-  tokens(messages: ChatMessage[]): number;
 }
 
 export type MessageType =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       dotenv:
         specifier: ^16.4.1
         version: 16.4.1
+      js-tiktoken:
+        specifier: ^1.0.10
+        version: 1.0.10
       llamaindex:
         specifier: latest
         version: link:../packages/core


### PR DESCRIPTION
Closes: https://github.com/run-llama/LlamaIndexTS/pull/667, https://github.com/run-llama/LlamaIndexTS/issues/664

I'm removing this API since most of the LLM classes don't have an accurate function (only OpenAI supports it), and there are runtime errors.

But I put code into `examples/recipes/cost-analysis.ts` to let users know how to implement it by theirselves.