### PR TITLE
fix(core): add more exports on `llm/index`

### DIFF
--- a/packages/core/e2e/fixtures/llm/anthropic.ts
+++ b/packages/core/e2e/fixtures/llm/anthropic.ts
@@ -1,3 +1,6 @@
 import { OpenAI } from "./openai.js";
 
 export class Anthropic extends OpenAI {}
+export const ALL_AVAILABLE_ANTHROPIC_LEGACY_MODELS = {};
+export const ALL_AVAILABLE_ANTHROPIC_MODELS = {};
+export const ALL_AVAILABLE_V3_MODELS = {};

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -1,5 +1,11 @@
-export { Anthropic } from "./anthropic.js";
+export {
+  ALL_AVAILABLE_ANTHROPIC_LEGACY_MODELS,
+  ALL_AVAILABLE_ANTHROPIC_MODELS,
+  ALL_AVAILABLE_V3_MODELS,
+  Anthropic,
+} from "./anthropic.js";
 export { FireworksLLM } from "./fireworks.js";
+export { GEMINI_MODEL, Gemini } from "./gemini.js";
 export { Groq } from "./groq.js";
 export {
   ALL_AVAILABLE_MISTRAL_MODELS,
@@ -10,12 +16,13 @@ export * from "./openai.js";
 export { Portkey } from "./portkey.js";
 export * from "./replicate_ai.js";
 // Note: The type aliases for replicate are to simplify usage for Llama 2 (we're using replicate for Llama 2 support)
-export { GEMINI_MODEL, Gemini } from "./gemini.js";
 export {
+  ALL_AVAILABLE_REPLICATE_MODELS,
   DeuceChatStrategy,
   LlamaDeuce,
   ReplicateChatStrategy,
   ReplicateLLM,
+  ReplicateSession,
 } from "./replicate_ai.js";
 export { TogetherLLM } from "./together.js";
 export * from "./types.js";


### PR DESCRIPTION
@marcusschiesser @himself65 why did we move away from just export * from every file in the directory? Is there a benefit to doing so? Clear downside is that we'll often forget to re-export things.