### PR TITLE
fix: Gemini text chat - prevent sending broken messageContent and history

### DIFF
--- a/.changeset/sharp-knives-ring.md
+++ b/.changeset/sharp-knives-ring.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+Improve Gemini message and context preparation

--- a/packages/core/src/Prompt.ts
+++ b/packages/core/src/Prompt.ts
@@ -371,6 +371,7 @@ export function messagesToHistoryStr(messages: ChatMessage[]) {
 }
 
 export const defaultContextSystemPrompt = ({ context = "" }) => {
+  if (!context) return "";
   return `Context information is below.
 ---------------------
 ${context}

--- a/packages/core/src/llm/index.ts
+++ b/packages/core/src/llm/index.ts
@@ -5,7 +5,7 @@ export {
   Anthropic,
 } from "./anthropic.js";
 export { FireworksLLM } from "./fireworks.js";
-export { GEMINI_MODEL, Gemini } from "./gemini.js";
+export { GEMINI_MODEL, Gemini, GeminiSession } from "./gemini.js";
 export { Groq } from "./groq.js";
 export { HuggingFaceInferenceAPI } from "./huggingface.js";
 export {


### PR DESCRIPTION
Gemini was completely broken for text chat and was getting confused when prompted with an empty context.

It is still broken for vision. Currently the `mimeType` is incorrect and `inlineData` isn't taken into account. Will submit a separate PR to address.