### PR TITLE
feat: allow to change ollama port

### DIFF
--- a/.changeset/brown-suits-thank.md
+++ b/.changeset/brown-suits-thank.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+feat: allow change host of ollama

--- a/.changeset/itchy-paws-love.md
+++ b/.changeset/itchy-paws-love.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+chore: export ollama in default js runtime

--- a/examples/ollama.ts
+++ b/examples/ollama.ts
@@ -2,7 +2,12 @@ import { OllamaEmbedding } from "llamaindex";
 import { Ollama } from "llamaindex/llm/ollama";
 
 (async () => {
-  const llm = new Ollama({ model: "llama3" });
+  const llm = new Ollama({
+    model: "llama3",
+    config: {
+      host: "http://localhost:11434",
+    },
+  });
   const embedModel = new OllamaEmbedding({ model: "nomic-embed-text" });
   {
     const response = await llm.chat({

--- a/packages/core/src/embeddings/index.ts
+++ b/packages/core/src/embeddings/index.ts
@@ -2,6 +2,7 @@ export * from "./GeminiEmbedding.js";
 export * from "./JinaAIEmbedding.js";
 export * from "./MistralAIEmbedding.js";
 export * from "./MultiModalEmbedding.js";
+export { OllamaEmbedding } from "./OllamaEmbedding.js";
 export * from "./OpenAIEmbedding.js";
 export { FireworksEmbedding } from "./fireworks.js";
 export { TogetherEmbedding } from "./together.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,5 +10,3 @@ export {
   HuggingFaceEmbedding,
   HuggingFaceEmbeddingModelType,
 } from "./embeddings/HuggingFaceEmbedding.js";
-export { OllamaEmbedding } from "./embeddings/OllamaEmbedding.js";
-export { Ollama, type OllamaParams } from "./llm/ollama.js";

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -17,6 +17,7 @@ export * from "./openai.js";
 export { Portkey } from "./portkey.js";
 export * from "./replicate_ai.js";
 // Note: The type aliases for replicate are to simplify usage for Llama 2 (we're using replicate for Llama 2 support)
+export { Ollama, type OllamaParams } from "./ollama.js";
 export {
   ALL_AVAILABLE_REPLICATE_MODELS,
   DeuceChatStrategy,


### PR DESCRIPTION
Allow user to change `host` of ollama

I realized that ollama might could be used in all js runtime even you are deploying it (maybe), so I export it for all js runtime by default