### PR TITLE
fix: metadata should not be included after sentence splitter

### DIFF
--- a/.changeset/real-seahorses-divide.md
+++ b/.changeset/real-seahorses-divide.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/core": patch
+---
+
+Fix issue with metadata included after sentence splitter

--- a/packages/core/src/node-parser/base.ts
+++ b/packages/core/src/node-parser/base.ts
@@ -140,7 +140,7 @@ export abstract class MetadataAwareTextSplitter extends TextSplitter {
     return nodes.reduce<TextNode[]>((allNodes, node) => {
       const metadataStr = this.getMetadataString(node);
       const splits = this.splitTextMetadataAware(
-        node.getContent(MetadataMode.ALL),
+        node.getContent(MetadataMode.NONE),
         metadataStr,
       );
       return allNodes.concat(buildNodeFromSplits(splits, node));


### PR DESCRIPTION
See https://github.com/run-llama/LlamaIndexTS/issues/1098