### PR TITLE
fix: remove clone object in `CallbackManager.dispatchEvent`

### DIFF
--- a/.changeset/six-needles-poke.md
+++ b/.changeset/six-needles-poke.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: remove clone object in `CallbackManager.dispatchEvent`

--- a/packages/core/src/callbacks/CallbackManager.ts
+++ b/packages/core/src/callbacks/CallbackManager.ts
@@ -212,10 +212,13 @@ export class CallbackManager implements CallbackManagerMethods {
     if (!handlers) {
       return;
     }
-    const clone = structuredClone(detail);
     queueMicrotask(() => {
       handlers.forEach((handler) =>
-        handler(LlamaIndexCustomEvent.fromEvent(event, clone)),
+        handler(
+          LlamaIndexCustomEvent.fromEvent(event, {
+            ...detail,
+          }),
+        ),
       );
     });
   }


### PR DESCRIPTION
Here is a pitfall inside tool-call-result, it can return anything, so we cannot just clone the detail.

But here is another issue that you can modify value inside the callback manager, but I think no one will do it