### PR TITLE
docs: fixed the broken link on Getting Started Section

### DIFF
--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -35,7 +35,7 @@ For more complex applications, our lower-level APIs allow advanced users to cust
 
 `npm install llamaindex`
 
-Our documentation includes [Installation Instructions](./getting_started/installation.mdx) and a [Starter Tutorial](./getting_started/starter.mdx) to build your first application.
+Our documentation includes [Installation Instructions](./getting_started/installation.mdx) and a [Starter Tutorial](./getting_started/starter_tutorial/retrieval_augmented_generation.mdx) to build your first application.
 
 Once you're up and running, [High-Level Concepts](./getting_started/concepts.md) has an overview of LlamaIndex's modular architecture. For more hands-on practical examples, look through our Examples section on the sidebar.
 


### PR DESCRIPTION
Replaced the Broken link on **Starter Tutorial** on https://ts.llamaindex.ai/#getting-started

Broken Link: https://ts.llamaindex.ai/getting_started/starter.mdx

Changed to: https://ts.llamaindex.ai/getting_started/starter_tutorial/retrieval_augmented_generation


fixes https://github.com/run-llama/LlamaIndexTS/issues/931