### PR TITLE
fix: use LLM's context window to specify agent's token limit

### DIFF
--- a/examples/agent/wiki.ts
+++ b/examples/agent/wiki.ts
@@ -19,6 +19,7 @@ async function main() {
   console.log(response.response);
 }
 
-main().then(() => {
+(async function () {
+  await main();
   console.log("Done");
-});
+})();

--- a/examples/agent/wiki.ts
+++ b/examples/agent/wiki.ts
@@ -1,0 +1,24 @@
+import { OpenAI, OpenAIAgent, WikipediaTool } from "llamaindex";
+
+async function main() {
+  const llm = new OpenAI({ model: "gpt-4-turbo-preview" });
+  const wikiTool = new WikipediaTool();
+
+  // Create an OpenAIAgent with the Wikipedia tool
+  const agent = new OpenAIAgent({
+    llm,
+    tools: [wikiTool],
+    verbose: true,
+  });
+
+  // Chat with the agent
+  const response = await agent.chat({
+    message: "Who was Goethe?",
+  });
+
+  console.log(response.response);
+}
+
+main().then(() => {
+  console.log("Done");
+});

--- a/packages/core/src/agent/openai/base.ts
+++ b/packages/core/src/agent/openai/base.ts
@@ -64,6 +64,7 @@ export class OpenAIAgent extends AgentRunner {
 
     super({
       agentWorker: stepEngine,
+      llm,
       memory,
       defaultToolChoice,
       chatHistory: prefixMessages,

--- a/packages/core/src/agent/openai/worker.ts
+++ b/packages/core/src/agent/openai/worker.ts
@@ -286,7 +286,9 @@ export class OpenAIAgentWorker implements AgentWorker {
   initializeStep(task: Task, kwargs?: any): TaskStep {
     const sources: ToolOutput[] = [];
 
-    const newMemory = new ChatMemoryBuffer();
+    const newMemory = new ChatMemoryBuffer({
+      tokenLimit: task.memory.tokenLimit,
+    });
 
     const taskState = {
       sources,

--- a/packages/core/src/agent/react/worker.ts
+++ b/packages/core/src/agent/react/worker.ts
@@ -106,7 +106,9 @@ export class ReActAgentWorker implements AgentWorker {
   initializeStep(task: Task, kwargs?: any): TaskStep {
     const sources: ToolOutput[] = [];
     const currentReasoning: BaseReasoningStep[] = [];
-    const newMemory = new ChatMemoryBuffer();
+    const newMemory = new ChatMemoryBuffer({
+      tokenLimit: task.memory.tokenLimit,
+    });
 
     const taskState = {
       sources,

--- a/packages/core/src/agent/runner/base.ts
+++ b/packages/core/src/agent/runner/base.ts
@@ -58,6 +58,7 @@ export class AgentRunner extends BaseAgentRunner {
     this.memory =
       params.memory ??
       new ChatMemoryBuffer({
+        llm: params.llm,
         chatHistory: params.chatHistory,
       });
     this.initTaskStateKwargs = params.initTaskStateKwargs ?? {};

--- a/packages/core/src/memory/ChatMemoryBuffer.ts
+++ b/packages/core/src/memory/ChatMemoryBuffer.ts
@@ -1,13 +1,17 @@
-import type { ChatMessage } from "../llm/index.js";
+import type { ChatMessage, LLM } from "../llm/index.js";
 import { SimpleChatStore } from "../storage/chatStore/SimpleChatStore.js";
 import type { BaseChatStore } from "../storage/chatStore/types.js";
 import type { BaseMemory } from "./types.js";
+
+const DEFAULT_TOKEN_LIMIT_RATIO = 0.75;
+const DEFAULT_TOKEN_LIMIT = 3000;
 
 type ChatMemoryBufferParams = {
   tokenLimit?: number;
   chatStore?: BaseChatStore;
   chatStoreKey?: string;
   chatHistory?: ChatMessage[];
+  llm?: LLM;
 };
 
 /**
@@ -23,9 +27,16 @@ export class ChatMemoryBuffer implements BaseMemory {
    * Initialize.
    */
   constructor(init?: Partial<ChatMemoryBufferParams>) {
-    this.tokenLimit = init?.tokenLimit ?? 3000;
     this.chatStore = init?.chatStore ?? new SimpleChatStore();
     this.chatStoreKey = init?.chatStoreKey ?? "chat_history";
+    if (init?.llm) {
+      const contextWindow = init.llm.metadata.contextWindow;
+      this.tokenLimit =
+        init?.tokenLimit ??
+        Math.ceil(contextWindow * DEFAULT_TOKEN_LIMIT_RATIO);
+    } else {
+      this.tokenLimit = init?.tokenLimit ?? DEFAULT_TOKEN_LIMIT;
+    }
 
     if (init?.chatHistory) {
       this.chatStore.setMessages(this.chatStoreKey, init.chatHistory);

--- a/packages/core/src/memory/ChatMemoryBuffer.ts
+++ b/packages/core/src/memory/ChatMemoryBuffer.ts
@@ -60,7 +60,7 @@ export class ChatMemoryBuffer implements BaseMemory {
 
     while (tokenCount > this.tokenLimit && messageCount > 1) {
       messageCount -= 1;
-      if (chatHistory[-messageCount].role === "assistant") {
+      if (chatHistory.at(-messageCount)?.role === "assistant") {
         // we cannot have an assistant message at the start of the chat history
         // if after removal of the first, we have an assistant message,
         // we need to remove the assistant message too


### PR DESCRIPTION
I found this issue while testing the `WikipediaTool,` which quickly fills up the agent's memory (see `examples/agent/wiki.ts`).
The default token limit of `ChatMemoryBuffer` is too small for LLMs with larger context windows. 
So it's a good idea to use one that's specific to the selected LLM.