### PR TITLE
fix: openai streaming with token usage and finish_reason

### DIFF
--- a/.changeset/nine-carpets-jam.md
+++ b/.changeset/nine-carpets-jam.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/openai": patch
+---
+
+fix: openai streaming with token usage and finish_reason

--- a/packages/llm/openai/src/llm.ts
+++ b/packages/llm/openai/src/llm.ts
@@ -425,10 +425,25 @@ export class OpenAI extends ToolCallLLM<OpenAIAdditionalChatOptions> {
     let currentToolCall: PartialToolCall | null = null;
     const toolCallMap = new Map<string, PartialToolCall>();
     for await (const part of stream) {
-      if (part.choices.length === 0) continue;
+      if (part.choices.length === 0) {
+        if (part.usage) {
+          yield {
+            raw: part,
+            delta: "",
+          };
+        }
+        continue;
+      }
       const choice = part.choices[0]!;
       // skip parts that don't have any content
-      if (!(choice.delta.content || choice.delta.tool_calls)) continue;
+      if (
+        !(
+          choice.delta.content ||
+          choice.delta.tool_calls ||
+          choice.finish_reason
+        )
+      )
+        continue;
 
       let shouldEmitToolCall: PartialToolCall | null = null;
       if (


### PR DESCRIPTION
llama openai is not streaming token usage even when
```
        additionalChatOptions: {
          stream: true,
          stream_options: {
            include_usage: true
          }
        }
```
is passed into LlamaOpenAI,
The fix will allow user to get token usage provided by OpenAI when streaming.