### PR TITLE
feat: improve BaseNode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,7 @@ jobs:
       - name: Run Type Check
         run: pnpm run type-check
       - name: Run Circular Dependency Check
-        run: pnpm run circular-check
-        working-directory: ./packages/core
+        run: pnpm dlx turbo run circular-check
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-react": "7.34.1",
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
+    "madge": "^7.0.0",
     "prettier": "^3.2.5",
     "prettier-plugin-organize-imports": "^3.2.4",
     "turbo": "^1.13.3",

--- a/packages/core/.madgerc
+++ b/packages/core/.madgerc
@@ -1,0 +1,7 @@
+{
+	"detectiveOptions": {
+		"ts": {
+			"skipTypeImports": true
+		}
+	}
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,6 @@
     "@swc/core": "^1.5.5",
     "concurrently": "^8.2.2",
     "glob": "^10.3.12",
-    "madge": "^7.0.0",
     "typescript": "^5.4.5"
   },
   "engines": {

--- a/packages/core/src/Settings.ts
+++ b/packages/core/src/Settings.ts
@@ -13,6 +13,11 @@ import {
   setCallbackManager,
   withCallbackManager,
 } from "./internal/settings/CallbackManager.js";
+import {
+  getChunkSize,
+  setChunkSize,
+  withChunkSize,
+} from "./internal/settings/chunk-size.js";
 import type { LLM } from "./llm/types.js";
 import type { NodeParser } from "./nodeParsers/types.js";
 
@@ -41,14 +46,12 @@ class GlobalSettings implements Config {
   #promptHelper: PromptHelper | null = null;
   #embedModel: BaseEmbedding | null = null;
   #nodeParser: NodeParser | null = null;
-  #chunkSize?: number;
   #chunkOverlap?: number;
 
   #llmAsyncLocalStorage = new AsyncLocalStorage<LLM>();
   #promptHelperAsyncLocalStorage = new AsyncLocalStorage<PromptHelper>();
   #embedModelAsyncLocalStorage = new AsyncLocalStorage<BaseEmbedding>();
   #nodeParserAsyncLocalStorage = new AsyncLocalStorage<NodeParser>();
-  #chunkSizeAsyncLocalStorage = new AsyncLocalStorage<number>();
   #chunkOverlapAsyncLocalStorage = new AsyncLocalStorage<number>();
   #promptAsyncLocalStorage = new AsyncLocalStorage<PromptConfig>();
 
@@ -115,8 +118,8 @@ class GlobalSettings implements Config {
   get nodeParser(): NodeParser {
     if (this.#nodeParser === null) {
       this.#nodeParser = new SimpleNodeParser({
-        chunkSize: this.#chunkSize,
-        chunkOverlap: this.#chunkOverlap,
+        chunkSize: this.chunkSize,
+        chunkOverlap: this.chunkOverlap,
       });
     }
 
@@ -147,15 +150,15 @@ class GlobalSettings implements Config {
   }
 
   set chunkSize(chunkSize: number | undefined) {
-    this.#chunkSize = chunkSize;
+    setChunkSize(chunkSize);
   }
 
   get chunkSize(): number | undefined {
-    return this.#chunkSizeAsyncLocalStorage.getStore() ?? this.#chunkSize;
+    return getChunkSize();
   }
 
   withChunkSize<Result>(chunkSize: number, fn: () => Result): Result {
-    return this.#chunkSizeAsyncLocalStorage.run(chunkSize, fn);
+    return withChunkSize(chunkSize, fn);
   }
 
   get chunkOverlap(): number | undefined {

--- a/packages/core/src/indices/vectorStore/index.ts
+++ b/packages/core/src/indices/vectorStore/index.ts
@@ -311,7 +311,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
     // NOTE: if the vector store keeps text,
     // we only need to add image and index nodes
     for (let i = 0; i < nodes.length; ++i) {
-      const type = nodes[i].getType();
+      const { type } = nodes[i];
       if (
         !vectorStore.storesText ||
         type === ObjectType.INDEX ||

--- a/packages/core/src/internal/decorator/node.ts
+++ b/packages/core/src/internal/decorator/node.ts
@@ -41,11 +41,10 @@ export function lazyInitHash(
   value: ClassAccessorDecoratorTarget<BaseNode, string>,
   _context: ClassAccessorDecoratorContext,
 ): ClassAccessorDecoratorResult<BaseNode, string> {
-  let initialized = false;
   return {
     get() {
-      if (!initialized) {
-        initialized = true;
+      const oldValue = value.get.call(this);
+      if (oldValue === "") {
         const hash = this.generateHash();
         value.set.call(this, hash);
       }
@@ -53,12 +52,8 @@ export function lazyInitHash(
     },
     set(newValue: string) {
       value.set.call(this, newValue);
-      initialized = true;
     },
     init(value: string): string {
-      if (value !== "") {
-        initialized = true;
-      }
       return value;
     },
   };

--- a/packages/core/src/internal/decorator/node.ts
+++ b/packages/core/src/internal/decorator/node.ts
@@ -1,0 +1,65 @@
+import { getEnv } from "@llamaindex/env";
+import type { BaseNode } from "../../Node.js";
+import { getChunkSize } from "../settings/chunk-size.js";
+
+const emitOnce = false;
+
+export function chunkSizeCheck(
+  contentGetter: () => string,
+  _context: ClassMethodDecoratorContext | ClassGetterDecoratorContext,
+) {
+  return function <Node extends BaseNode>(this: Node) {
+    const content = contentGetter.call(this);
+    const chunkSize = getChunkSize();
+    const enableChunkSizeCheck = getEnv("ENABLE_CHUNK_SIZE_CHECK") === "true";
+    if (
+      enableChunkSizeCheck &&
+      chunkSize !== undefined &&
+      content.length > chunkSize
+    ) {
+      console.warn(
+        `Node (${this.id_}) is larger than chunk size: ${content.length}`,
+      );
+      if (!emitOnce) {
+        console.warn(
+          "Will truncate the content if it is larger than chunk size",
+        );
+        console.warn("If you want to disable this behavior:");
+        console.warn("  1. Set Settings.chunkSize = undefined");
+        console.warn("  2. Set Settings.chunkSize to a larger value");
+        console.warn(
+          "  3. Change the way of splitting content into smaller chunks",
+        );
+      }
+      return content.slice(0, chunkSize);
+    }
+    return content;
+  };
+}
+
+export function lazyInitHash(
+  value: ClassAccessorDecoratorTarget<BaseNode, string>,
+  _context: ClassAccessorDecoratorContext,
+): ClassAccessorDecoratorResult<BaseNode, string> {
+  let initialized = false;
+  return {
+    get() {
+      if (!initialized) {
+        initialized = true;
+        const hash = this.generateHash();
+        value.set.call(this, hash);
+      }
+      return value.get.call(this);
+    },
+    set(newValue: string) {
+      value.set.call(this, newValue);
+      initialized = true;
+    },
+    init(value: string): string {
+      if (value !== "") {
+        initialized = true;
+      }
+      return value;
+    },
+  };
+}

--- a/packages/core/src/internal/settings/chunk-size.ts
+++ b/packages/core/src/internal/settings/chunk-size.ts
@@ -1,0 +1,19 @@
+import { AsyncLocalStorage } from "@llamaindex/env";
+
+const chunkSizeAsyncLocalStorage = new AsyncLocalStorage<number | undefined>();
+const globalChunkSize: number | null = null;
+
+export function getChunkSize(): number | undefined {
+  return globalChunkSize ?? chunkSizeAsyncLocalStorage.getStore();
+}
+
+export function setChunkSize(chunkSize: number | undefined) {
+  chunkSizeAsyncLocalStorage.enterWith(chunkSize);
+}
+
+export function withChunkSize<Result>(
+  embeddedModel: number,
+  fn: () => Result,
+): Result {
+  return chunkSizeAsyncLocalStorage.run(embeddedModel, fn);
+}

--- a/packages/core/src/storage/docStore/KVDocumentStore.ts
+++ b/packages/core/src/storage/docStore/KVDocumentStore.ts
@@ -30,6 +30,8 @@ export class KVDocumentStore extends BaseDocumentStore {
       const value = jsonDict[key];
       if (isValidDocJson(value)) {
         docs[key] = jsonToDoc(value);
+      } else {
+        console.warn(`Invalid JSON for docId ${key}`);
       }
     }
     return docs;

--- a/packages/core/src/storage/docStore/utils.ts
+++ b/packages/core/src/storage/docStore/utils.ts
@@ -4,14 +4,28 @@ import { Document, ObjectType, TextNode } from "../../Node.js";
 const TYPE_KEY = "__type__";
 const DATA_KEY = "__data__";
 
-export function docToJson(doc: BaseNode): Record<string, any> {
+type DocJson = {
+  [TYPE_KEY]: ObjectType;
+  [DATA_KEY]: string;
+};
+
+export function isValidDocJson(docJson: any): docJson is DocJson {
+  return (
+    typeof docJson === "object" &&
+    docJson !== null &&
+    docJson[TYPE_KEY] !== undefined &&
+    docJson[DATA_KEY] !== undefined
+  );
+}
+
+export function docToJson(doc: BaseNode): DocJson {
   return {
-    [DATA_KEY]: JSON.stringify(doc),
-    [TYPE_KEY]: doc.getType(),
+    [DATA_KEY]: JSON.stringify(doc.toJSON()),
+    [TYPE_KEY]: doc.type,
   };
 }
 
-export function jsonToDoc(docDict: Record<string, any>): BaseNode {
+export function jsonToDoc(docDict: DocJson): BaseNode {
   const docType = docDict[TYPE_KEY];
   const dataDict = JSON.parse(docDict[DATA_KEY]);
   let doc: BaseNode;

--- a/packages/core/tests/Embedding.test.ts
+++ b/packages/core/tests/Embedding.test.ts
@@ -1,8 +1,4 @@
-import {
-  OpenAIEmbedding,
-  SimilarityType,
-  similarity,
-} from "llamaindex/embeddings/index";
+import { OpenAIEmbedding, SimilarityType, similarity } from "llamaindex";
 import { beforeAll, describe, expect, test } from "vitest";
 import { mockEmbeddingModel } from "./utility/mockOpenAI.js";
 

--- a/packages/core/tests/Node.test.ts
+++ b/packages/core/tests/Node.test.ts
@@ -1,5 +1,25 @@
-import { TextNode } from "llamaindex/Node";
+import { Document, TextNode } from "llamaindex/Node";
 import { beforeEach, describe, expect, test } from "vitest";
+
+describe("Document", () => {
+  let document: Document;
+
+  beforeEach(() => {
+    document = new Document({ text: "Hello World" });
+  });
+
+  test("should generate a hash", () => {
+    expect(document.hash).toMatchInlineSnapshot(
+      `"oTzSyefxfMvXPvCh5d4kr8KULZ/huPO8cONeH0CDYvs="`,
+    );
+  });
+
+  test("clone should have the same hash", () => {
+    const hash = document.hash;
+    const clone = document.clone();
+    expect(clone.hash).toBe(hash);
+  });
+});
 
 describe("TextNode", () => {
   let node: TextNode;
@@ -16,5 +36,31 @@ describe("TextNode", () => {
     const hash = node.hash;
     const clone = node.clone();
     expect(clone.hash).toBe(hash);
+  });
+
+  test("node toJSON should keep the same", () => {
+    node.metadata.something = 1;
+    node.metadata.somethingElse = "2";
+    expect(node.toJSON()).toMatchInlineSnapshot(`
+      {
+        "embedding": undefined,
+        "endCharIdx": undefined,
+        "excludedEmbedMetadataKeys": [],
+        "excludedLlmMetadataKeys": [],
+        "hash": "aLQ8UsN9q6ConAsF6cVzCWtPSM3DSQhMQO2bg1O8RUQ=",
+        "id_": "caaeb1a1-fb5e-4f62-9d1d-ef2a484d2908",
+        "metadata": {
+          "something": 1,
+          "somethingElse": "2",
+        },
+        "metadataSeparator": "
+      ",
+        "relationships": {},
+        "startCharIdx": undefined,
+        "text": "Hello World",
+        "textTemplate": "",
+        "type": "TEXT",
+      }
+    `);
   });
 });

--- a/packages/core/tests/Node.test.ts
+++ b/packages/core/tests/Node.test.ts
@@ -10,7 +10,7 @@ describe("Document", () => {
 
   test("should generate a hash", () => {
     expect(document.hash).toMatchInlineSnapshot(
-      `"oTzSyefxfMvXPvCh5d4kr8KULZ/huPO8cONeH0CDYvs="`,
+      `"1mkNkQC30mZlBBG48DNuG2WSKcTQ32DImC+4JUoVijg="`,
     );
   });
 
@@ -29,7 +29,9 @@ describe("TextNode", () => {
   });
 
   test("should generate a hash", () => {
-    expect(node.hash).toBe("nTSKdUTYqR52MPv/brvb4RTGeqedTEqG9QN8KSAj2Do=");
+    expect(node.hash).toMatchInlineSnapshot(
+      `"nTSKdUTYqR52MPv/brvb4RTGeqedTEqG9QN8KSAj2Do="`,
+    );
   });
 
   test("clone should have the same hash", () => {
@@ -41,14 +43,18 @@ describe("TextNode", () => {
   test("node toJSON should keep the same", () => {
     node.metadata.something = 1;
     node.metadata.somethingElse = "2";
-    expect(node.toJSON()).toMatchInlineSnapshot(`
+    expect(node.toJSON()).toMatchInlineSnapshot(
+      {
+        id_: expect.any(String),
+      },
+      `
       {
         "embedding": undefined,
         "endCharIdx": undefined,
         "excludedEmbedMetadataKeys": [],
         "excludedLlmMetadataKeys": [],
-        "hash": "aLQ8UsN9q6ConAsF6cVzCWtPSM3DSQhMQO2bg1O8RUQ=",
-        "id_": "caaeb1a1-fb5e-4f62-9d1d-ef2a484d2908",
+        "hash": "nTSKdUTYqR52MPv/brvb4RTGeqedTEqG9QN8KSAj2Do=",
+        "id_": Any<String>,
         "metadata": {
           "something": 1,
           "somethingElse": "2",
@@ -61,6 +67,7 @@ describe("TextNode", () => {
         "textTemplate": "",
         "type": "TEXT",
       }
-    `);
+    `,
+    );
   });
 });

--- a/packages/core/tests/indices/VectorStoreIndex.test.ts
+++ b/packages/core/tests/indices/VectorStoreIndex.test.ts
@@ -15,7 +15,7 @@ const testDir = await mkdtemp(join(tmpdir(), "test-"));
 
 import { mockServiceContext } from "../utility/mockServiceContext.js";
 
-describe.sequential("VectorStoreIndex", () => {
+describe("VectorStoreIndex", () => {
   let serviceContext: ServiceContext;
   let storageContext: StorageContext;
   let testStrategy: (

--- a/packages/core/tests/indices/VectorStoreIndex.test.ts
+++ b/packages/core/tests/indices/VectorStoreIndex.test.ts
@@ -5,8 +5,7 @@ import {
   storageContextFromDefaults,
 } from "llamaindex";
 import { DocStoreStrategy } from "llamaindex/ingestion/strategies/index";
-import { rmSync } from "node:fs";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
@@ -57,7 +56,7 @@ describe("VectorStoreIndex", () => {
     expect(entries[0]).toBe(entries[1]);
   });
 
-  afterAll(() => {
-    rmSync(testDir, { recursive: true });
+  afterAll(async () => {
+    await rm(testDir, { recursive: true });
   });
 });

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -4,7 +4,11 @@
     "outDir": "./lib",
     "module": "node16",
     "moduleResolution": "node16",
-    "target": "ESNext"
+    "target": "ESNext",
+    "paths": {
+      "llamaindex": ["../src/index.ts"],
+      "llamaindex/*": ["../src/*"]
+    }
   },
   "include": ["./**/*.ts"],
   "references": [

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -4,11 +4,7 @@
     "outDir": "./lib",
     "module": "node16",
     "moduleResolution": "node16",
-    "target": "ESNext",
-    "paths": {
-      "llamaindex": ["../src/index.ts"],
-      "llamaindex/*": ["../src/*"]
-    }
+    "target": "ESNext"
   },
   "include": ["./**/*.ts"],
   "references": [

--- a/packages/env/.madgerc
+++ b/packages/env/.madgerc
@@ -1,0 +1,7 @@
+{
+	"detectiveOptions": {
+		"ts": {
+			"skipTypeImports": true
+		}
+	}
+}

--- a/packages/env/jsr.json
+++ b/packages/env/jsr.json
@@ -5,6 +5,6 @@
     ".": "./src/index.ts"
   },
   "publish": {
-    "include": ["LICENSE", "README.md", "src/**/*.ts", "jsr.json"]
+    "include": ["LICENSE", "README.md", "src/**/*", "jsr.json"]
   }
 }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -62,6 +62,7 @@
     "build:type": "tsc -p tsconfig.json",
     "postbuild": "node -e \"require('fs').writeFileSync('./dist/cjs/package.json', JSON.stringify({ type: 'commonjs' }))\"",
     "dev": "concurrently \"pnpm run build:esm --watch\" \"pnpm run build:cjs --watch\" \"pnpm run build:type --watch\"",
+    "circular-check": "madge -c ./src/index.ts",
     "test": "vitest"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       lint-staged:
         specifier: ^15.2.2
         version: 15.2.2
+      madge:
+        specifier: ^7.0.0
+        version: 7.0.0(typescript@5.4.5)
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -461,9 +464,6 @@ importers:
       glob:
         specifier: ^10.3.12
         version: 10.3.12
-      madge:
-        specifier: ^7.0.0
-        version: 7.0.0(typescript@5.4.5)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
     "test": {
       "dependsOn": ["^build"]
     },
+    "circular-check": {},
     "e2e": {
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
Not a breaking change. Related https://github.com/run-llama/LlamaIndexTS/issues/739

Update:
1. remove `Object.assign(this, init)` which is not a type-safe way.
2. put madge circular check on top level
3. adding more strong type check place