### PR TITLE
refactor: VectorStoreIndex: use TransformerComponent to calc embeddings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If you need any of those classes, you have to import them instead directly. Here
 import { PineconeVectorStore } from "@llamaindex/edge/storage/vectorStore/PineconeVectorStore";
 ```
 
-As the `PDFReader` is not with the Edge runtime, here's how to use the `SimpleDirectoryReader` with the `LlamaParseReader` to load PDFs:
+As the `PDFReader` is not working with the Edge runtime, here's how to use the `SimpleDirectoryReader` with the `LlamaParseReader` to load PDFs:
 
 ```typescript
 import { SimpleDirectoryReader } from "@llamaindex/edge/readers/SimpleDirectoryReader";

--- a/examples/multimodal/load.ts
+++ b/examples/multimodal/load.ts
@@ -4,6 +4,7 @@ import {
   VectorStoreIndex,
   storageContextFromDefaults,
 } from "llamaindex";
+import { DocStoreStrategy } from "llamaindex/ingestion/strategies/index";
 
 import * as path from "path";
 
@@ -31,6 +32,7 @@ async function generateDatasource() {
     });
     await VectorStoreIndex.fromDocuments(documents, {
       storageContext,
+      docStoreStrategy: DocStoreStrategy.NONE,
     });
   });
   console.log(`Storage successfully generated in ${ms / 1000}s.`);

--- a/packages/core/e2e/fixtures/embeddings/OpenAIEmbedding.ts
+++ b/packages/core/e2e/fixtures/embeddings/OpenAIEmbedding.ts
@@ -28,6 +28,7 @@ export class OpenAIEmbedding implements BaseEmbedding {
   }
 
   async transform(nodes: BaseNode[], _options?: any): Promise<BaseNode[]> {
+    nodes.forEach((node) => (node.embedding = [0]));
     return nodes;
   }
 }

--- a/packages/core/src/embeddings/MultiModalEmbedding.ts
+++ b/packages/core/src/embeddings/MultiModalEmbedding.ts
@@ -1,4 +1,9 @@
-import type { ImageType } from "../Node.js";
+import {
+  MetadataMode,
+  splitNodesByType,
+  type BaseNode,
+  type ImageType,
+} from "../Node.js";
 import { BaseEmbedding } from "./types.js";
 
 /*
@@ -8,9 +13,37 @@ import { BaseEmbedding } from "./types.js";
 export abstract class MultiModalEmbedding extends BaseEmbedding {
   abstract getImageEmbedding(images: ImageType): Promise<number[]>;
 
+  /**
+   * Optionally override this method to retrieve multiple image embeddings in a single request
+   * @param texts
+   */
   async getImageEmbeddings(images: ImageType[]): Promise<number[][]> {
     return Promise.all(
       images.map((imgFilePath) => this.getImageEmbedding(imgFilePath)),
     );
+  }
+
+  async transform(nodes: BaseNode[], _options?: any): Promise<BaseNode[]> {
+    const { imageNodes, textNodes } = splitNodesByType(nodes);
+
+    const embeddings = await this.batchEmbeddings(
+      textNodes.map((node) => node.getContent(MetadataMode.EMBED)),
+      this.getTextEmbeddings.bind(this),
+      _options,
+    );
+    for (let i = 0; i < textNodes.length; i++) {
+      textNodes[i].embedding = embeddings[i];
+    }
+
+    const imageEmbeddings = await this.batchEmbeddings(
+      imageNodes.map((n) => n.image),
+      this.getImageEmbeddings.bind(this),
+      _options,
+    );
+    for (let i = 0; i < imageNodes.length; i++) {
+      imageNodes[i].embedding = imageEmbeddings[i];
+    }
+
+    return nodes;
   }
 }

--- a/packages/core/src/embeddings/MultiModalEmbedding.ts
+++ b/packages/core/src/embeddings/MultiModalEmbedding.ts
@@ -4,7 +4,7 @@ import {
   type BaseNode,
   type ImageType,
 } from "../Node.js";
-import { BaseEmbedding } from "./types.js";
+import { BaseEmbedding, batchEmbeddings } from "./types.js";
 
 /*
  * Base class for Multi Modal embeddings.
@@ -26,18 +26,20 @@ export abstract class MultiModalEmbedding extends BaseEmbedding {
   async transform(nodes: BaseNode[], _options?: any): Promise<BaseNode[]> {
     const { imageNodes, textNodes } = splitNodesByType(nodes);
 
-    const embeddings = await this.batchEmbeddings(
+    const embeddings = await batchEmbeddings(
       textNodes.map((node) => node.getContent(MetadataMode.EMBED)),
       this.getTextEmbeddings.bind(this),
+      this.embedBatchSize,
       _options,
     );
     for (let i = 0; i < textNodes.length; i++) {
       textNodes[i].embedding = embeddings[i];
     }
 
-    const imageEmbeddings = await this.batchEmbeddings(
+    const imageEmbeddings = await batchEmbeddings(
       imageNodes.map((n) => n.image),
       this.getImageEmbeddings.bind(this),
+      this.embedBatchSize,
       _options,
     );
     for (let i = 0; i < imageNodes.length; i++) {


### PR DESCRIPTION
Refactor VectorStoreIndex: use `TransformerComponent` to calc embeddings (for image nodes and non-image nodes)