### PR TITLE
fix: export llama reader in non-nodejs runtime

### DIFF
--- a/.changeset/violet-buckets-joke.md
+++ b/.changeset/violet-buckets-joke.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: export llama reader in non-nodejs runtime

--- a/packages/llamaindex/src/index.edge.ts
+++ b/packages/llamaindex/src/index.edge.ts
@@ -1,3 +1,8 @@
+export {
+  LlamaParseReader,
+  type Language,
+  type ResultType,
+} from "@llamaindex/cloud/reader";
 export * from "@llamaindex/core/agent";
 export * from "@llamaindex/core/chat-engine";
 export {


### PR DESCRIPTION
Fixes: https://github.com/run-llama/LlamaIndexTS/issues/1271