### PR TITLE
fix: text before heading in markdown reader

### DIFF
--- a/.changeset/good-carpets-rhyme.md
+++ b/.changeset/good-carpets-rhyme.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": minor
+---
+
+Fix text before heading in markdown reader

--- a/packages/core/src/readers/MarkdownReader.ts
+++ b/packages/core/src/readers/MarkdownReader.ts
@@ -44,6 +44,8 @@ export class MarkdownReader implements FileReader {
             continue;
           }
           markdownTups.push([currentHeader, currentText]);
+        } else if (currentText) {
+          markdownTups.push([null, currentText]);
         }
 
         currentHeader = line;


### PR DESCRIPTION
The current MarkdownReader doesn't support text before headings. This PR fixes this issue