### PR TITLE
chore: rollback chromadb version to 1.7.3

### DIFF
--- a/.changeset/wet-boxes-compete.md
+++ b/.changeset/wet-boxes-compete.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+Force ChromaDB version to 1.7.3 (to prevent NextJS issues)

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,7 @@
     "@notionhq/client": "^2.2.15",
     "@pinecone-database/pinecone": "^2.2.0",
     "@zilliz/milvus2-sdk-node": "^2.4.2",
-    "chromadb": "^1.8.1",
+    "chromadb": "^1.7.3",
     "commander": "^12.0.0",
     "dotenv": "^16.4.5",
     "js-tiktoken": "^1.0.11",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "@zilliz/milvus2-sdk-node": "^2.4.2",
     "ajv": "^8.13.0",
     "assemblyai": "^4.4.2",
-    "chromadb": "~1.8.1",
+    "chromadb": "~1.7.3",
     "cohere-ai": "^7.9.5",
     "js-tiktoken": "^1.0.11",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       chromadb:
-        specifier: ^1.8.1
-        version: 1.8.1(@google/generative-ai@0.11.0)(cohere-ai@7.9.5(encoding@0.1.13))(encoding@0.1.13)(openai@4.46.0(encoding@0.1.13))
+        specifier: ^1.7.3
+        version: 1.7.3(@google/generative-ai@0.11.0)(cohere-ai@7.9.5(encoding@0.1.13))(encoding@0.1.13)(openai@4.46.0(encoding@0.1.13))
       commander:
         specifier: ^12.0.0
         version: 12.0.0
@@ -386,8 +386,8 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
       chromadb:
-        specifier: ~1.8.1
-        version: 1.8.1(@google/generative-ai@0.11.0)(cohere-ai@7.9.5(encoding@0.1.13))(encoding@0.1.13)(openai@4.46.0(encoding@0.1.13))
+        specifier: ~1.7.3
+        version: 1.7.3(@google/generative-ai@0.11.0)(cohere-ai@7.9.5(encoding@0.1.13))(encoding@0.1.13)(openai@4.46.0(encoding@0.1.13))
       cohere-ai:
         specifier: ^7.9.5
         version: 7.9.5(encoding@0.1.13)
@@ -4075,8 +4075,8 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  chromadb@1.8.1:
-    resolution: {integrity: sha512-NpbYydbg4Uqt/9BXKgkZXn0fqpsh2Z1yjhkhKH+rcHMoq0pwI18BFSU2QU7Fk/ZypwGefW2AvqyE/3ZJIgy4QA==}
+  chromadb@1.7.3:
+    resolution: {integrity: sha512-3GgvQjpqgk5C89x5EuTDaXKbfrdqYDJ5UVyLQ3ZmwxnpetNc+HhRDGjkvXa5KSvpQ3lmKoyDoqnN4tZepfFkbw==}
     engines: {node: '>=14.17.0'}
     peerDependencies:
       '@google/generative-ai': ^0.1.1
@@ -14166,7 +14166,7 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  chromadb@1.8.1(@google/generative-ai@0.11.0)(cohere-ai@7.9.5(encoding@0.1.13))(encoding@0.1.13)(openai@4.46.0(encoding@0.1.13)):
+  chromadb@1.7.3(@google/generative-ai@0.11.0)(cohere-ai@7.9.5(encoding@0.1.13))(encoding@0.1.13)(openai@4.46.0(encoding@0.1.13)):
     dependencies:
       cliui: 8.0.1
       isomorphic-fetch: 3.0.0(encoding@0.1.13)


### PR DESCRIPTION
Because chromadb haven't released a newer version from 1.8.1 yet so we still have the issue mentioned in: https://github.com/run-llama/LlamaIndexTS/pull/417
This PR downgrades the chromadb package to 1.7.3 again