### PR TITLE
fix: use metadata mode LLM for generating context

### DIFF
--- a/.changeset/tough-cups-doubt.md
+++ b/.changeset/tough-cups-doubt.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: use LLM metadata mode for generating context of ContextChatEngine

--- a/packages/llamaindex/src/engines/chat/ContextChatEngine.ts
+++ b/packages/llamaindex/src/engines/chat/ContextChatEngine.ts
@@ -4,7 +4,7 @@ import type {
   MessageContent,
   MessageType,
 } from "@llamaindex/core/llms";
-import { EngineResponse } from "@llamaindex/core/schema";
+import { EngineResponse, MetadataMode } from "@llamaindex/core/schema";
 import {
   extractText,
   streamConverter,
@@ -53,6 +53,7 @@ export class ContextChatEngine extends PromptMixin implements ChatEngine {
       contextSystemPrompt: init?.contextSystemPrompt,
       nodePostprocessors: init?.nodePostprocessors,
       contextRole: init?.contextRole,
+      metadataMode: MetadataMode.LLM,
     });
     this.systemPrompt = init.systemPrompt;
   }

--- a/packages/llamaindex/src/engines/chat/DefaultContextGenerator.ts
+++ b/packages/llamaindex/src/engines/chat/DefaultContextGenerator.ts
@@ -1,5 +1,5 @@
 import type { MessageContent, MessageType } from "@llamaindex/core/llms";
-import { type NodeWithScore } from "@llamaindex/core/schema";
+import { MetadataMode, type NodeWithScore } from "@llamaindex/core/schema";
 import type { BaseNodePostprocessor } from "../../postprocessors/index.js";
 import type { ContextSystemPrompt } from "../../Prompt.js";
 import { defaultContextSystemPrompt } from "../../Prompt.js";
@@ -16,12 +16,14 @@ export class DefaultContextGenerator
   contextSystemPrompt: ContextSystemPrompt;
   nodePostprocessors: BaseNodePostprocessor[];
   contextRole: MessageType;
+  metadataMode?: MetadataMode;
 
   constructor(init: {
     retriever: BaseRetriever;
     contextSystemPrompt?: ContextSystemPrompt;
     nodePostprocessors?: BaseNodePostprocessor[];
     contextRole?: MessageType;
+    metadataMode?: MetadataMode;
   }) {
     super();
 
@@ -30,6 +32,7 @@ export class DefaultContextGenerator
       init?.contextSystemPrompt ?? defaultContextSystemPrompt;
     this.nodePostprocessors = init.nodePostprocessors || [];
     this.contextRole = init.contextRole ?? "system";
+    this.metadataMode = init.metadataMode ?? MetadataMode.NONE;
   }
 
   protected _getPrompts(): { contextSystemPrompt: ContextSystemPrompt } {
@@ -75,6 +78,8 @@ export class DefaultContextGenerator
     const content = await createMessageContent(
       this.contextSystemPrompt,
       nodes.map((r) => r.node),
+      undefined,
+      this.metadataMode,
     );
 
     return {


### PR DESCRIPTION
Should use mode LLM to generating context in ContextChatEngine LITS.
See Python usage: https://github.com/run-llama/llama_index/blob/96a196a9d0bed9ea8a3b9f9caac18639faaf0249/llama-index-core/llama_index/core/chat_engine/condense_plus_context.py#L167-L169