### PR TITLE
fix: use sha256 hash value as the Document id_ in MarkdownReader

### DIFF
--- a/packages/core/src/readers/MarkdownReader.ts
+++ b/packages/core/src/readers/MarkdownReader.ts
@@ -96,14 +96,14 @@ export class MarkdownReader implements FileReader {
     const tups = this.parseTups(content);
     const results: Document[] = [];
     for (const [header, value] of tups) {
+      const sha256 = createSHA256()
       if (header) {
-        results.push(
-          new Document({
-            text: `\n\n${header}\n${value}`,
-          }),
-        );
+        const text = `\n\n${header}\n${value}`;
+        sha256.update(text);
+        results.push(new Document({ text, id_: sha256.digest() }));
       } else {
-        results.push(new Document({ text: value }));
+        sha256.update(value);
+        results.push(new Document({ text: value, id_: sha256.digest() }));
       }
     }
     return results;


### PR DESCRIPTION
MarkdownReader uses randomUUID() as the id_, which invalidate DocStoreStrategy.UPSERTS and DocStoreStrategy.UPSERTS_AND_DELETE, check [here](https://github.com/run-llama/LlamaIndexTS/blob/74686f5776d4707815e1f3f761dabc5393b29779/packages/core/src/ingestion/strategies/classify.ts#L13).