### PR TITLE
Fix/Agent llm initialization

### DIFF
--- a/packages/core/src/agent/anthropic.ts
+++ b/packages/core/src/agent/anthropic.ts
@@ -39,9 +39,9 @@ export class AnthropicAgent extends AgentRunner<Anthropic> {
   constructor(params: AnthropicAgentParams) {
     super({
       llm:
-        params.llm ?? Settings.llm instanceof Anthropic
+        params.llm ?? (Settings.llm instanceof Anthropic
           ? (Settings.llm as Anthropic)
-          : new Anthropic(),
+          : new Anthropic()),
       chatHistory: params.chatHistory ?? [],
       systemPrompt: params.systemPrompt ?? null,
       runner: new AnthropicAgentWorker(),

--- a/packages/core/src/agent/openai.ts
+++ b/packages/core/src/agent/openai.ts
@@ -36,9 +36,9 @@ export class OpenAIAgent extends AgentRunner<OpenAI> {
   constructor(params: OpenAIAgentParams) {
     super({
       llm:
-        params.llm ?? Settings.llm instanceof OpenAI
+        params.llm ?? (Settings.llm instanceof OpenAI
           ? (Settings.llm as OpenAI)
-          : new OpenAI(),
+          : new OpenAI()),
       chatHistory: params.chatHistory ?? [],
       runner: new OpenAIAgentWorker(),
       systemPrompt: params.systemPrompt ?? null,


### PR DESCRIPTION
Bug: When initializing agent with `llm` like:
```
new OpenAIAgent({
  tools,
  llm: new OpenAI({ apiKey: 'abc', temperature: 0.6 }),  // custom openai config
  chatHistory,
})
```
Error `Set OpenAI Key in OPENAI_API_KEY env variable` is thrown.

Fix: Syntax for 
```
params.llm ?? Settings.llm instanceof OpenAI ? (Settings.llm as OpenAI) : new OpenAI()
```
needs additional bracket like:
```
params.llm ?? (Settings.llm instanceof OpenAI ? (Settings.llm as OpenAI) : new OpenAI())
```
otherwise everytime `new OpenAI()` will be executed, and if no env variable is set, error is thrown
