### PR TITLE
fix: local build having "missing client - which HTTP client do you want to generate" issue

### DIFF
--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "generate": "pnpm dlx @hey-api/openapi-ts",
+    "generate": "pnpm dlx @hey-api/openapi-ts --client fetch",
     "build": "pnpm run generate && bunchee"
   },
   "files": [


### PR DESCRIPTION
fixes the following error that happened in my local build

```
🔥 Unexpected error occurred. Log saved to /Users/marcus/code/llamaindex/LlamaIndexTS/packages/cloud/openapi-ts-error-1722331433039.log
🔥 Unexpected error occurred. 🚫 missing client - which HTTP client do you want to generate?
 ELIFECYCLE  Command failed with exit code 1.
```