### PR TITLE
fix: truncate long document

### DIFF
--- a/packages/core/src/Node.ts
+++ b/packages/core/src/Node.ts
@@ -1,5 +1,6 @@
 import { createSHA256, path, randomUUID } from "@llamaindex/env";
 import _ from "lodash";
+import { Settings } from "./Settings.js";
 
 export enum NodeRelationship {
   SOURCE = "SOURCE",
@@ -208,7 +209,14 @@ export class TextNode<T extends Metadata = Metadata> extends BaseNode<T> {
 
   getContent(metadataMode: MetadataMode = MetadataMode.NONE): string {
     const metadataStr = this.getMetadataStr(metadataMode).trim();
-    return `${metadataStr}\n\n${this.text}`.trim();
+    const fullText = `${metadataStr}\n\n${this.text}`.trim();
+    if (Settings.chunkSize) {
+      if (fullText.length > Settings.chunkSize) {
+        console.warn(`Content ${this.id_} is too long, truncating`);
+        return this.text.slice(0, Settings.chunkSize);
+      }
+    }
+    return fullText;
   }
 
   getMetadataStr(metadataMode: MetadataMode): string {

--- a/packages/core/src/readers/SimpleDirectoryReader.edge.ts
+++ b/packages/core/src/readers/SimpleDirectoryReader.edge.ts
@@ -1,5 +1,5 @@
-import { fs, path } from "@llamaindex/env";
-import { Document, type Metadata } from "../Node.js";
+import { path } from "@llamaindex/env";
+import { Document } from "../Node.js";
 import { walk } from "../storage/FileSystem.js";
 import { TextFileReader } from "./TextFileReader.js";
 import type { BaseReader } from "./type.js";
@@ -85,7 +85,7 @@ export class SimpleDirectoryReader implements BaseReader {
           continue;
         }
 
-        const fileDocs = await reader.loadData(filePath, fs);
+        const fileDocs = await reader.loadData(filePath);
         fileDocs.forEach(addMetaData(filePath));
 
         // Observer can still cancel addition of the resulting docs from this file
@@ -123,8 +123,8 @@ export class SimpleDirectoryReader implements BaseReader {
   }
 }
 
-function addMetaData(filePath: string): (doc: Document<Metadata>) => void {
-  return (doc: Document<Metadata>) => {
+function addMetaData(filePath: string): (doc: Document) => void {
+  return (doc: Document) => {
     doc.metadata["file_path"] = path.resolve(filePath);
     doc.metadata["file_name"] = path.basename(filePath);
   };


### PR DESCRIPTION
Fixes: https://github.com/run-llama/LlamaIndexTS/issues/836

There are some possible ways to solve that issue.

1. force split text right before embedding

This is not what the user expected, and must lose much of infos

2. Split documents inside of each loader.

Good, but it still will overflow the chunk size since metadata may overflow the chunk size.
