### PR TITLE
fix: DataCloneError when using FunctionTool

### DIFF
--- a/.changeset/short-plants-sip.md
+++ b/.changeset/short-plants-sip.md
@@ -1,0 +1,6 @@
+---
+"@llamaindex/core": patch
+"llamaindex": patch
+---
+
+fix: DataCloneError when using FunctionTool

--- a/packages/core/src/global/settings/callback-manager.ts
+++ b/packages/core/src/global/settings/callback-manager.ts
@@ -105,9 +105,7 @@ export class CallbackManager {
     }
     queueMicrotask(() => {
       cbs.forEach((handler) =>
-        handler(
-          LlamaIndexCustomEvent.fromEvent(event, structuredClone(detail)),
-        ),
+        handler(LlamaIndexCustomEvent.fromEvent(event, { ...detail })),
       );
     });
   }

--- a/packages/core/tests/event-system.test.ts
+++ b/packages/core/tests/event-system.test.ts
@@ -6,6 +6,9 @@ declare module "@llamaindex/core/global" {
     test: {
       value: number;
     };
+    functionTest: {
+      fn: ({ x }: { x: number }) => string;
+    };
   }
 }
 
@@ -36,6 +39,25 @@ describe("event system", () => {
 
     Settings.callbackManager.dispatchEvent("test", {
       value: 42,
+    });
+    expect(callback).toHaveBeenCalledTimes(0);
+    await new Promise((resolve) => process.nextTick(resolve));
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("dispatch function tool event", async () => {
+    const testFunction = ({ x }: { x: number }) => `${x * 2}`;
+    let callback;
+    Settings.callbackManager.on(
+      "functionTest",
+      (callback = vi.fn((event) => {
+        const data = event.detail;
+        expect(data.fn).toBe(testFunction);
+      })),
+    );
+
+    Settings.callbackManager.dispatchEvent("functionTest", {
+      fn: testFunction,
     });
     expect(callback).toHaveBeenCalledTimes(0);
     await new Promise((resolve) => process.nextTick(resolve));


### PR DESCRIPTION
In #1026, `CallbackManager.dispatchEvent` was changed from [using a spread operator](https://github.com/run-llama/LlamaIndexTS/blob/llamaindex%400.4.14/packages/llamaindex/src/callbacks/CallbackManager.ts#L223-L225) to using `structuredClone`. This breaks with `llm-tool-result` events, since `FunctionTool` has an `_fn` property with the original function. `structuredClone` throws a `DataCloneError` since it cannot clone functions.

I'm not sure if there was more motivation behind using `structruedClone`, but I've added a test to reproduce the error with a simplified event, and changed `dispatchEvent` back to using a spread operator to perform a shallow clone of the event detail.