### PR TITLE
feat: add json mode and image retrieval to LlamaParse

### DIFF
--- a/.changeset/proud-geckos-greet.md
+++ b/.changeset/proud-geckos-greet.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+add json mode and image retrieval to LlamaParseReader

--- a/packages/core/src/readers/LlamaParseReader.ts
+++ b/packages/core/src/readers/LlamaParseReader.ts
@@ -150,8 +150,8 @@ export class LlamaParseReader implements FileReader {
     }
   }
 
-  async loadData(file: string): Promise<Document[]> {
-    const metadata = { file_path: file };
+  // Create a job for the LlamaParse API
+  private async createJob(file: string): Promise<string> {
 
     // Load data, set the mime type
     const data = await fs.readFile(file);
@@ -178,7 +178,7 @@ export class LlamaParseReader implements FileReader {
 
     // Send the request, start job
     const url = `${this.baseUrl}/upload`;
-    let response = await fetch(url, {
+    const response = await fetch(url, {
       signal: AbortSignal.timeout(this.maxTimeout * 1000),
       method: "POST",
       body,
@@ -188,32 +188,26 @@ export class LlamaParseReader implements FileReader {
       throw new Error(`Failed to parse the file: ${await response.text()}`);
     }
     const jsonResponse = await response.json();
+    return jsonResponse.id;
+  }
 
-    // Check the status of the job, return when done
-    const jobId = jsonResponse.id;
-    if (this.verbose) {
-      console.log(`Started parsing the file under job id ${jobId}`);
-    }
-
-    const resultUrl = `${this.baseUrl}/job/${jobId}/result/${this.resultType}`;
+  // Get the result of the job
+  private async getJobResult(jobId: string, resultType: string): Promise<any> {
+    const resultUrl = `${this.baseUrl}/job/${jobId}/result/${resultType}`;
+    const statusUrl = `${this.baseUrl}/job/${jobId}`;
+    const headers = { Authorization: `Bearer ${this.apiKey}` };
 
     const start = Date.now();
     let tries = 0;
     while (true) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, this.checkInterval * 1000),
-      );
-      response = await fetch(resultUrl, {
-        headers,
-        signal: AbortSignal.timeout(this.maxTimeout * 1000),
-      });
+      await new Promise((resolve) => setTimeout(resolve, this.checkInterval * 1000));
 
-      if (!response.ok) {
+      // Check the job status. If unsuccessful response, checks if maximum timeout has been reached. If reached, throws an error
+      const statusResponse = await fetch(statusUrl, { headers, signal: AbortSignal.timeout(this.maxTimeout * 1000) });
+      if (!statusResponse.ok) {
         const end = Date.now();
         if (end - start > this.maxTimeout * 1000) {
-          throw new Error(
-            `Timeout while parsing the file: ${await response.text()}`,
-          );
+          throw new Error(`Timeout while parsing the file: ${await statusResponse.text()}`);
         }
         if (this.verbose && tries % 10 === 0) {
           process.stdout.write(".");
@@ -222,14 +216,132 @@ export class LlamaParseReader implements FileReader {
         continue;
       }
 
-      const resultJson = await response.json();
-      return [
-        new Document({
-          text: resultJson[this.resultType],
-          metadata: metadata,
-        }),
-      ];
+      // If response is succesful, check status of job. Allowed values "PENDING", "SUCCESS", "ERROR", "CANCELED"
+      const statusJson = await statusResponse.json();
+      const status = statusJson.status;
+      // If job has completed, return the result
+      if (status === "SUCCESS") {
+        const resultResponse = await fetch(resultUrl, { headers, signal: AbortSignal.timeout(this.maxTimeout * 1000) });
+        if (!resultResponse.ok) {
+          throw new Error(`Failed to fetch result: ${await resultResponse.text()}`);
+        }
+        return resultResponse.json();
+        // If job is still pending, check if maximum timeout has been reached. If reached, throws an error
+      } else if (status === "PENDING") {
+        const end = Date.now();
+        if (end - start > this.maxTimeout * 1000) {
+          throw new Error(`Timeout while parsing the file: ${await statusResponse.text()}`);
+        }
+        if (this.verbose && tries % 10 === 0) {
+          process.stdout.write(".");
+        }
+        tries++;
+        continue;
+      } else {
+        throw new Error(`Failed to parse the file: ${jobId}, status: ${status}`);
+      }
     }
+  }
+
+    /**
+   * Loads data from a file and returns an array of Document objects.
+   * To be used with resultType = "text" and "markdown"
+   * 
+   * @param {string} file - The path to the file to be loaded.
+   * @return {Promise<Document[]>} A Promise object that resolves to an array of Document objects.
+   */
+  async loadData(file: string): Promise<Document[]> {
+    // Set metadata to contain file_path
+    const metadata = { file_path: file };
+
+    // Creates a job for the file
+    const jobId = await this.createJob(file);
+    if (this.verbose) {
+      console.log(`Started parsing the file under job id ${jobId}`);
+    }
+
+    // Return results as Document objects
+    const resultJson = await this.getJobResult(jobId, this.resultType);
+    return [
+      new Document({
+        text: resultJson[this.resultType],
+        metadata: metadata,
+      }),
+    ];
+  }
+    /**
+   * Loads data from a file and returns its contents as a JSON object.
+   * To be used with resultType = "json"
+   *
+   * @param {string} file - The path to the file to be loaded.
+   * @return {Promise<Record<string, any>>} A Promise that resolves to the JSON object.
+   */
+  async loadJson(file: string): Promise<Record<string, any>> {
+    // Creates a job for the file
+    const jobId = await this.createJob(file);
+    if (this.verbose) {
+      console.log(`Started parsing the file under job id ${jobId}`);
+    }
+
+    // Return results as JSON object
+    const resultJson = await this.getJobResult(jobId, "json");
+    resultJson.job_id = jobId;
+    resultJson.file_path = file;
+    return resultJson;
+  }
+
+    /**
+   * Downloads and saves images from a given JSON result to a specified download path.
+   * Currently only supports resultType = "json"
+   *
+   * @param {Record<string, any>[]} jsonResult - The JSON result containing image information.
+   * @param {string} downloadPath - The path to save the downloaded images.
+   * @return {Promise<Record<string, any>[]>} A Promise that resolves to an array of image objects.
+   */
+  async getImages(jsonResult: Record<string, any>[], downloadPath: string): Promise<Record<string, any>[]> {
+    const headers = { Authorization: `Bearer ${this.apiKey}` };
+
+    // Create download directory if it doesn't exist (Actually check for write access, not existence, since fsPromises does not have a `existsSync` method)
+    if (!fs.access(downloadPath)) {
+      await fs.mkdir(downloadPath, { recursive: true });
+    }
+
+    const images: Record<string, any>[] = [];
+    for (const result of jsonResult) {
+      const jobId = result.job_id;
+      for (const page of result.pages) {
+        if (this.verbose) {
+          console.log(`> Image for page ${page.page}: ${page.images}`);
+        }
+        for (const image of page.images) {
+          const imageName = image.name;
+          // Get the full path
+          let imagePath = `${downloadPath}/${jobId}-${imageName}`;
+
+          if (!imagePath.endsWith(".png") && !imagePath.endsWith(".jpg")) {
+            imagePath += ".png";
+          }
+
+          // Get a valid image path
+          image.path = imagePath;
+          image.job_id = jobId;
+          image.original_pdf_path = result.file_path;
+          image.page_number = page.page;
+
+          const imageUrl = `${this.baseUrl}/job/${jobId}/result/image/${imageName}`;
+          const response = await fetch(imageUrl, { headers });
+          if (!response.ok) {
+            throw new Error(`Failed to download image: ${await response.text()}`);
+          }
+          const arrayBuffer = await response.arrayBuffer();
+          const buffer = Buffer.from(arrayBuffer);
+          await fs.writeFile(imagePath, buffer);
+
+          images.push(image);
+        }
+      }
+    }
+    return images;
   }
 
   private async getMimeType(data: Buffer): Promise<string> {

--- a/packages/core/src/readers/LlamaParseReader.ts
+++ b/packages/core/src/readers/LlamaParseReader.ts
@@ -152,7 +152,6 @@ export class LlamaParseReader implements FileReader {
 
   // Create a job for the LlamaParse API
   private async createJob(file: string): Promise<string> {
-
     // Load data, set the mime type
     const data = await fs.readFile(file);
     const mimeType = await this.getMimeType(data);
@@ -200,14 +199,21 @@ export class LlamaParseReader implements FileReader {
     const start = Date.now();
     let tries = 0;
     while (true) {
-      await new Promise((resolve) => setTimeout(resolve, this.checkInterval * 1000));
+      await new Promise((resolve) =>
+        setTimeout(resolve, this.checkInterval * 1000),
+      );
 
       // Check the job status. If unsuccessful response, checks if maximum timeout has been reached. If reached, throws an error
-      const statusResponse = await fetch(statusUrl, { headers, signal: AbortSignal.timeout(this.maxTimeout * 1000) });
+      const statusResponse = await fetch(statusUrl, {
+        headers,
+        signal: AbortSignal.timeout(this.maxTimeout * 1000),
+      });
       if (!statusResponse.ok) {
         const end = Date.now();
         if (end - start > this.maxTimeout * 1000) {
-          throw new Error(`Timeout while parsing the file: ${await statusResponse.text()}`);
+          throw new Error(
+            `Timeout while parsing the file: ${await statusResponse.text()}`,
+          );
         }
         if (this.verbose && tries % 10 === 0) {
           process.stdout.write(".");
@@ -221,16 +227,23 @@ export class LlamaParseReader implements FileReader {
       const status = statusJson.status;
       // If job has completed, return the result
       if (status === "SUCCESS") {
-        const resultResponse = await fetch(resultUrl, { headers, signal: AbortSignal.timeout(this.maxTimeout * 1000) });
+        const resultResponse = await fetch(resultUrl, {
+          headers,
+          signal: AbortSignal.timeout(this.maxTimeout * 1000),
+        });
         if (!resultResponse.ok) {
-          throw new Error(`Failed to fetch result: ${await resultResponse.text()}`);
+          throw new Error(
+            `Failed to fetch result: ${await resultResponse.text()}`,
+          );
         }
         return resultResponse.json();
         // If job is still pending, check if maximum timeout has been reached. If reached, throws an error
       } else if (status === "PENDING") {
         const end = Date.now();
         if (end - start > this.maxTimeout * 1000) {
-          throw new Error(`Timeout while parsing the file: ${await statusResponse.text()}`);
+          throw new Error(
+            `Timeout while parsing the file: ${await statusResponse.text()}`,
+          );
         }
         if (this.verbose && tries % 10 === 0) {
           process.stdout.write(".");
@@ -238,15 +251,17 @@ export class LlamaParseReader implements FileReader {
         tries++;
         continue;
       } else {
-        throw new Error(`Failed to parse the file: ${jobId}, status: ${status}`);
+        throw new Error(
+          `Failed to parse the file: ${jobId}, status: ${status}`,
+        );
       }
     }
   }
 
-    /**
+  /**
    * Loads data from a file and returns an array of Document objects.
    * To be used with resultType = "text" and "markdown"
-   * 
+   *
    * @param {string} file - The path to the file to be loaded.
    * @return {Promise<Document[]>} A Promise object that resolves to an array of Document objects.
    */
@@ -269,7 +284,7 @@ export class LlamaParseReader implements FileReader {
       }),
     ];
   }
-    /**
+  /**
    * Loads data from a file and returns its contents as a JSON object.
    * To be used with resultType = "json"
    *
@@ -290,7 +305,7 @@ export class LlamaParseReader implements FileReader {
     return resultJson;
   }
 
-    /**
+  /**
    * Downloads and saves images from a given JSON result to a specified download path.
    * Currently only supports resultType = "json"
    *
@@ -298,7 +313,10 @@ export class LlamaParseReader implements FileReader {
    * @param {string} downloadPath - The path to save the downloaded images.
    * @return {Promise<Record<string, any>[]>} A Promise that resolves to an array of image objects.
    */
-  async getImages(jsonResult: Record<string, any>[], downloadPath: string): Promise<Record<string, any>[]> {
+  async getImages(
+    jsonResult: Record<string, any>[],
+    downloadPath: string,
+  ): Promise<Record<string, any>[]> {
     const headers = { Authorization: `Bearer ${this.apiKey}` };
 
     // Create download directory if it doesn't exist (Actually check for write access, not existence, since fsPromises does not have a `existsSync` method)
@@ -331,7 +349,9 @@ export class LlamaParseReader implements FileReader {
           const imageUrl = `${this.baseUrl}/job/${jobId}/result/image/${imageName}`;
           const response = await fetch(imageUrl, { headers });
           if (!response.ok) {
-            throw new Error(`Failed to download image: ${await response.text()}`);
+            throw new Error(
+              `Failed to download image: ${await response.text()}`,
+            );
           }
           const arrayBuffer = await response.arrayBuffer();
           const buffer = Buffer.from(arrayBuffer);


### PR DESCRIPTION
Testing looks good, pure json results are as expected. 
I'm a bit unsure about how to further use the json results tho.

Is there a function akin to this python [example](https://github.com/run-llama/llama_parse/blob/main/examples/demo_json.ipynb): 

Especially, is there an existing way to use this part:

```
json_objs = parser.get_json_result("./uber_10q_march_2022.pdf")
json_list = json_objs[0]["pages"]

```
In LlamaIndexTS? 

My idea would be to use` jsonToNode` afterwards to turn the results into proper Nodes for further processing. Or am I missing something?

Also restructured most of LlamaParseReader to align more closely with the python version. This modular approach should avoid redundant code.