### PR TITLE
fix: remove Stream API polyfill

### DIFF
--- a/examples/agent/openai-task.ts
+++ b/examples/agent/openai-task.ts
@@ -1,5 +1,4 @@
-import { ChatResponseChunk, OpenAIAgent } from "llamaindex";
-import { ReadableStream } from "node:stream/web";
+import { OpenAIAgent } from "llamaindex";
 import {
   getCurrentIDTool,
   getUserInfoTool,
@@ -18,7 +17,7 @@ async function main() {
   );
 
   for await (const stepOutput of task) {
-    const stream = stepOutput.output as ReadableStream<ChatResponseChunk>;
+    const stream = stepOutput.output;
     if (stepOutput.isLast) {
       for await (const chunk of stream) {
         process.stdout.write(chunk.delta);

--- a/examples/agent/openai-task.ts
+++ b/examples/agent/openai-task.ts
@@ -1,4 +1,4 @@
-import { OpenAIAgent } from "llamaindex";
+import { ChatResponseChunk, OpenAIAgent } from "llamaindex";
 import {
   getCurrentIDTool,
   getUserInfoTool,
@@ -17,7 +17,7 @@ async function main() {
   );
 
   for await (const stepOutput of task) {
-    const stream = stepOutput.output;
+    const stream = stepOutput.output as ReadableStream<ChatResponseChunk>;
     if (stepOutput.isLast) {
       for await (const chunk of stream) {
         process.stdout.write(chunk.delta);

--- a/examples/agent/react-task.ts
+++ b/examples/agent/react-task.ts
@@ -1,5 +1,4 @@
 import { ChatResponseChunk, ReActAgent } from "llamaindex";
-import { ReadableStream } from "node:stream/web";
 import {
   getCurrentIDTool,
   getUserInfoTool,

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -7,8 +7,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["ES2022", "DOM.AsyncIterable"],
-    "types": ["node"],
     "outDir": "./lib",
     "tsBuildInfoFile": "./lib/.tsbuildinfo",
     "incremental": true,

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM.AsyncIterable"],
     "types": ["node"],
     "outDir": "./lib",
     "tsBuildInfoFile": "./lib/.tsbuildinfo",

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -16,11 +16,6 @@ import { createHash, randomUUID } from "node:crypto";
 import { EOL } from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
-import {
-  ReadableStream,
-  TransformStream,
-  WritableStream,
-} from "node:stream/web";
 import { fileURLToPath } from "node:url";
 import { createWriteStream, fs } from "./fs/node.js";
 import type { SHA256 } from "./polyfill.js";
@@ -48,7 +43,4 @@ export {
   path,
   randomUUID,
   Readable,
-  ReadableStream,
-  TransformStream,
-  WritableStream,
 };

--- a/packages/env/src/polyfill.ts
+++ b/packages/env/src/polyfill.ts
@@ -46,12 +46,4 @@ export function randomUUID(): string {
   return crypto.randomUUID();
 }
 
-// @ts-expect-error
-const ReadableStream = globalThis.ReadableStream;
-// @ts-expect-error
-const TransformStream = globalThis.TransformStream;
-// @ts-expect-error
-const WritableStream = globalThis.WritableStream;
-
 export { AsyncLocalStorage, CustomEvent, getEnv, setEnvs } from "./utils.js";
-export { ReadableStream, TransformStream, WritableStream };

--- a/packages/llamaindex/e2e/examples/cloudflare-worker-agent/src/index.ts
+++ b/packages/llamaindex/e2e/examples/cloudflare-worker-agent/src/index.ts
@@ -18,14 +18,12 @@ export default {
     console.log(2);
     const textEncoder = new TextEncoder();
     const response = responseStream.pipeThrough<Uint8Array>(
-      // @ts-expect-error: see https://github.com/cloudflare/workerd/issues/2067
       new TransformStream({
         transform: (chunk, controller) => {
           controller.enqueue(textEncoder.encode(chunk.delta));
         },
       }),
     );
-    // @ts-expect-error: see https://github.com/cloudflare/workerd/issues/2067
     return new Response(response);
   },
 };

--- a/packages/llamaindex/e2e/tsconfig.json
+++ b/packages/llamaindex/e2e/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "node16",
     "moduleResolution": "node16",
     "target": "ESNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM.AsyncIterable"],
     "types": ["node"]
   },
   "include": ["./node", "./mock-module.js", "./mock-register.js", "./fixtures"],

--- a/packages/llamaindex/src/agent/base.ts
+++ b/packages/llamaindex/src/agent/base.ts
@@ -7,7 +7,7 @@ import type {
 } from "@llamaindex/core/llms";
 import { EngineResponse } from "@llamaindex/core/schema";
 import { wrapEventCaller } from "@llamaindex/core/utils";
-import { ReadableStream, TransformStream, randomUUID } from "@llamaindex/env";
+import { randomUUID } from "@llamaindex/env";
 import { ChatHistory } from "../ChatHistory.js";
 import { Settings } from "../Settings.js";
 import {
@@ -16,7 +16,7 @@ import {
   type ChatEngineParamsStreaming,
 } from "../engines/chat/index.js";
 import { consoleLogger, emptyLogger } from "../internal/logger.js";
-import { isAsyncIterable } from "../internal/utils.js";
+import { isReadableStream } from "../internal/utils.js";
 import { ObjectRetriever } from "../objects/index.js";
 import type {
   AgentTaskContext,
@@ -374,7 +374,7 @@ export abstract class AgentRunner<
       this.#chatHistory = [...stepOutput.taskStep.context.store.messages];
       if (stepOutput.isLast) {
         const { output } = stepOutput;
-        if (isAsyncIterable(output)) {
+        if (isReadableStream(output)) {
           return output.pipeThrough<EngineResponse>(
             new TransformStream({
               transform(chunk, controller) {

--- a/packages/llamaindex/src/agent/react.ts
+++ b/packages/llamaindex/src/agent/react.ts
@@ -7,7 +7,7 @@ import type {
   LLM,
 } from "@llamaindex/core/llms";
 import { extractText } from "@llamaindex/core/utils";
-import { randomUUID, ReadableStream } from "@llamaindex/env";
+import { randomUUID } from "@llamaindex/env";
 import { getReACTAgentSystemHeader } from "../internal/prompt/react.js";
 import {
   isAsyncIterable,

--- a/packages/llamaindex/src/agent/types.ts
+++ b/packages/llamaindex/src/agent/types.ts
@@ -7,7 +7,6 @@ import type {
   MessageContent,
   ToolOutput,
 } from "@llamaindex/core/llms";
-import { ReadableStream } from "@llamaindex/env";
 import type { Logger } from "../internal/logger.js";
 import type { UUID } from "../types.js";
 

--- a/packages/llamaindex/src/agent/utils.ts
+++ b/packages/llamaindex/src/agent/utils.ts
@@ -16,7 +16,6 @@ import type {
   ToolOutput,
 } from "@llamaindex/core/llms";
 import { baseToolWithCallSchema } from "@llamaindex/core/schema";
-import { ReadableStream } from "@llamaindex/env";
 import { z } from "zod";
 import type { Logger } from "../internal/logger.js";
 import {

--- a/packages/llamaindex/src/internal/utils.ts
+++ b/packages/llamaindex/src/internal/utils.ts
@@ -10,6 +10,10 @@ export const isAsyncIterable = (
   return obj != null && typeof obj === "object" && Symbol.asyncIterator in obj;
 };
 
+export const isReadableStream = (obj: unknown): obj is ReadableStream => {
+  return obj instanceof ReadableStream;
+};
+
 export const isIterable = (obj: unknown): obj is Iterable<unknown> => {
   return obj != null && typeof obj === "object" && Symbol.iterator in obj;
 };


### PR DESCRIPTION
remove polyfill because originally we use this for type check but now TypeScript >5.4 already add this type `DOM.AsyncIterator` so I think it's safe to remove the polyfill now.