### PR TITLE
fix: database insertion for PGVectorStore

### DIFF
--- a/.changeset/new-tools-help.md
+++ b/.changeset/new-tools-help.md
@@ -1,5 +1,0 @@
----
-"llamaindex": patch
----
-
-fix: database insertion for PGVectorStore

--- a/.changeset/new-tools-help.md
+++ b/.changeset/new-tools-help.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: database insertion for PGVectorStore

--- a/.changeset/six-frogs-thank.md
+++ b/.changeset/six-frogs-thank.md
@@ -1,0 +1,11 @@
+---
+"llamaindex": patch
+---
+
+Fix database insertion for `PGVectorStore`
+
+It will now:
+
+- throw an error if there is an insertion error.
+- Upsert documents with the same id.
+- add all documents to the database as a single `INSERT` call (inside a transaction).


### PR DESCRIPTION
Closes: #1153 

It will now:

- throw an error if there is an insertion error.
- Upsert documents with the same id.
- add all documents to the database as a single `INSERT` call (inside a transaction).