### PR TITLE
fix: remove non-standard API `pipeline`

### DIFF
--- a/.changeset/calm-owls-notice.md
+++ b/.changeset/calm-owls-notice.md
@@ -1,0 +1,6 @@
+---
+"llamaindex": patch
+"@llamaindex/env": patch
+---
+
+fix: remove non-standard API `pipeline`

--- a/packages/core/src/agent/base.ts
+++ b/packages/core/src/agent/base.ts
@@ -1,9 +1,4 @@
-import {
-  ReadableStream,
-  TransformStream,
-  pipeline,
-  randomUUID,
-} from "@llamaindex/env";
+import { ReadableStream, TransformStream, randomUUID } from "@llamaindex/env";
 import { Settings } from "../Settings.js";
 import {
   type ChatEngine,
@@ -340,46 +335,36 @@ export abstract class AgentRunner<
     | ReadableStream<AgentStreamChatResponse<AdditionalMessageOptions>>
   > {
     const task = this.createTask(params.message, !!params.stream);
-    const stepOutput = await pipeline(
-      task,
-      async (
-        iter: AsyncIterable<
-          TaskStepOutput<AI, Store, AdditionalMessageOptions>
-        >,
-      ) => {
-        for await (const stepOutput of iter) {
-          // update chat history for each round
-          this.#chatHistory = [...stepOutput.taskStep.context.store.messages];
-          if (stepOutput.isLast) {
-            return stepOutput;
-          }
-        }
-        throw new Error("Task did not complete");
-      },
-    );
-    const { output, taskStep } = stepOutput;
-    if (isAsyncIterable(output)) {
-      return output.pipeThrough<
-        AgentStreamChatResponse<AdditionalMessageOptions>
-      >(
-        new TransformStream({
-          transform(chunk, controller) {
-            controller.enqueue({
-              response: chunk,
-              get sources() {
-                return [...taskStep.context.store.toolOutputs];
+    for await (const stepOutput of task) {
+      // update chat history for each round
+      this.#chatHistory = [...stepOutput.taskStep.context.store.messages];
+      if (stepOutput.isLast) {
+        const { output, taskStep } = stepOutput;
+        if (isAsyncIterable(output)) {
+          return output.pipeThrough<
+            AgentStreamChatResponse<AdditionalMessageOptions>
+          >(
+            new TransformStream({
+              transform(chunk, controller) {
+                controller.enqueue({
+                  response: chunk,
+                  get sources() {
+                    return [...taskStep.context.store.toolOutputs];
+                  },
+                });
               },
-            });
-          },
-        }),
-      );
-    } else {
-      return {
-        response: output,
-        get sources() {
-          return [...taskStep.context.store.toolOutputs];
-        },
-      } satisfies AgentChatResponse<AdditionalMessageOptions>;
+            }),
+          );
+        } else {
+          return {
+            response: output,
+            get sources() {
+              return [...taskStep.context.store.toolOutputs];
+            },
+          } satisfies AgentChatResponse<AdditionalMessageOptions>;
+        }
+      }
     }
+    throw new Error("Task ended without a last step.");
   }
 }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -70,7 +70,6 @@
     "@swc/core": "^1.5.5",
     "concurrently": "^8.2.2",
     "pathe": "^1.1.2",
-    "readable-stream": "^4.5.2",
     "vitest": "^1.6.0"
   },
   "dependencies": {
@@ -79,17 +78,13 @@
   },
   "peerDependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
-    "pathe": "^1.1.2",
-    "readable-stream": "^4.5.2"
+    "pathe": "^1.1.2"
   },
   "peerDependenciesMeta": {
     "@aws-crypto/sha256-js": {
       "optional": true
     },
     "pathe": {
-      "optional": true
-    },
-    "readable-stream": {
       "optional": true
     }
   }

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -15,7 +15,6 @@ import { ok } from "node:assert";
 import { createHash, randomUUID } from "node:crypto";
 import { EOL } from "node:os";
 import path from "node:path";
-import { pipeline } from "node:stream/promises";
 import {
   ReadableStream,
   TransformStream,
@@ -45,6 +44,5 @@ export {
   fs,
   ok,
   path,
-  pipeline,
   randomUUID,
 };

--- a/packages/env/src/polyfill.ts
+++ b/packages/env/src/polyfill.ts
@@ -9,13 +9,9 @@
  */
 import { Sha256 } from "@aws-crypto/sha256-js";
 import pathe from "pathe";
-// @ts-expect-error
-import { promises } from "readable-stream";
 import { fs } from "./fs/memory.js";
 
-const { pipeline } = promises;
-
-export { fs, pathe as path, pipeline };
+export { fs, pathe as path };
 
 export interface SHA256 {
   update(data: string | Uint8Array): void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,9 +652,6 @@ importers:
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
-      readable-stream:
-        specifier: ^4.5.2
-        version: 4.5.2
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@20.12.11)(terser@5.31.0)
@@ -3914,9 +3911,6 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  buffer@6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -7907,10 +7901,6 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
-
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -8161,10 +8151,6 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
-
-  readable-stream@4.5.2:
-    resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   readable-web-to-node-stream@3.0.2:
     resolution: {integrity: sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==}
@@ -13975,11 +13961,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  buffer@6.0.3:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   builtin-modules@3.3.0: {}
 
   bunchee@5.1.5(typescript@5.4.5):
@@ -18689,8 +18670,6 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  process@0.11.10: {}
-
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -19020,14 +18999,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  readable-stream@4.5.2:
-    dependencies:
-      abort-controller: 3.0.0
-      buffer: 6.0.3
-      events: 3.3.0
-      process: 0.11.10
-      string_decoder: 1.3.0
 
   readable-web-to-node-stream@3.0.2:
     dependencies:


### PR DESCRIPTION
I'm writing a Cloudflare worker and found that `readable-stream` cannot be parsed correctly because it uses the CJS format. So I will remove `pipeline` API since we can do the same thing in other way