### PR TITLE
fix: typo in custom page separator parameter for LlamaParse

### DIFF
--- a/.changeset/witty-bats-shave.md
+++ b/.changeset/witty-bats-shave.md
@@ -1,0 +1,7 @@
+---
+"llamaindex": patch
+"@llamaindex/cloud": patch
+"docs": patch
+---
+
+fix: typo in custom page separator parameter for LlamaParse

--- a/apps/docs/docs/modules/data_loaders/llama_parse/index.mdx
+++ b/apps/docs/docs/modules/data_loaders/llama_parse/index.mdx
@@ -27,25 +27,25 @@ They can be divided into two groups.
 
 - `apiKey` is required. Can be set as an environment variable `LLAMA_CLOUD_API_KEY`
 - `checkInterval` is the interval in seconds to check if the parsing is done. Default is `1`.
-- `maxTimeout` is the maximum timout to wait for parsing to finish. Default is `2000`
+- `maxTimeout` is the maximum timeout to wait for parsing to finish. Default is `2000`
 - `verbose` shows progress of the parsing. Default is `true`
 - `ignoreErrors` set to false to get errors while parsing. Default is `true` and returns an empty array on error.
 
 #### Advanced params:
 
 - `resultType` can be set to `markdown`, `text` or `json`. Defaults to `text`. More information about `json` mode on the next pages.
-- `language` primarly helps with OCR recognition. Defaults to `en`. Click [here](../../../api/type-aliases/Language.md) for a list of supported languages.
+- `language` primarily helps with OCR recognition. Defaults to `en`. Click [here](../../../api/type-aliases/Language.md) for a list of supported languages.
 - `parsingInstructions?` Optional. Can help with complicated document structures. See this [LlamaIndex Blog Post](https://www.llamaindex.ai/blog/launching-the-first-genai-native-document-parsing-platform) for an example.
 - `skipDiagonalText?` Optional. Set to true to ignore diagonal text. (Text that is not rotated 0, 90, 180 or 270 degrees)
 - `invalidateCache?` Optional. Set to true to ignore the LlamaCloud cache. All document are kept in cache for 48hours after the job was completed to avoid processing the same document twice. Can be useful for testing when trying to re-parse the same document with, e.g. different `parsingInstructions`.
 - `doNotCache?` Optional. Set to true to not cache the document.
 - `fastMode?` Optional. Set to true to use the fast mode. This mode will skip OCR of images, and table/heading reconstruction. Note: Non-compatible with `gpt4oMode`.
-- `doNotUnrollColumns?` Optional. Set to true to keep the text according to document layout. Reduce reconstruction accuracy, and LLM's/embedings performances in most cases.
-- `pageSeperator?` Optional. The page seperator to use. Defaults is `\\n---\\n`.
+- `doNotUnrollColumns?` Optional. Set to true to keep the text according to document layout. Reduce reconstruction accuracy, and LLMs/embeddings performances in most cases.
+- `pageSeparator?` Optional. The page separator to use. Defaults is `\\n---\\n`.
 - `gpt4oMode` set to true to use GPT-4o to extract content. Default is `false`.
 - `gpt4oApiKey?` Optional. Set the GPT-4o API key. Lowers the cost of parsing by using your own API key. Your OpenAI account will be charged. Can also be set in the environment variable `LLAMA_CLOUD_GPT4O_API_KEY`.
 - `boundingBox?` Optional. Specify an area of the document to parse. Expects the bounding box margins as a string in clockwise order, e.g. `boundingBox = "0.1,0,0,0"` to not parse the top 10% of the document.
-- `targetPages?` Optional. Specify which pages to parse by specifying them as a comma-seperated list. First page is `0`.
+- `targetPages?` Optional. Specify which pages to parse by specifying them as a comma-separated list. First page is `0`.
 - `numWorkers` as in the python version, is set in `SimpleDirectoryReader`. Default is 1.
 
 ### LlamaParse with SimpleDirectoryReader

--- a/packages/cloud/openapi.json
+++ b/packages/cloud/openapi.json
@@ -12113,9 +12113,9 @@
             "description": "Template for how metadata is formatted, with {key} and {value} placeholders.",
             "default": "{key}: {value}"
           },
-          "metadata_seperator": {
+          "metadata_separator": {
             "type": "string",
-            "title": "Metadata Seperator",
+            "title": "Metadata Separator",
             "description": "Separator between metadata fields when converting to string.",
             "default": "\n"
           },

--- a/packages/llamaindex/CHANGELOG.md
+++ b/packages/llamaindex/CHANGELOG.md
@@ -125,7 +125,7 @@
 
 ### Patch Changes
 
-- 6bc5bdd: feat: add cache disabling, fast mode, do not unroll columns mode and custom page seperator to LlamaParseReader
+- 6bc5bdd: feat: add cache disabling, fast mode, do not unroll columns mode and custom page separator to LlamaParseReader
 - bf25ff6: fix: polyfill for cloudflare worker
 - e6d6576: chore: use `unpdf`
 

--- a/packages/llamaindex/src/readers/LlamaParseReader.ts
+++ b/packages/llamaindex/src/readers/LlamaParseReader.ts
@@ -128,7 +128,7 @@ export class LlamaParseReader extends FileReader {
   // Wether to keep column in the text according to document layout. Reduce reconstruction accuracy, and LLM's/embedings performances in most cases.
   doNotUnrollColumns?: boolean;
   // The page separator to use to split the text. Default is None, which means the parser will use the default separator '\\n---\\n'.
-  pageSeperator?: string;
+  pageSeparator?: string;
   // Whether to use gpt-4o to extract text from documents.
   gpt4oMode: boolean = false;
   // The API key for the GPT-4o API. Optional, lowers the cost of parsing. Can be set as an env variable: LLAMA_CLOUD_GPT4O_API_KEY.
@@ -184,7 +184,7 @@ export class LlamaParseReader extends FileReader {
       do_not_cache: this.doNotCache?.toString(),
       fast_mode: this.fastMode?.toString(),
       do_not_unroll_columns: this.doNotUnrollColumns?.toString(),
-      page_seperator: this.pageSeperator,
+      page_separator: this.pageSeparator,
       gpt4o_mode: this.gpt4oMode?.toString(),
       gpt4o_api_key: this.gpt4oApiKey,
       bounding_box: this.boundingBox,


### PR DESCRIPTION
A typo in the parameter made it impossible to change the default page separator on LlamaParse (`\n---\n`). This PR fixes the issue.

Related issues:
- #924 
- https://github.com/run-llama/llama_parse/issues/263
- https://github.com/run-llama/llama_parse/issues/223
- https://github.com/run-llama/llama_parse/issues/230

I also fixed a few typo from the same doc page.