### PR TITLE
fix: passing max_token option to replicate's api call

### DIFF
--- a/.changeset/tender-mice-retire.md
+++ b/.changeset/tender-mice-retire.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: passing max_token option to replicate's api call

--- a/packages/llamaindex/src/llm/replicate_ai.ts
+++ b/packages/llamaindex/src/llm/replicate_ai.ts
@@ -323,6 +323,7 @@ If a question does not make any sense, or is not factually coherent, explain why
         prompt,
         system_prompt: systemPrompt,
         temperature: this.temperature,
+        max_tokens: this.maxTokens,
         top_p: this.topP,
       },
     };


### PR DESCRIPTION
In the `ReplicateLLM` class, the `maxTokens` option was not being passed to the replicate's api when calling the `chat()` method.