### PR TITLE
feat: Support MetadataFilters for Milvus and SimpleVectorStore

### DIFF
--- a/.changeset/famous-poets-hammer.md
+++ b/.changeset/famous-poets-hammer.md
@@ -1,0 +1,6 @@
+---
+"llamaindex": patch
+"@llamaindex/llamaindex-test": patch
+---
+
+Add support for Metadata filters

--- a/examples/metadata-filter/milvus.ts
+++ b/examples/metadata-filter/milvus.ts
@@ -1,0 +1,40 @@
+import { MilvusVectorStore, VectorStoreIndex } from "llamaindex";
+
+const collectionName = "movie_reviews";
+
+async function main() {
+  try {
+    const milvus = new MilvusVectorStore({ collection: collectionName });
+    const index = await VectorStoreIndex.fromVectorStore(milvus);
+    const retriever = index.asRetriever({ similarityTopK: 20 });
+
+    console.log("\n=====\nQuerying the index with filters");
+    const queryEngineWithFilters = index.asQueryEngine({
+      retriever,
+      preFilters: {
+        filters: [
+          {
+            key: "document_id",
+            value: "./data/movie_reviews.csv_37",
+            operator: "==",
+          },
+          {
+            key: "document_id",
+            value: "./data/movie_reviews.csv_37",
+            operator: "!=",
+          },
+        ],
+        condition: "or",
+      },
+    });
+    const resultAfterFilter = await queryEngineWithFilters.query({
+      query: "Get all movie titles.",
+    });
+    console.log(`Query from ${resultAfterFilter.sourceNodes?.length} nodes`);
+    console.log(resultAfterFilter.response);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+void main();

--- a/examples/metadata-filter/simple.ts
+++ b/examples/metadata-filter/simple.ts
@@ -66,7 +66,7 @@ async function main() {
   console.log("No filter response:", noFilterResponse.toString());
 
   console.log(
-    "\n=============\nQuerying index with dogId 2. The output always should be red.",
+    "\n=============\nQuerying index with dogId 2 and private false. The output always should be red.",
   );
   const queryEngineDogId2 = index.asQueryEngine({
     preFilters: {
@@ -85,10 +85,30 @@ async function main() {
     },
     similarityTopK: 3,
   });
-  const response = await queryEngineDogId2.query({
+  const responseEQ = await queryEngineDogId2.query({
     query: "What is the color of the dog?",
   });
-  console.log("Filter with dogId 2 response:", response.toString());
+  console.log("Filter with dogId 2 response:", responseEQ.toString());
+
+  console.log(
+    "\n=============\nQuerying index with dogId IN (1, 3). The output should be brown and red.",
+  );
+  const queryEngineDogId3 = index.asQueryEngine({
+    preFilters: {
+      filters: [
+        {
+          key: "dogId",
+          value: ["1", "3"],
+          operator: "in",
+        },
+      ],
+    },
+    similarityTopK: 3,
+  });
+  const responseIN = await queryEngineDogId3.query({
+    query: "What is the color of the dog?",
+  });
+  console.log("Filter with dogId IN (1, 3) response:", responseIN.toString());
 }
 
 void main();

--- a/examples/metadata-filter/simple.ts
+++ b/examples/metadata-filter/simple.ts
@@ -68,7 +68,7 @@ async function main() {
   console.log(
     "\n=============\nQuerying index with dogId 2 and private false. The output always should be red.",
   );
-  const queryEngineDogId2 = index.asQueryEngine({
+  const queryEngineEQ = index.asQueryEngine({
     preFilters: {
       filters: [
         {
@@ -85,7 +85,7 @@ async function main() {
     },
     similarityTopK: 3,
   });
-  const responseEQ = await queryEngineDogId2.query({
+  const responseEQ = await queryEngineEQ.query({
     query: "What is the color of the dog?",
   });
   console.log("Filter with dogId 2 response:", responseEQ.toString());
@@ -93,7 +93,7 @@ async function main() {
   console.log(
     "\n=============\nQuerying index with dogId IN (1, 3). The output should be brown and red.",
   );
-  const queryEngineDogId3 = index.asQueryEngine({
+  const queryEngineIN = index.asQueryEngine({
     preFilters: {
       filters: [
         {
@@ -105,10 +105,39 @@ async function main() {
     },
     similarityTopK: 3,
   });
-  const responseIN = await queryEngineDogId3.query({
+  const responseIN = await queryEngineIN.query({
     query: "What is the color of the dog?",
   });
   console.log("Filter with dogId IN (1, 3) response:", responseIN.toString());
+
+  console.log(
+    "\n=============\nQuerying index with dogId IN (1, 3). The output should be any.",
+  );
+  const queryEngineOR = index.asQueryEngine({
+    preFilters: {
+      filters: [
+        {
+          key: "private",
+          value: "false",
+          operator: "==",
+        },
+        {
+          key: "dogId",
+          value: ["1", "3"],
+          operator: "in",
+        },
+      ],
+      condition: "or",
+    },
+    similarityTopK: 3,
+  });
+  const responseOR = await queryEngineOR.query({
+    query: "What is the color of the dog?",
+  });
+  console.log(
+    "Filter with dogId with OR operator response:",
+    responseOR.toString(),
+  );
 }
 
 void main();

--- a/examples/metadata-filter/simple.ts
+++ b/examples/metadata-filter/simple.ts
@@ -74,12 +74,12 @@ async function main() {
         {
           key: "private",
           value: "false",
-          filterType: "ExactMatch",
+          operator: "==",
         },
         {
           key: "dogId",
           value: "3",
-          filterType: "ExactMatch",
+          operator: "==",
         },
       ],
     },

--- a/examples/milvus/query.ts
+++ b/examples/milvus/query.ts
@@ -5,18 +5,44 @@ const collectionName = "movie_reviews";
 async function main() {
   try {
     const milvus = new MilvusVectorStore({ collection: collectionName });
-
     const index = await VectorStoreIndex.fromVectorStore(milvus);
+    const retriever = index.asRetriever({ similarityTopK: 20 });
 
-    const retriever = await index.asRetriever({ similarityTopK: 20 });
-
-    const queryEngine = await index.asQueryEngine({ retriever });
-
-    const results = await queryEngine.query({
-      query: "What is the best reviewed movie?",
+    console.log("=====\nQuerying the index without any filters.");
+    const queryEngineNoFilters = index.asQueryEngine({ retriever });
+    const resultNoFilter = await queryEngineNoFilters.query({
+      query: "Summary movie reviews",
     });
+    console.log(`Query from ${resultNoFilter.sourceNodes?.length} nodes`);
+    console.log(resultNoFilter.response);
 
-    console.log(results.response);
+    console.log("\n=====\nQuerying the index with filters");
+    const queryEngineWithFilters = index.asQueryEngine({
+      retriever,
+      preFilters: {
+        filters: [
+          {
+            key: "doc_id",
+            value: [
+              "./data/movie_reviews.csv_95",
+              "./data/movie_reviews.csv_101",
+            ],
+            operator: "in",
+          },
+          {
+            key: "document_id",
+            value: "./data/movie_reviews.csv_37",
+            operator: "==",
+          },
+        ],
+        condition: "or",
+      },
+    });
+    const resultAfterFilter = await queryEngineWithFilters.query({
+      query: "Summary movie reviews",
+    });
+    console.log(`Query from ${resultAfterFilter.sourceNodes?.length} nodes`);
+    console.log(resultAfterFilter.response);
   } catch (e) {
     console.error(e);
   }

--- a/examples/milvus/query.ts
+++ b/examples/milvus/query.ts
@@ -5,44 +5,18 @@ const collectionName = "movie_reviews";
 async function main() {
   try {
     const milvus = new MilvusVectorStore({ collection: collectionName });
+
     const index = await VectorStoreIndex.fromVectorStore(milvus);
-    const retriever = index.asRetriever({ similarityTopK: 20 });
 
-    console.log("=====\nQuerying the index without any filters.");
-    const queryEngineNoFilters = index.asQueryEngine({ retriever });
-    const resultNoFilter = await queryEngineNoFilters.query({
-      query: "Summary movie reviews",
-    });
-    console.log(`Query from ${resultNoFilter.sourceNodes?.length} nodes`);
-    console.log(resultNoFilter.response);
+    const retriever = await index.asRetriever({ similarityTopK: 20 });
 
-    console.log("\n=====\nQuerying the index with filters");
-    const queryEngineWithFilters = index.asQueryEngine({
-      retriever,
-      preFilters: {
-        filters: [
-          {
-            key: "doc_id",
-            value: [
-              "./data/movie_reviews.csv_95",
-              "./data/movie_reviews.csv_101",
-            ],
-            operator: "in",
-          },
-          {
-            key: "document_id",
-            value: "./data/movie_reviews.csv_37",
-            operator: "==",
-          },
-        ],
-        condition: "or",
-      },
+    const queryEngine = await index.asQueryEngine({ retriever });
+
+    const results = await queryEngine.query({
+      query: "What is the best reviewed movie?",
     });
-    const resultAfterFilter = await queryEngineWithFilters.query({
-      query: "Summary movie reviews",
-    });
-    console.log(`Query from ${resultAfterFilter.sourceNodes?.length} nodes`);
-    console.log(resultAfterFilter.response);
+
+    console.log(results.response);
   } catch (e) {
     console.error(e);
   }

--- a/packages/llamaindex/src/storage/vectorStore/MilvusVectorStore.ts
+++ b/packages/llamaindex/src/storage/vectorStore/MilvusVectorStore.ts
@@ -69,8 +69,6 @@ function parseScalarFilters(scalarFilters: MetadataFilters): string {
     }
   }
 
-  console.log({ filterStr: filters.join(` ${condition} `) });
-
   return filters.join(` ${condition} `);
 }
 
@@ -240,7 +238,7 @@ export class MilvusVectorStore
     });
   }
 
-  private toMilvusFilter(filters?: MetadataFilters): string | undefined {
+  public toMilvusFilter(filters?: MetadataFilters): string | undefined {
     if (!filters) return undefined;
     // TODO: Milvus also support standard filters, we can add it later
     return parseScalarFilters(filters);

--- a/packages/llamaindex/src/storage/vectorStore/MilvusVectorStore.ts
+++ b/packages/llamaindex/src/storage/vectorStore/MilvusVectorStore.ts
@@ -47,7 +47,7 @@ function parseScalarFilters(scalarFilters: MetadataFilters): string {
         break;
       }
       case "nin": {
-        // Milmus does not support `nin` operator, so we need to manually check every value
+        // Milvus does not support `nin` operator, so we need to manually check every value
         // Expected: not metadata["key"] != "value1" and not metadata["key"] != "value2"
         const filterStr = parseArrayValue(filter.value)
           .map((v) => `metadata["${filter.key}"] != "${v}"`)

--- a/packages/llamaindex/src/storage/vectorStore/PGVectorStore.ts
+++ b/packages/llamaindex/src/storage/vectorStore/PGVectorStore.ts
@@ -272,7 +272,10 @@ export class PGVectorStore
     query.filters?.filters.forEach((filter, index) => {
       const paramIndex = params.length + 1;
       whereClauses.push(`metadata->>'${filter.key}' = $${paramIndex}`);
-      params.push(filter.value);
+      // TODO: support filter with other operators
+      if (!Array.isArray(filter.value)) {
+        params.push(filter.value);
+      }
     });
 
     const where =

--- a/packages/llamaindex/src/storage/vectorStore/PineconeVectorStore.ts
+++ b/packages/llamaindex/src/storage/vectorStore/PineconeVectorStore.ts
@@ -1,7 +1,7 @@
 import {
   VectorStoreBase,
-  type ExactMatchFilter,
   type IEmbedModel,
+  type MetadataFilter,
   type MetadataFilters,
   type VectorStoreNoEmbedModel,
   type VectorStoreQuery,
@@ -199,8 +199,12 @@ export class PineconeVectorStore
   }
 
   toPineconeFilter(stdFilters?: MetadataFilters) {
-    return stdFilters?.filters?.reduce((carry: any, item: ExactMatchFilter) => {
-      carry[item.key] = item.value;
+    return stdFilters?.filters?.reduce((carry: any, item: MetadataFilter) => {
+      // Use MetadataFilter with EQ operator to replace ExactMatchFilter
+      // TODO: support filter with other operators
+      if (item.operator === "==") {
+        carry[item.key] = item.value;
+      }
       return carry;
     }, {});
   }

--- a/packages/llamaindex/src/storage/vectorStore/SimpleVectorStore.ts
+++ b/packages/llamaindex/src/storage/vectorStore/SimpleVectorStore.ts
@@ -15,12 +15,16 @@ import {
   type IEmbedModel,
   type MetadataFilter,
   type MetadataFilters,
-  type MetadataFilterValue,
   type VectorStoreNoEmbedModel,
   type VectorStoreQuery,
   type VectorStoreQueryResult,
 } from "./types.js";
-import { nodeToMetadata } from "./utils.js";
+import {
+  nodeToMetadata,
+  parseArrayValue,
+  parseNumberValue,
+  parsePrimitiveValue,
+} from "./utils.js";
 
 const LEARNER_MODES = new Set<VectorStoreQueryMode>([
   VectorStoreQueryMode.SVM,
@@ -31,28 +35,6 @@ const LEARNER_MODES = new Set<VectorStoreQueryMode>([
 const MMR_MODE = VectorStoreQueryMode.MMR;
 
 type MetadataValue = Record<string, any>;
-
-const parseNumberValue = (value: MetadataFilterValue): number => {
-  if (typeof value !== "number") throw new Error("Value must be a number");
-  return value;
-};
-
-const parsePrimitiveValue = (value: MetadataFilterValue): string => {
-  if (typeof value !== "number" && typeof value !== "string") {
-    throw new Error("Value must be a string or number");
-  }
-  return value.toString();
-};
-
-const parseArrayValue = (value: MetadataFilterValue): string[] => {
-  const isPrimitiveArray =
-    Array.isArray(value) &&
-    value.every((v) => typeof v === "string" || typeof v === "number");
-  if (!isPrimitiveArray) {
-    throw new Error("Value must be an array of strings or numbers");
-  }
-  return value.map(String);
-};
 
 // Mapping of filter operators to metadata filter functions
 const OPERATOR_TO_FILTER: {

--- a/packages/llamaindex/src/storage/vectorStore/SimpleVectorStore.ts
+++ b/packages/llamaindex/src/storage/vectorStore/SimpleVectorStore.ts
@@ -117,8 +117,18 @@ export class SimpleVectorStore
         },
       ) => boolean
     > = {
-      "==": (input) => {
+      [FilterOperator.EQ]: function (input): boolean {
         return String(input.metadata[input.key]) === input.value.toString(); // compare as string
+      },
+      [FilterOperator.IN]: function (input): boolean {
+        if (!Array.isArray(input.value)) {
+          throw new Error(
+            "To use IN, value must be an array of strings or numbers",
+          );
+        }
+        return input.value
+          .map(String)
+          .includes(String(input.metadata[input.key]));
       },
     };
 

--- a/packages/llamaindex/src/storage/vectorStore/SimpleVectorStore.ts
+++ b/packages/llamaindex/src/storage/vectorStore/SimpleVectorStore.ts
@@ -134,18 +134,22 @@ export class SimpleVectorStore
 
     const queryFilterFn = (nodeId: string) => {
       if (!query.filters) return true;
-      const filters = query.filters.filters;
-      for (const filter of filters) {
+      const { filters, condition } = query.filters;
+      const queryCondition = condition || "and"; // default to and
+
+      const queryFilterItemFn = (filter: MetadataFilter) => {
         const { key, value, operator } = filter;
         const metadataLookupFn = operatorToFilterFn[operator];
         const metadata = this.data.metadataDict[nodeId];
-        const isMatch =
+        return (
           metadataLookupFn &&
           metadata &&
-          metadataLookupFn({ metadata, key, value });
-        if (!isMatch) return false; // TODO: handle condition OR AND
-      }
-      return true;
+          metadataLookupFn({ metadata, key, value })
+        );
+      };
+
+      if (queryCondition === "and") return filters.every(queryFilterItemFn);
+      return filters.some(queryFilterItemFn);
     };
 
     const nodeFilterFn = (nodeId: string) => {

--- a/packages/llamaindex/src/storage/vectorStore/types.ts
+++ b/packages/llamaindex/src/storage/vectorStore/types.ts
@@ -31,12 +31,12 @@ export interface ExactMatchFilter {
 
 export enum FilterOperator {
   EQ = "==", // default operator (string, number)
+  IN = "in", // In array (string or number)
   // GT = ">", // greater than (number)
   // LT = "<", // less than (number)
   // NE = "!=", // not equal to (string, number)
   // GTE = ">=", // greater than or equal to (number)
   // LTE = "<=", // less than or equal to (number)
-  // IN = "in", // In array (string or number)
   // NIN = "nin", // Not in array (string or number)
   // ANY = "any", // Contains any (array of strings)
   // ALL = "all", // Contains all (array of strings)

--- a/packages/llamaindex/src/storage/vectorStore/types.ts
+++ b/packages/llamaindex/src/storage/vectorStore/types.ts
@@ -32,16 +32,16 @@ export interface ExactMatchFilter {
 export enum FilterOperator {
   EQ = "==", // default operator (string, number)
   IN = "in", // In array (string or number)
-  // GT = ">", // greater than (number)
-  // LT = "<", // less than (number)
-  // NE = "!=", // not equal to (string, number)
-  // GTE = ">=", // greater than or equal to (number)
-  // LTE = "<=", // less than or equal to (number)
-  // NIN = "nin", // Not in array (string or number)
-  // ANY = "any", // Contains any (array of strings)
-  // ALL = "all", // Contains all (array of strings)
-  // TEXT_MATCH = "text_match", // full text match (allows you to search for a specific substring, token or phrase within the text field)
-  // CONTAINS = "contains", // metadata array contains value (string or number)
+  GT = ">", // greater than (number)
+  LT = "<", // less than (number)
+  NE = "!=", // not equal to (string, number)
+  GTE = ">=", // greater than or equal to (number)
+  LTE = "<=", // less than or equal to (number)
+  NIN = "nin", // Not in array (string or number)
+  ANY = "any", // Contains any (array of strings)
+  ALL = "all", // Contains all (array of strings)
+  TEXT_MATCH = "text_match", // full text match (allows you to search for a specific substring, token or phrase within the text field)
+  CONTAINS = "contains", // metadata array contains value (string or number)
 }
 
 export enum FilterCondition {

--- a/packages/llamaindex/src/storage/vectorStore/types.ts
+++ b/packages/llamaindex/src/storage/vectorStore/types.ts
@@ -20,19 +20,51 @@ export enum VectorStoreQueryMode {
   MMR = "mmr",
 }
 
+/**
+ * @deprecated Use MetadataFilter with operator EQ instead
+ */
 export interface ExactMatchFilter {
   filterType: "ExactMatch";
   key: string;
   value: string | number;
 }
 
+export enum FilterOperator {
+  EQ = "==", // default operator (string, number)
+  // GT = ">", // greater than (number)
+  // LT = "<", // less than (number)
+  // NE = "!=", // not equal to (string, number)
+  // GTE = ">=", // greater than or equal to (number)
+  // LTE = "<=", // less than or equal to (number)
+  // IN = "in", // In array (string or number)
+  // NIN = "nin", // Not in array (string or number)
+  // ANY = "any", // Contains any (array of strings)
+  // ALL = "all", // Contains all (array of strings)
+  // TEXT_MATCH = "text_match", // full text match (allows you to search for a specific substring, token or phrase within the text field)
+  // CONTAINS = "contains", // metadata array contains value (string or number)
+}
+
+export enum FilterCondition {
+  AND = "and",
+  OR = "or",
+}
+
+export type MetadataFilterValue = string | number | string[] | number[];
+
+export interface MetadataFilter {
+  key: string;
+  value: MetadataFilterValue;
+  operator: `${FilterOperator}`; // ==, any, all,...
+}
+
 export interface MetadataFilters {
-  filters: ExactMatchFilter[];
+  filters: Array<MetadataFilter>;
+  condition?: `${FilterCondition}`; // and, or
 }
 
 export interface VectorStoreQuerySpec {
   query: string;
-  filters: ExactMatchFilter[];
+  filters: MetadataFilter[];
   topK?: number;
 }
 

--- a/packages/llamaindex/src/storage/vectorStore/utils.ts
+++ b/packages/llamaindex/src/storage/vectorStore/utils.ts
@@ -1,5 +1,6 @@
 import type { BaseNode, Metadata } from "@llamaindex/core/schema";
 import { ObjectType, jsonToNode } from "@llamaindex/core/schema";
+import type { MetadataFilterValue } from "./types.js";
 
 const DEFAULT_TEXT_KEY = "text";
 
@@ -77,3 +78,25 @@ export function metadataDictToNode(
       return jsonToNode(nodeObj, ObjectType.TEXT);
   }
 }
+
+export const parseNumberValue = (value: MetadataFilterValue): number => {
+  if (typeof value !== "number") throw new Error("Value must be a number");
+  return value;
+};
+
+export const parsePrimitiveValue = (value: MetadataFilterValue): string => {
+  if (typeof value !== "number" && typeof value !== "string") {
+    throw new Error("Value must be a string or number");
+  }
+  return value.toString();
+};
+
+export const parseArrayValue = (value: MetadataFilterValue): string[] => {
+  const isPrimitiveArray =
+    Array.isArray(value) &&
+    value.every((v) => typeof v === "string" || typeof v === "number");
+  if (!isPrimitiveArray) {
+    throw new Error("Value must be an array of strings or numbers");
+  }
+  return value.map(String);
+};

--- a/packages/llamaindex/tests/mocks/TestableMilvusVectorStore.ts
+++ b/packages/llamaindex/tests/mocks/TestableMilvusVectorStore.ts
@@ -1,0 +1,24 @@
+import type { BaseNode } from "@llamaindex/core/schema";
+import type { MilvusClient } from "@zilliz/milvus2-sdk-node";
+import { MilvusVectorStore } from "llamaindex";
+import { type Mocked } from "vitest";
+
+export class TestableMilvusVectorStore extends MilvusVectorStore {
+  public nodes: BaseNode[] = [];
+
+  private fakeTimeout = (ms: number) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
+
+  public async add(nodes: BaseNode[]): Promise<string[]> {
+    this.nodes.push(...nodes);
+    await this.fakeTimeout(100);
+    return nodes.map((node) => node.id_);
+  }
+
+  constructor() {
+    super({
+      milvusClient: {} as Mocked<MilvusClient>,
+    });
+  }
+}

--- a/packages/llamaindex/tests/vectorStores/MilvusVectorStore.test.ts
+++ b/packages/llamaindex/tests/vectorStores/MilvusVectorStore.test.ts
@@ -1,14 +1,12 @@
 import type { BaseNode } from "@llamaindex/core/schema";
 import { TextNode } from "@llamaindex/core/schema";
-import type { MilvusClient } from "@zilliz/milvus2-sdk-node";
 import {
   MilvusVectorStore,
   VectorStoreQueryMode,
   type MetadataFilters,
 } from "llamaindex";
-import { beforeEach, describe, expect, it, vi, type Mocked } from "vitest";
-
-vi.mock("@qdrant/js-client-rest");
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TestableMilvusVectorStore } from "../mocks/TestableMilvusVectorStore.js";
 
 type FilterTestCase = {
   title: string;
@@ -17,26 +15,6 @@ type FilterTestCase = {
   expectedFilterStr: string | undefined;
   mockResultIds: string[];
 };
-
-export class TestableMilvusVectorStore extends MilvusVectorStore {
-  public nodes: BaseNode[] = [];
-
-  private fakeTimeout = (ms: number) => {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-  };
-
-  public async add(nodes: BaseNode[]): Promise<string[]> {
-    this.nodes.push(...nodes);
-    await this.fakeTimeout(100);
-    return nodes.map((node) => node.id_);
-  }
-
-  constructor() {
-    super({
-      milvusClient: {} as Mocked<MilvusClient>,
-    });
-  }
-}
 
 describe("MilvusVectorStore", () => {
   let store: MilvusVectorStore;

--- a/packages/llamaindex/tests/vectorStores/MilvusVectorStore.test.ts
+++ b/packages/llamaindex/tests/vectorStores/MilvusVectorStore.test.ts
@@ -1,0 +1,355 @@
+import type { BaseNode } from "@llamaindex/core/schema";
+import { TextNode } from "@llamaindex/core/schema";
+import type { MilvusClient } from "@zilliz/milvus2-sdk-node";
+import {
+  MilvusVectorStore,
+  VectorStoreQueryMode,
+  type MetadataFilters,
+} from "llamaindex";
+import { beforeEach, describe, expect, it, vi, type Mocked } from "vitest";
+
+vi.mock("@qdrant/js-client-rest");
+
+type FilterTestCase = {
+  title: string;
+  filters?: MetadataFilters;
+  expected: number;
+  expectedFilterStr: string | undefined;
+  mockResultIds: string[];
+};
+
+export class TestableMilvusVectorStore extends MilvusVectorStore {
+  public nodes: BaseNode[] = [];
+
+  private fakeTimeout = (ms: number) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
+
+  public async add(nodes: BaseNode[]): Promise<string[]> {
+    this.nodes.push(...nodes);
+    await this.fakeTimeout(100);
+    return nodes.map((node) => node.id_);
+  }
+
+  constructor() {
+    super({
+      milvusClient: {} as Mocked<MilvusClient>,
+    });
+  }
+}
+
+describe("MilvusVectorStore", () => {
+  let store: MilvusVectorStore;
+  let nodes: BaseNode[];
+
+  beforeEach(() => {
+    store = new TestableMilvusVectorStore();
+    nodes = [
+      new TextNode({
+        id_: "1",
+        embedding: [0.1, 0.2],
+        text: "The dog is brown",
+        metadata: {
+          name: "Anakin",
+          dogId: "1",
+          private: "true",
+          weight: 1.2,
+          type: ["husky", "puppy"],
+        },
+      }),
+      new TextNode({
+        id_: "2",
+        embedding: [0.1, 0.2],
+        text: "The dog is yellow",
+        metadata: {
+          name: "Luke",
+          dogId: "2",
+          private: "false",
+          weight: 2.3,
+          type: ["puppy"],
+        },
+      }),
+      new TextNode({
+        id_: "3",
+        embedding: [0.1, 0.2],
+        text: "The dog is red",
+        metadata: {
+          name: "Leia",
+          dogId: "3",
+          private: "false",
+          weight: 3.4,
+          type: ["husky"],
+        },
+      }),
+    ];
+  });
+
+  describe("[MilvusVectorStore] manage nodes", () => {
+    it("able to add nodes to store", async () => {
+      const ids = await store.add(nodes);
+      expect(ids).length(3);
+    });
+  });
+
+  describe("[MilvusVectorStore] filter nodes with supported operators", () => {
+    const testcases: FilterTestCase[] = [
+      {
+        title: "No filter",
+        expected: 3,
+        mockResultIds: ["1", "2", "3"],
+        expectedFilterStr: undefined,
+      },
+      {
+        title: "Filter EQ",
+        filters: {
+          filters: [
+            {
+              key: "private",
+              value: "false",
+              operator: "==",
+            },
+          ],
+        },
+        expected: 2,
+        mockResultIds: ["2", "3"],
+        expectedFilterStr: 'metadata["private"] == "false"',
+      },
+      {
+        title: "Filter NE",
+        filters: {
+          filters: [
+            {
+              key: "private",
+              value: "false",
+              operator: "!=",
+            },
+          ],
+        },
+        expected: 1,
+        mockResultIds: ["1"],
+        expectedFilterStr: 'metadata["private"] != "false"',
+      },
+      {
+        title: "Filter GT",
+        filters: {
+          filters: [
+            {
+              key: "weight",
+              value: 2.3,
+              operator: ">",
+            },
+          ],
+        },
+        expected: 1,
+        mockResultIds: ["3"],
+        expectedFilterStr: 'metadata["weight"] > 2.3',
+      },
+      {
+        title: "Filter GTE",
+        filters: {
+          filters: [
+            {
+              key: "weight",
+              value: 2.3,
+              operator: ">=",
+            },
+          ],
+        },
+        expected: 2,
+        mockResultIds: ["2", "3"],
+        expectedFilterStr: 'metadata["weight"] >= 2.3',
+      },
+      {
+        title: "Filter LT",
+        filters: {
+          filters: [
+            {
+              key: "weight",
+              value: 2.3,
+              operator: "<",
+            },
+          ],
+        },
+        expected: 1,
+        mockResultIds: ["1"],
+        expectedFilterStr: 'metadata["weight"] < 2.3',
+      },
+      {
+        title: "Filter LTE",
+        filters: {
+          filters: [
+            {
+              key: "weight",
+              value: 2.3,
+              operator: "<=",
+            },
+          ],
+        },
+        expected: 2,
+        mockResultIds: ["1", "2"],
+        expectedFilterStr: 'metadata["weight"] <= 2.3',
+      },
+      {
+        title: "Filter IN",
+        filters: {
+          filters: [
+            {
+              key: "dogId",
+              value: ["1", "3"],
+              operator: "in",
+            },
+          ],
+        },
+        expected: 2,
+        mockResultIds: ["1", "3"],
+        expectedFilterStr: 'metadata["dogId"] in ["1", "3"]',
+      },
+      {
+        title: "Filter NIN",
+        filters: {
+          filters: [
+            {
+              key: "name",
+              value: ["Anakin", "Leia"],
+              operator: "nin",
+            },
+          ],
+        },
+        expected: 1,
+        mockResultIds: ["2"],
+        expectedFilterStr:
+          'metadata["name"] != "Anakin" && metadata["name"] != "Leia"',
+      },
+      {
+        title: "Filter OR",
+        filters: {
+          filters: [
+            {
+              key: "private",
+              value: "false",
+              operator: "==",
+            },
+            {
+              key: "dogId",
+              value: ["1", "3"],
+              operator: "in",
+            },
+          ],
+          condition: "or",
+        },
+        expected: 3,
+        mockResultIds: ["1", "2", "3"],
+        expectedFilterStr:
+          'metadata["private"] == "false" or metadata["dogId"] in ["1", "3"]',
+      },
+      {
+        title: "Filter AND",
+        filters: {
+          filters: [
+            {
+              key: "private",
+              value: "false",
+              operator: "==",
+            },
+            {
+              key: "dogId",
+              value: "10",
+              operator: "==",
+            },
+          ],
+          condition: "and",
+        },
+        expected: 0,
+        mockResultIds: [],
+        expectedFilterStr:
+          'metadata["private"] == "false" and metadata["dogId"] == "10"',
+      },
+    ];
+
+    testcases.forEach((tc) => {
+      it(`[${tc.title}] should return ${tc.expected} nodes`, async () => {
+        expect(store.toMilvusFilter(tc.filters)).toBe(tc.expectedFilterStr);
+
+        vi.spyOn(store, "query").mockResolvedValue({
+          ids: tc.mockResultIds,
+          similarities: [0.1, 0.2, 0.3],
+        });
+
+        await store.add(nodes);
+        const result = await store.query({
+          queryEmbedding: [0.1, 0.2],
+          similarityTopK: 3,
+          mode: VectorStoreQueryMode.DEFAULT,
+          filters: tc.filters,
+        });
+        expect(result.ids).length(tc.expected);
+      });
+    });
+  });
+
+  describe("[MilvusVectorStore] filter nodes with unsupported operators", () => {
+    const testcases: Array<
+      Omit<FilterTestCase, "expectedFilterStr" | "mockResultIds">
+    > = [
+      {
+        title: "Filter ANY",
+        filters: {
+          filters: [
+            {
+              key: "type",
+              value: ["husky", "puppy"],
+              operator: "any",
+            },
+          ],
+        },
+        expected: 3,
+      },
+      {
+        title: "Filter ALL",
+        filters: {
+          filters: [
+            {
+              key: "type",
+              value: ["husky", "puppy"],
+              operator: "all",
+            },
+          ],
+        },
+        expected: 1,
+      },
+      {
+        title: "Filter CONTAINS",
+        filters: {
+          filters: [
+            {
+              key: "type",
+              value: "puppy",
+              operator: "contains",
+            },
+          ],
+        },
+        expected: 2,
+      },
+      {
+        title: "Filter TEXT_MATCH",
+        filters: {
+          filters: [
+            {
+              key: "name",
+              value: "Luk",
+              operator: "text_match",
+            },
+          ],
+        },
+        expected: 1,
+      },
+    ];
+
+    testcases.forEach((tc) => {
+      it(`[Unsupported Operator] [${tc.title}] should throw error`, async () => {
+        const errorMsg = `Operator ${tc.filters?.filters[0].operator} is not supported.`;
+        expect(() => store.toMilvusFilter(tc.filters)).toThrow(errorMsg);
+      });
+    });
+  });
+});

--- a/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
+++ b/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
@@ -19,19 +19,19 @@ describe("SimpleVectorStore", () => {
         id_: "1",
         embedding: [0.1, 0.2],
         text: "The dog is brown",
-        metadata: { dogId: "1", private: true },
+        metadata: { dogId: "1", private: "true" },
       }),
       new TextNode({
         id_: "2",
         embedding: [0.2, 0.3],
         text: "The dog is yellow",
-        metadata: { dogId: "2", private: false },
+        metadata: { dogId: "2", private: "false" },
       }),
       new TextNode({
         id_: "3",
         embedding: [0.3, 0.1],
         text: "The dog is red",
-        metadata: { dogId: "3", private: false },
+        metadata: { dogId: "3", private: "false" },
       }),
     ];
     store = new SimpleVectorStore({
@@ -41,9 +41,9 @@ describe("SimpleVectorStore", () => {
         textIdToRefDocId: {},
         metadataDict: {
           // Mocking the metadataDict
-          "1": { dogId: "1", private: true },
-          "2": { dogId: "2", private: false },
-          "3": { dogId: "3", private: false },
+          "1": { dogId: "1", private: "true" },
+          "2": { dogId: "2", private: "false" },
+          "3": { dogId: "3", private: "false" },
         },
       },
     });

--- a/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
+++ b/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
@@ -265,7 +265,7 @@ describe("SimpleVectorStore", () => {
         expected: 3,
       },
       {
-        title: "Filter OR",
+        title: "Filter AND",
         filters: {
           filters: [
             {

--- a/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
+++ b/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
@@ -74,7 +74,7 @@ describe("SimpleVectorStore", () => {
             {
               key: "private",
               value: "false",
-              filterType: "ExactMatch",
+              operator: "==",
             },
           ],
         },

--- a/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
+++ b/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
@@ -63,7 +63,7 @@ describe("SimpleVectorStore", () => {
       });
       expect(result.similarities).length(3);
     });
-    it("able to query nodes with filter", async () => {
+    it("able to query nodes with filter EQ", async () => {
       await store.add(nodes);
       const result = await store.query({
         queryEmbedding: [0.1, 0.2],
@@ -75,6 +75,24 @@ describe("SimpleVectorStore", () => {
               key: "private",
               value: "false",
               operator: "==",
+            },
+          ],
+        },
+      });
+      expect(result.similarities).length(2);
+    });
+    it("able to query nodes with filter IN", async () => {
+      await store.add(nodes);
+      const result = await store.query({
+        queryEmbedding: [0.1, 0.2],
+        similarityTopK: 3,
+        mode: VectorStoreQueryMode.DEFAULT,
+        filters: {
+          filters: [
+            {
+              key: "dogId",
+              value: ["1", "3"],
+              operator: "in",
             },
           ],
         },

--- a/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
+++ b/packages/llamaindex/tests/vectorStores/SimpleVectorStore.test.ts
@@ -99,5 +99,29 @@ describe("SimpleVectorStore", () => {
       });
       expect(result.similarities).length(2);
     });
+    it("able to query nodes with filter condition OR", async () => {
+      await store.add(nodes);
+      const result = await store.query({
+        queryEmbedding: [0.1, 0.2],
+        similarityTopK: 3,
+        mode: VectorStoreQueryMode.DEFAULT,
+        filters: {
+          filters: [
+            {
+              key: "private",
+              value: "false",
+              operator: "==",
+            },
+            {
+              key: "dogId",
+              value: ["1", "3"],
+              operator: "in",
+            },
+          ],
+          condition: "or",
+        },
+      });
+      expect(result.similarities).length(3);
+    });
   });
 });


### PR DESCRIPTION
- Mark ExactMatchFilter as deprecated and use MetadataFilter with many supported operations
- Support `OR` and `AND` condition
- Support new operators: EQ, IN
- Add filtering for MilvusVectorStore first
- Support more operators
- Add tests and examples with all operators for SimpleVectorStore and Milvus

Sample filter:
```
const queryEngineOR = index.asQueryEngine({
    preFilters: {
      filters: [
        {
          key: "private",
          value: "false",
          operator: "==",
        },
        {
          key: "dogId",
          value: ["1", "3"],
          operator: "in",
        },
      ],
      condition: "or",
    }
  });
```
