### PR TITLE
fix: add `serializer` in doc store

### DIFF
--- a/.changeset/gorgeous-bees-hide.md
+++ b/.changeset/gorgeous-bees-hide.md
@@ -1,0 +1,7 @@
+---
+"llamaindex": patch
+---
+
+fix: add `serializer` in doc store
+
+`PostgresDocumentStore` now will not use JSON.stringify for better performance

--- a/packages/llamaindex/src/ingestion/IngestionCache.ts
+++ b/packages/llamaindex/src/ingestion/IngestionCache.ts
@@ -1,7 +1,11 @@
 import type { BaseNode, TransformComponent } from "@llamaindex/core/schema";
 import { MetadataMode } from "@llamaindex/core/schema";
 import { createSHA256 } from "@llamaindex/env";
-import { docToJson, jsonToDoc } from "../storage/docStore/utils.js";
+import {
+  docToJson,
+  jsonSerializer,
+  jsonToDoc,
+} from "../storage/docStore/utils.js";
 import { SimpleKVStore } from "../storage/kvStore/SimpleKVStore.js";
 import type { BaseKVStore } from "../storage/kvStore/types.js";
 
@@ -53,7 +57,7 @@ export class IngestionCache {
 
   async put(hash: string, nodes: BaseNode[]) {
     const val = {
-      [this.nodesKey]: nodes.map((node) => docToJson(node)),
+      [this.nodesKey]: nodes.map((node) => docToJson(node, jsonSerializer)),
     };
     await this.cache.put(hash, val, this.collection);
   }
@@ -63,6 +67,8 @@ export class IngestionCache {
     if (!json || !json[this.nodesKey] || !Array.isArray(json[this.nodesKey])) {
       return undefined;
     }
-    return json[this.nodesKey].map((doc: any) => jsonToDoc(doc));
+    return json[this.nodesKey].map((doc: any) =>
+      jsonToDoc(doc, jsonSerializer),
+    );
   }
 }

--- a/packages/llamaindex/src/storage/docStore/PostgresDocumentStore.ts
+++ b/packages/llamaindex/src/storage/docStore/PostgresDocumentStore.ts
@@ -1,10 +1,13 @@
 import { DEFAULT_NAMESPACE } from "@llamaindex/core/global";
 import { PostgresKVStore } from "../kvStore/PostgresKVStore.js";
 import { KVDocumentStore } from "./KVDocumentStore.js";
+import { noneSerializer } from "./utils.js";
 
 const DEFAULT_TABLE_NAME = "llamaindex_doc_store";
 
 export class PostgresDocumentStore extends KVDocumentStore {
+  serializer = noneSerializer;
+
   constructor(config?: {
     schemaName?: string;
     tableName?: string;
@@ -16,7 +19,6 @@ export class PostgresDocumentStore extends KVDocumentStore {
       tableName: config?.tableName || DEFAULT_TABLE_NAME,
     });
     const namespace = config?.namespace || DEFAULT_NAMESPACE;
-    const nativeJson = true;
-    super(kvStore, namespace, nativeJson);
+    super(kvStore, namespace);
   }
 }

--- a/packages/llamaindex/src/storage/docStore/PostgresDocumentStore.ts
+++ b/packages/llamaindex/src/storage/docStore/PostgresDocumentStore.ts
@@ -13,7 +13,7 @@ export type PostgresDocumentStoreConfig = PostgresKVStoreConfig & {
 };
 
 export class PostgresDocumentStore extends KVDocumentStore {
-	serializer = noneSerializer;
+  serializer = noneSerializer;
 
   constructor(config?: PostgresDocumentStoreConfig) {
     const kvStore = new PostgresKVStore({

--- a/packages/llamaindex/src/storage/docStore/PostgresDocumentStore.ts
+++ b/packages/llamaindex/src/storage/docStore/PostgresDocumentStore.ts
@@ -16,6 +16,7 @@ export class PostgresDocumentStore extends KVDocumentStore {
       tableName: config?.tableName || DEFAULT_TABLE_NAME,
     });
     const namespace = config?.namespace || DEFAULT_NAMESPACE;
-    super(kvStore, namespace);
+    const nativeJson = true;
+    super(kvStore, namespace, nativeJson);
   }
 }

--- a/packages/llamaindex/src/storage/docStore/types.ts
+++ b/packages/llamaindex/src/storage/docStore/types.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_PERSIST_DIR,
 } from "@llamaindex/core/global";
 import { BaseNode } from "@llamaindex/core/schema";
+import { jsonSerializer, type Serializer } from "./utils.js";
 
 const defaultPersistPath = `${DEFAULT_PERSIST_DIR}/${DEFAULT_DOC_STORE_PERSIST_FILENAME}`;
 
@@ -12,6 +13,8 @@ export interface RefDocInfo {
 }
 
 export abstract class BaseDocumentStore {
+  serializer: Serializer<any> = jsonSerializer;
+
   // Save/load
   persist(persistPath: string = defaultPersistPath): void {
     // Persist the docstore to a file.

--- a/packages/llamaindex/src/storage/docStore/utils.ts
+++ b/packages/llamaindex/src/storage/docStore/utils.ts
@@ -6,7 +6,7 @@ const DATA_KEY = "__data__";
 
 type DocJson = {
   [TYPE_KEY]: ObjectType;
-  [DATA_KEY]: string;
+  [DATA_KEY]: string | any;
 };
 
 export function isValidDocJson(docJson: any): docJson is DocJson {
@@ -18,16 +18,18 @@ export function isValidDocJson(docJson: any): docJson is DocJson {
   );
 }
 
-export function docToJson(doc: BaseNode): DocJson {
+export function docToJson(doc: BaseNode, nativeJson?: boolean): DocJson {
   return {
-    [DATA_KEY]: JSON.stringify(doc.toJSON()),
+    [DATA_KEY]: nativeJson ? doc.toJSON() : JSON.stringify(doc.toJSON()),
     [TYPE_KEY]: doc.type,
   };
 }
 
-export function jsonToDoc(docDict: DocJson): BaseNode {
+export function jsonToDoc(docDict: DocJson, nativeJson?: boolean): BaseNode {
   const docType = docDict[TYPE_KEY];
-  const dataDict = JSON.parse(docDict[DATA_KEY]);
+  const dataDict = nativeJson
+    ? docDict[DATA_KEY]
+    : JSON.parse(docDict[DATA_KEY]);
   let doc: BaseNode;
 
   if (docType === ObjectType.DOCUMENT) {

--- a/packages/llamaindex/src/storage/docStore/utils.ts
+++ b/packages/llamaindex/src/storage/docStore/utils.ts
@@ -4,12 +4,35 @@ import { Document, ObjectType, TextNode } from "@llamaindex/core/schema";
 const TYPE_KEY = "__type__";
 const DATA_KEY = "__data__";
 
-type DocJson = {
-  [TYPE_KEY]: ObjectType;
-  [DATA_KEY]: string | any;
+export interface Serializer<T> {
+  toPersistence(data: Record<string, unknown>): T;
+  fromPersistence(data: T): Record<string, unknown>;
+}
+
+export const jsonSerializer: Serializer<string> = {
+  toPersistence(data) {
+    return JSON.stringify(data);
+  },
+  fromPersistence(data) {
+    return JSON.parse(data);
+  },
 };
 
-export function isValidDocJson(docJson: any): docJson is DocJson {
+export const noneSerializer: Serializer<Record<string, unknown>> = {
+  toPersistence(data) {
+    return data;
+  },
+  fromPersistence(data) {
+    return data;
+  },
+};
+
+type DocJson<Data> = {
+  [TYPE_KEY]: ObjectType;
+  [DATA_KEY]: Data;
+};
+
+export function isValidDocJson(docJson: any): docJson is DocJson<unknown> {
   return (
     typeof docJson === "object" &&
     docJson !== null &&
@@ -18,18 +41,22 @@ export function isValidDocJson(docJson: any): docJson is DocJson {
   );
 }
 
-export function docToJson(doc: BaseNode, nativeJson?: boolean): DocJson {
+export function docToJson(
+  doc: BaseNode,
+  serializer: Serializer<unknown>,
+): DocJson<unknown> {
   return {
-    [DATA_KEY]: nativeJson ? doc.toJSON() : JSON.stringify(doc.toJSON()),
+    [DATA_KEY]: serializer.toPersistence(doc.toJSON()),
     [TYPE_KEY]: doc.type,
   };
 }
 
-export function jsonToDoc(docDict: DocJson, nativeJson?: boolean): BaseNode {
+export function jsonToDoc<Data>(
+  docDict: DocJson<Data>,
+  serializer: Serializer<Data>,
+): BaseNode {
   const docType = docDict[TYPE_KEY];
-  const dataDict = nativeJson
-    ? docDict[DATA_KEY]
-    : JSON.parse(docDict[DATA_KEY]);
+  const dataDict = serializer.fromPersistence(docDict[DATA_KEY]) as any;
   let doc: BaseNode;
 
   if (docType === ObjectType.DOCUMENT) {


### PR DESCRIPTION
- allow querying documents `__data__` in `pg` by storing plain JSON
- avoid performance costs involved with `parse`/`stringify`