### PR TITLE
fix: PGVector similarity score

### DIFF
--- a/packages/core/src/storage/vectorStore/PGVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/PGVectorStore.ts
@@ -292,14 +292,10 @@ export class PGVectorStore implements VectorStore {
       });
     });
 
-    let similarities = undefined;
-    if (results && results.rows && results.rows.length > 0) {
-        similarities = results.rows.map((row) => 1 - row.s);
-    } 
     const ret = {
-        nodes: nodes,
-        similarities: similarities,
-        ids: results.rows.map((row)=>row.id)
+      nodes: nodes,
+      similarities: results.rows.map((row) => 1 - row.s),
+      ids: results.rows.map((row)=>row.id)
     };
 
     return Promise.resolve(ret);

--- a/packages/core/src/storage/vectorStore/PGVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/PGVectorStore.ts
@@ -295,7 +295,7 @@ export class PGVectorStore implements VectorStore {
     const ret = {
       nodes: nodes,
       similarities: results.rows.map((row) => 1 - row.s),
-      ids: results.rows.map((row)=>row.id)
+      ids: results.rows.map((row) => row.id),
     };
 
     return Promise.resolve(ret);

--- a/packages/core/src/storage/vectorStore/PGVectorStore.ts
+++ b/packages/core/src/storage/vectorStore/PGVectorStore.ts
@@ -292,10 +292,14 @@ export class PGVectorStore implements VectorStore {
       });
     });
 
+    let similarities = undefined;
+    if (results && results.rows && results.rows.length > 0) {
+        similarities = results.rows.map((row) => 1 - row.s);
+    } 
     const ret = {
-      nodes: nodes,
-      similarities: results.rows.map((row) => row.s),
-      ids: results.rows.map((row) => row.id),
+        nodes: nodes,
+        similarities: similarities,
+        ids: results.rows.map((row)=>row.id)
     };
 
     return Promise.resolve(ret);


### PR DESCRIPTION
Similarity score should be 1 minus the resulting value from the PG cosine distance. This change now matches with the Python package.