### PR TITLE
fix: ignore webpack resolve unpdf for nextjs

### DIFF
--- a/.changeset/rare-sheep-search.md
+++ b/.changeset/rare-sheep-search.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: ignore resolving unpdf for nextjs

--- a/packages/llamaindex/src/next.ts
+++ b/packages/llamaindex/src/next.ts
@@ -37,6 +37,7 @@ export default function withLlamaIndex(config: any) {
     webpackConfig.resolve.alias = {
       ...webpackConfig.resolve.alias,
       "@google-cloud/vertexai": false,
+      unpdf: false,
     };
     // Following lines will fix issues with onnxruntime-node when using pnpm
     // See: https://github.com/vercel/next.js/issues/43433


### PR DESCRIPTION
Webpack is unable to resolve a dynamic import in unpdf package:
https://github.com/unjs/unpdf/blob/ca834860d9720830c4bfa4927f076cc2af432dfa/src/utils.ts#L71

And it cause this warning when using with NextJs:
```
 ⚠ ../../LlamaIndexTS/node_modules/.pnpm/unpdf@0.11.0_encoding@0.1.13/node_modules/unpdf/dist/pdfjs.mjs
Critical dependency: the request of a dependency is an expression

Import trace for requested module:
../../LlamaIndexTS/node_modules/.pnpm/unpdf@0.11.0_encoding@0.1.13/node_modules/unpdf/dist/pdfjs.mjs
../../LlamaIndexTS/node_modules/.pnpm/unpdf@0.11.0_encoding@0.1.13/node_modules/unpdf/dist/index.mjs
../../LlamaIndexTS/packages/llamaindex/dist/readers/PDFReader.js
../../LlamaIndexTS/packages/llamaindex/dist/readers/SimpleDirectoryReader.js
./app/api/chat/engine/loader.ts
./app/api/chat/llamaindex/documents/helper.ts
./app/api/chat/engine/tools/document-generator.ts
./app/api/chat/engine/tools/index.ts
./app/api/chat/workflow/tools.ts
./app/api/chat/workflow/agents.ts
./app/api/chat/workflow/factory.ts
./app/api/chat/route.ts
```

The issue only happened with NextJs Webpack and didn't happen with Express or Nodejs 
(tested by running `npx tsx examples\readers\src\llamaparse.ts`)

So the solution is ignoring the unpdf package during module resolution in Nextjs.