### PR TITLE
fix: use Array.prototype.flat instead of Array.prototype.push(...spread)

### DIFF
--- a/packages/core/src/ingestion/IngestionPipeline.ts
+++ b/packages/core/src/ingestion/IngestionPipeline.ts
@@ -94,20 +94,20 @@ export class IngestionPipeline {
     documents?: Document[],
     nodes?: BaseNode[],
   ): Promise<BaseNode[]> {
-    let inputNodes: BaseNode[] = [];
+    const inputNodes: BaseNode[][] = [];
     if (documents) {
-      inputNodes = inputNodes.concat(documents);
+      inputNodes.push(documents);
     }
     if (nodes) {
-      inputNodes = inputNodes.concat(nodes);
+      inputNodes.push(nodes);
     }
     if (this.documents) {
-      inputNodes = inputNodes.concat(this.documents);
+      inputNodes.push(this.documents);
     }
     if (this.reader) {
-      inputNodes = inputNodes.concat(await this.reader.loadData()));
+      inputNodes.push(await this.reader.loadData());
     }
-    return inputNodes;
+    return inputNodes.flat();
   }
 
   async run(

--- a/packages/core/src/ingestion/IngestionPipeline.ts
+++ b/packages/core/src/ingestion/IngestionPipeline.ts
@@ -94,18 +94,18 @@ export class IngestionPipeline {
     documents?: Document[],
     nodes?: BaseNode[],
   ): Promise<BaseNode[]> {
-    const inputNodes: BaseNode[] = [];
+    let inputNodes: BaseNode[] = [];
     if (documents) {
-      inputNodes.push(...documents);
+      inputNodes = inputNodes.concat(documents);
     }
     if (nodes) {
-      inputNodes.push(...nodes);
+      inputNodes = inputNodes.concat(nodes);
     }
     if (this.documents) {
-      inputNodes.push(...this.documents);
+      inputNodes = inputNodes.concat(this.documents);
     }
     if (this.reader) {
-      inputNodes.push(...(await this.reader.loadData()));
+      inputNodes = inputNodes.concat(await this.reader.loadData()));
     }
     return inputNodes;
   }


### PR DESCRIPTION
if `reader.loadData` return large amount of documents, the `IngestionPipeline.prepareInput` will throw "RangeError: Maximum call stack size exceeded", use Array.concat to avoid it.