### PR TITLE
feat: add api key methods, usage retrieval and ignoreErrors flag to LlamaParseReader

### DIFF
--- a/.changeset/lazy-wombats-type.md
+++ b/.changeset/lazy-wombats-type.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+feat: add API keys manipulation methods and usage retrieval to LlamaParseReader

--- a/examples/readers/package.json
+++ b/examples/readers/package.json
@@ -12,7 +12,8 @@
     "start:llamaparse": "node --import tsx ./src/llamaparse.ts",
     "start:notion": "node --import tsx ./src/notion.ts",
     "start:llamaparse-dir": "node --import tsx ./src/simple-directory-reader-with-llamaparse.ts",
-    "start:llamaparse-json": "node --import tsx ./src/llamaparse-json.ts"
+    "start:llamaparse-json": "node --import tsx ./src/llamaparse-json.ts",
+    "start:llamaparse-api": "node --import tsx ./src/llamaparse-api.ts"
   },
   "dependencies": {
     "llamaindex": "*"

--- a/examples/readers/src/llamaparse-api.ts
+++ b/examples/readers/src/llamaparse-api.ts
@@ -1,0 +1,26 @@
+import { LlamaParseReader } from "llamaindex";
+
+async function main() {
+  const reader = new LlamaParseReader();
+  const name = `A fresh key`;
+  // Generate an API key
+  const genResponse = await reader.generateApiKey(name);
+  // Extract UUID from response
+  const api_key_id = genResponse.id;
+
+  const updatedName = `An updated key`;
+  // Update API key name
+  const upResponse = await reader.updateApiKey(api_key_id, updatedName);
+  console.log(upResponse);
+  // Delete API key
+  const delResponse = await reader.deleteApiKey(api_key_id);
+  console.log(delResponse);
+  // List all API keys under the account
+  const listResponse = await reader.getApiKeys();
+  console.log(listResponse);
+  // Get parsing usage
+  const usage = await reader.getParsingUsage();
+  console.log(usage);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Use cases:

> automation of api key renewal

> usage retrieval can be used to limit spending, as llamaparse has no spending limit that can be set.

`max_pdf_pages` is currently always responding with `1000`, so backend has no implementation for unlimited max_pdf_pages, but that's just cosmetical really