### PR TITLE
feat: add `AzureCosmosDBNoSqlVectorStore` and `SimpleCosmosDBReader`

### DIFF
--- a/.changeset/metal-cameras-argue.md
+++ b/.changeset/metal-cameras-argue.md
@@ -1,0 +1,6 @@
+---
+"llamaindex": patch
+"@llamaindex/readers": patch
+---
+
+Feature/ Add AzureCosmosDBNoSqlVectorStore and SimpleCosmosDBReader

--- a/examples/cosmosdb/addPlainData.ts
+++ b/examples/cosmosdb/addPlainData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
 import { CosmosClient } from "@azure/cosmos";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
@@ -6,14 +5,14 @@ import * as fs from "fs";
 // Load environment variables from local .env file
 dotenv.config();
 
-const jsonFile = "./data/tinytweets.json";
+const jsonFile = "./data/shortStories.json";
 const cosmosEndpoint = process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT!;
 const cosmosConnectionString =
   process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING!;
 const databaseName =
-  process.env.AZURE_COSMOSDB_DATABASE_NAME || "tweetDatabase";
+  process.env.AZURE_COSMOSDB_DATABASE_NAME || "shortStoriesDatabase";
 const containerName =
-  process.env.AZURE_COSMOSDB_CONTAINER_NAME || "tweetContainer";
+  process.env.AZURE_COSMOSDB_CONTAINER_NAME || "shortStoriesContainer";
 
 async function addDocumentsToCosmosDB() {
   if (!cosmosConnectionString && !cosmosEndpoint) {
@@ -24,7 +23,7 @@ async function addDocumentsToCosmosDB() {
 
   let cosmosClient: CosmosClient;
 
-  const tweets = JSON.parse(fs.readFileSync(jsonFile, "utf-8"));
+  const stories = JSON.parse(fs.readFileSync(jsonFile, "utf-8"));
 
   // initialize the cosmos client
   if (cosmosConnectionString) {
@@ -42,14 +41,15 @@ async function addDocumentsToCosmosDB() {
   });
   const { container } = await database.containers.createIfNotExists({
     id: containerName,
+    partitionKey: "/id",
   });
 
   console.log(
     `Data import started to the CosmosDB container ${containerName}.`,
   );
-  // Insert the tweets into the CosmosDB container
-  for (const tweet of tweets) {
-    await container.items.create(tweet);
+  // Insert the short stories into the CosmosDB container
+  for (const story of stories) {
+    await container.items.create(story);
   }
 
   console.log(

--- a/examples/cosmosdb/addPlainData.ts
+++ b/examples/cosmosdb/addPlainData.ts
@@ -1,0 +1,60 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { CosmosClient } from "@azure/cosmos";
+import { DefaultAzureCredential } from "@azure/identity";
+import * as dotenv from "dotenv";
+import * as fs from "fs";
+// Load environment variables from local .env file
+dotenv.config();
+
+const jsonFile = "./data/tinytweets.json";
+const cosmosEndpoint = process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT!;
+const cosmosConnectionString =
+  process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING!;
+const databaseName =
+  process.env.AZURE_COSMOSDB_DATABASE_NAME || "tweetDatabase";
+const containerName =
+  process.env.AZURE_COSMOSDB_CONTAINER_NAME || "tweetContainer";
+
+async function addDocumentsToCosmosDB() {
+  if (!cosmosConnectionString && !cosmosEndpoint) {
+    throw new Error(
+      "Azure CosmosDB connection string or endpoint must be set.",
+    );
+  }
+
+  let cosmosClient: CosmosClient;
+
+  const tweets = JSON.parse(fs.readFileSync(jsonFile, "utf-8"));
+
+  // initialize the cosmos client
+  if (cosmosConnectionString) {
+    cosmosClient = new CosmosClient(cosmosConnectionString);
+  } else {
+    cosmosClient = new CosmosClient({
+      endpoint: cosmosEndpoint,
+      aadCredentials: new DefaultAzureCredential(),
+    });
+  }
+
+  // Create a new database and container if they don't exist
+  const { database } = await cosmosClient.databases.createIfNotExists({
+    id: databaseName,
+  });
+  const { container } = await database.containers.createIfNotExists({
+    id: containerName,
+  });
+
+  console.log(
+    `Data import started to the CosmosDB container ${containerName}.`,
+  );
+  // Insert the tweets into the CosmosDB container
+  for (const tweet of tweets) {
+    await container.items.create(tweet);
+  }
+
+  console.log(
+    `Successfully imported data to the CosmosDB container ${containerName}.`,
+  );
+}
+
+addDocumentsToCosmosDB().catch(console.error);

--- a/examples/cosmosdb/loadVectorData.ts
+++ b/examples/cosmosdb/loadVectorData.ts
@@ -1,0 +1,94 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { CosmosClient } from "@azure/cosmos";
+import { DefaultAzureCredential } from "@azure/identity";
+import * as dotenv from "dotenv";
+import {
+  AzureCosmosDBNoSqlVectorStore,
+  OpenAI,
+  OpenAIEmbedding,
+  Settings,
+  SimpleCosmosDBReader,
+  SimpleCosmosReaderLoaderConfig,
+  storageContextFromDefaults,
+  VectorStoreIndex,
+} from "llamaindex";
+
+// Load environment variables from local .env file
+dotenv.config();
+
+const cosmosEndpoint = process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT!;
+const cosmosConnectionString =
+  process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING!;
+const databaseName =
+  process.env.AZURE_COSMOSDB_DATABASE_NAME || "tweetDatabase";
+const collectionName =
+  process.env.AZURE_COSMOSDB_CONTAINER_NAME || "tweetContainer";
+const vectorCollectionName =
+  process.env.AZURE_COSMOSDB_VECTOR_CONTAINER_NAME || "vectorContainer";
+
+// This exampple uses Azure OpenAI llm and embedding models
+const llmInit = {
+  azure: {
+    apiVersion: process.env.AZURE_OPENAI_LLM_API_VERSION,
+    endpoint: process.env.AZURE_OPENAI_LLM_ENDPOINT,
+    apiKey: process.env.AZURE_OPENAI_LLM_API_KEY,
+  },
+};
+
+const embedModelInit = {
+  azure: {
+    apiVersion: process.env.AZURE_OPENAI_EMBEDDING_API_VERSION,
+    endpoint: process.env.AZURE_OPENAI_EMBEDDING_ENDPOINT,
+    apiKey: process.env.AZURE_OPENAI_EMBEDDING_API_KEY,
+  },
+};
+
+Settings.llm = new OpenAI(llmInit);
+Settings.embedModel = new OpenAIEmbedding(embedModelInit);
+
+async function loadVectorData() {
+  if (!cosmosConnectionString && !cosmosEndpoint) {
+    throw new Error(
+      "Azure CosmosDB connection string or endpoint must be set.",
+    );
+  }
+
+  let cosmosClient: CosmosClient;
+  // initialize the cosmos client
+  if (cosmosConnectionString) {
+    cosmosClient = new CosmosClient(cosmosConnectionString);
+  } else {
+    cosmosClient = new CosmosClient({
+      endpoint: cosmosEndpoint,
+      aadCredentials: new DefaultAzureCredential(),
+    });
+  }
+
+  const reader = new SimpleCosmosDBReader(cosmosClient);
+  // create a configuration object for the reader
+  const simpleCosmosReaderConfig: SimpleCosmosReaderLoaderConfig = {
+    databaseName,
+    containerName: collectionName,
+    fields: ["text"],
+    query: "SELECT c.id, c.full_text as text, c.entities as metadata FROM c",
+    metadataFields: ["metadata"],
+  };
+
+  // load objects from cosmos and convert them into LlamaIndex Document objects
+  const documents = await reader.loadData(simpleCosmosReaderConfig);
+  // create Atlas as a vector store
+  const vectorStore = new AzureCosmosDBNoSqlVectorStore({
+    client: cosmosClient,
+    databaseName,
+    containerName: vectorCollectionName,
+  });
+
+  // Store the embeddings in the CosmosDB container
+  const storageContext = await storageContextFromDefaults({ vectorStore });
+  await VectorStoreIndex.fromDocuments(documents, { storageContext });
+  console.log(
+    `Successfully created embeddings in the CosmosDB container ${vectorCollectionName}.`,
+  );
+}
+
+loadVectorData().catch(console.error);

--- a/examples/cosmosdb/loadVectorData.ts
+++ b/examples/cosmosdb/loadVectorData.ts
@@ -76,7 +76,7 @@ async function loadVectorData() {
 
   // load objects from cosmos and convert them into LlamaIndex Document objects
   const documents = await reader.loadData(simpleCosmosReaderConfig);
-  // create Atlas as a vector store
+  // create Azure CosmosDB as a vector store
   const vectorStore = new AzureCosmosDBNoSqlVectorStore({
     client: cosmosClient,
     databaseName,

--- a/examples/cosmosdb/loadVectorData.ts
+++ b/examples/cosmosdb/loadVectorData.ts
@@ -1,18 +1,18 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
 import { CosmosClient } from "@azure/cosmos";
 import { DefaultAzureCredential } from "@azure/identity";
+import {
+  SimpleCosmosDBReader,
+  SimpleCosmosDBReaderLoaderConfig,
+} from "@llamaindex/readers/cosmosdb";
 import * as dotenv from "dotenv";
 import {
   AzureCosmosDBNoSqlVectorStore,
   OpenAI,
   OpenAIEmbedding,
   Settings,
-  SimpleCosmosDBReader,
-  SimpleCosmosReaderLoaderConfig,
   storageContextFromDefaults,
   VectorStoreIndex,
 } from "llamaindex";
-
 // Load environment variables from local .env file
 dotenv.config();
 
@@ -20,9 +20,9 @@ const cosmosEndpoint = process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT!;
 const cosmosConnectionString =
   process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING!;
 const databaseName =
-  process.env.AZURE_COSMOSDB_DATABASE_NAME || "tweetDatabase";
+  process.env.AZURE_COSMOSDB_DATABASE_NAME || "shortStoriesDatabase";
 const collectionName =
-  process.env.AZURE_COSMOSDB_CONTAINER_NAME || "tweetContainer";
+  process.env.AZURE_COSMOSDB_CONTAINER_NAME || "shortStoriesContainer";
 const vectorCollectionName =
   process.env.AZURE_COSMOSDB_VECTOR_CONTAINER_NAME || "vectorContainer";
 
@@ -66,11 +66,11 @@ async function loadVectorData() {
 
   const reader = new SimpleCosmosDBReader(cosmosClient);
   // create a configuration object for the reader
-  const simpleCosmosReaderConfig: SimpleCosmosReaderLoaderConfig = {
+  const simpleCosmosReaderConfig: SimpleCosmosDBReaderLoaderConfig = {
     databaseName,
     containerName: collectionName,
     fields: ["text"],
-    query: "SELECT c.id, c.full_text as text, c.entities as metadata FROM c",
+    query: "SELECT c.id, c.text as text, c.metadata as metadata FROM c",
     metadataFields: ["metadata"],
   };
 
@@ -81,6 +81,7 @@ async function loadVectorData() {
     client: cosmosClient,
     databaseName,
     containerName: vectorCollectionName,
+    flatMetadata: false,
   });
 
   // Store the embeddings in the CosmosDB container

--- a/examples/cosmosdb/queryVectorData.ts
+++ b/examples/cosmosdb/queryVectorData.ts
@@ -1,0 +1,84 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { CosmosClient } from "@azure/cosmos";
+import { DefaultAzureCredential } from "@azure/identity";
+import * as dotenv from "dotenv";
+import {
+  AzureCosmosDBNoSQLConfig,
+  AzureCosmosDBNoSqlVectorStore,
+  OpenAI,
+  OpenAIEmbedding,
+  Settings,
+  VectorStoreIndex,
+} from "llamaindex";
+
+// Load environment variables from local .env file
+dotenv.config();
+
+const cosmosEndpoint = process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT!;
+const cosmosConnectionString =
+  process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING!;
+const databaseName =
+  process.env.AZURE_COSMOSDB_DATABASE_NAME || "tweetDatabase";
+const containerName =
+  process.env.AZURE_COSMOSDB_VECTOR_CONTAINER_NAME || "vectorContainer";
+
+const llmInit = {
+  azure: {
+    apiVersion: process.env.AZURE_OPENAI_LLM_API_VERSION,
+    endpoint: process.env.AZURE_OPENAI_LLM_ENDPOINT,
+    apiKey: process.env.AZURE_OPENAI_LLM_API_KEY,
+  },
+};
+
+const embedModelInit = {
+  azure: {
+    apiVersion: process.env.AZURE_OPENAI_EMBEDDING_API_VERSION,
+    endpoint: process.env.AZURE_OPENAI_EMBEDDING_ENDPOINT,
+    apiKey: process.env.AZURE_OPENAI_EMBEDDING_API_KEY,
+  },
+};
+
+Settings.llm = new OpenAI(llmInit);
+Settings.embedModel = new OpenAIEmbedding(embedModelInit);
+
+async function query() {
+  if (!cosmosConnectionString && !cosmosEndpoint) {
+    throw new Error(
+      "Azure CosmosDB connection string or endpoint must be set.",
+    );
+  }
+
+  let cosmosClient: CosmosClient;
+  // initialize the cosmos client
+  if (cosmosConnectionString) {
+    cosmosClient = new CosmosClient(cosmosConnectionString);
+  } else {
+    cosmosClient = new CosmosClient({
+      endpoint: cosmosEndpoint,
+      aadCredentials: new DefaultAzureCredential(),
+    });
+  }
+
+  // configure the Azure CosmosDB NoSQL Vector Store
+  const dbConfig: AzureCosmosDBNoSQLConfig = {
+    client: cosmosClient,
+    databaseName,
+    containerName,
+    flatMetadata: false,
+  };
+  const store = new AzureCosmosDBNoSqlVectorStore(dbConfig);
+
+  // create an index from the Azure CosmosDB NoSQL Vector Store
+  const index = await VectorStoreIndex.fromVectorStore(store);
+
+  // create a retriever and a query engine from the index
+  const retriever = index.asRetriever({ similarityTopK: 20 });
+  const queryEngine = index.asQueryEngine({ retriever });
+
+  const result = await queryEngine.query({
+    query: "What is the company brainTree named after?", // The company Braintree is named after the town where John Adams grew up
+  });
+  console.log(result.message);
+}
+
+void query();

--- a/examples/cosmosdb/queryVectorData.ts
+++ b/examples/cosmosdb/queryVectorData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable turbo/no-undeclared-env-vars */
 import { CosmosClient } from "@azure/cosmos";
 import { DefaultAzureCredential } from "@azure/identity";
 import * as dotenv from "dotenv";
@@ -18,7 +17,7 @@ const cosmosEndpoint = process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT!;
 const cosmosConnectionString =
   process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING!;
 const databaseName =
-  process.env.AZURE_COSMOSDB_DATABASE_NAME || "tweetDatabase";
+  process.env.AZURE_COSMOSDB_DATABASE_NAME || "shortStoriesDatabase";
 const containerName =
   process.env.AZURE_COSMOSDB_VECTOR_CONTAINER_NAME || "vectorContainer";
 
@@ -76,7 +75,7 @@ async function query() {
   const queryEngine = index.asQueryEngine({ retriever });
 
   const result = await queryEngine.query({
-    query: "What is the company brainTree named after?", // The company Braintree is named after the town where John Adams grew up
+    query: "Who all jog?", // Cosmo, Ludo, Maud, Hale, Constance, Garrison, Fergus, Rafe, Waverly, Rex, Loveday
   });
   console.log(result.message);
 }

--- a/examples/data/shortStories.json
+++ b/examples/data/shortStories.json
@@ -1,0 +1,702 @@
+[
+  {
+    "text": "Araminta found herself elbow deep in her garden, planting an array of flowers, when she uncovered a tiny, ornate box. Curious, she opened it to reveal a glittering, ancient amulet that promised the bearer the gift of understanding animals. She wore it and spent jubilant afternoons conversing with garden birds and her old cat, Whiskers.",
+    "metadata": {
+      "category": "Category: Fantasy/Adventure",
+      "subCategory": "Gardening Discoveries"
+    }
+  },
+  {
+    "text": "Arden spent the afternoon testing his new invention in the park—a device that could translate dog barks into human language. Each curious bark from nearby dogs resulted in cheers and laughter from the gathering crowd as the device spat out humorous and sassy translations.",
+    "metadata": {
+      "category": "Category: Innovation and Entertainment",
+      "subCategory": "Pet Communication Gadgets"
+    }
+  },
+  {
+    "text": "Azalea rushed through the rainy streets, juggling her groceries as she dodged puddles. Today was her turn to cook the family dinner, and she was determined to make her grandmother's famous lasagna. As she hurried into her apartment, she almost crashed into her neighbor, who laughed and helped her pick up a stray tomato. Despite the chaos, Azalea knew that the warm smiles at dinner would make the rush worthwhile.",
+    "metadata": {
+      "category": "Category: Daily Activities",
+      "subCategory": "Urban Life Challenges"
+    }
+  },
+  {
+    "text": "Birdie hopped off the train in a bustling city, her camera slung over her shoulder. With each snapshot, she captured fleeting moments: a child's laughter, a couple's quarrel, an old man's wisdom-filled eyes. As dusk fell, her photos told the story of a bustling day, weaving a tapestry of urban life that she’d later exhibit at her downtown gallery.",
+    "metadata": {
+      "category": "Urban Photography Exploration",
+      "subCategory": "Urban Photography"
+    }
+  },
+  {
+    "text": "Blythe woke up early to catch the stunning sunrise from her rooftop. Later that morning, she decided to bake blueberry muffins to share with her new neighbors, turning a casual hello into a sweet gesture of friendship. As the day wound down, Blythe hosted a small board games night, filling her home with laughter and strategic whispers only gameplay can inspire.",
+    "metadata": {
+      "category": "Category: Daily Activities",
+      "subCategory": "Urban Lifestyle"
+    }
+  },
+  {
+    "text": "Clover dashed through the bustling streets, late for her meeting. In her haste, she bumped into a mime, accidentally becoming part of his performance. The crowd roared with laughter as Clover, red-faced but amused, played along, juggling imaginary balls. Her unintended detour not only entertained a crowd but also landed her a minor role in a local comedy troupe.",
+    "metadata": {
+      "category": "Category: Urban Adventures",
+      "subCategory": "Street Performance Mishaps"
+    }
+  },
+  {
+    "text": "Lilac hurried through the bustling market to pick the freshest vegetables for her impromptu dinner party. As she rushed back home, she bumped into an old friend she hadn't seen in years, leading to an evening filled with laughter and reminiscing, making her dinner party an unexpected reunion.",
+    "metadata": {
+      "category": "Category: Friendship & Reunions",
+      "subCategory": "Impromptu Reunions"
+    }
+  },
+  {
+    "text": "Lavender rushed through her early morning tasks, finding her lost cat, and eventually made it to the bus stop just in time. During her bus ride, she sketched random passengers and struck a conversation with an elderly man who shared fascinating stories about the town's history. Unbeknownst to her, she had left her sketchbook behind, and it embarked on an adventure of its own as various people added their own drawings to it before it finally made its way back to her.",
+    "metadata": {
+      "category": "Category: Daily Adventures",
+      "subCategory": "Urban Adventures"
+    }
+  },
+  {
+    "text": "Posey decided it was the perfect day to test her grandmother's vintage typewriter. She set it up in the park, her fingers dancing over the keys as curious onlookers occasionally stopped by. Each click and clack echoed her heart's rhythm, telling a silent story of her love for forgotten treasures. As the sun began to set, Posey realized she had filled pages with whimsical thoughts and tales. Feeling accomplished, she packed up, promising the typewriter another adventure soon.",
+    "metadata": {
+      "category": "Category: Lifestyle and Hobbies",
+      "subCategory": "Vintage Escapades"
+    }
+  },
+  {
+    "text": "Waverly sprinted through the crowded farmer's market, dodging between stalls in a desperate bid to catch the runaway puppy that was weaving through people's legs. Just as it seemed doomed to disappear in the throng, an old lady with lightening reflexes snagged its leash, saving the day with a smile. Waverly thanked her profusely, catching her breath, as the little escape artist barked happily, oblivious to the chaos it had caused.",
+    "metadata": {
+      "category": "Category: Adventure",
+      "subCategory": "Urban Chase"
+    }
+  },
+  {
+    "text": "Birch woke up early for his Saturday morning ritual: hiking through the tranquil forests. Today, he stumbled upon a hidden waterfall he'd never seen before. Mesmerized, he spent hours sketching the scene in his notebook, capturing the beauty in pencil strokes. What started as a typical day, ended with a newfound inspiration for his art.",
+    "metadata": {
+      "category": "Outdoor Adventure & Artistic Inspiration",
+      "subCategory": "Outdoor Exploration"
+    }
+  },
+  {
+    "text": "Booker, a skilled carpenter, spent the quiet Sunday afternoon crafting a unique wooden chessboard. As he intricately carved each piece, he reminisced about the games he played with his grandfather. By sunset, Booker finished the chessboard, feeling a warm sense of accomplishment and connection to his cherished memories.",
+    "metadata": {
+      "category": "Category: Crafts and Hobbies",
+      "subCategory": "Craftsmanship and Memories"
+    }
+  },
+  {
+    "text": "Dane woke up excited, it was finally the day of the city's annual kite festival. He grabbed his handmade kite, its colors vibrant under the sun, and headed to the park. Upon arriving, he found a spot on the grassy hill, feeling the breeze which was perfect for flying. As Dane launched his kite into the sky, a crowd gathered, impressed by its agility and beauty. Hours flew by like seconds, and as the festival ended, Dane felt a sense of pride watching his",
+    "metadata": {
+      "category": "Category: Outdoor Activities",
+      "subCategory": "kite fly so well."
+    }
+  },
+  {
+    "text": "Garrison missed his bus again, so he decided to jog to work. Along the way, he found a lost dog with no collar. Determined to find the owner, he took a small detour to the local vet, only to discover that the dog was from the next town over. Instead of going to work, Garrison spent his day reuniting the dog with its family, making new friends, and unexpectedly enjoying the best day off.",
+    "metadata": {
+      "category": "Category: Unexpected Adventures",
+      "subCategory": "Unexpected Adventures"
+    }
+  },
+  {
+    "text": "Hale, tired after a long work day, decided to unwind with a jog through the bustling city park. Amidst his stride, he spotted a lost puppy with a collar tag inscribed \"Buddy\". Determined, Hale spent the next hour dodging puzzled pedestrians, clumsy cyclists, and precariously perched pigeons to return Buddy to the address on the tag. The grateful owner rewarded Hale with a fresh apple pie, making his unexpected adventure even sweeter.",
+    "metadata": {
+      "category": "Category: Urban Adventure",
+      "subCategory": "Urban Adventure"
+    }
+  },
+  {
+    "text": "Kit dashed through the subway station, barely catching the last train home. He sighed in relief, finally settling into a seat. Across from him, a curious old lady with a large, mysterious hat watched. She pulled a flute from her bag and played a haunting melody that seemed to make the train travel faster. Kit was intrigued by the magic of the moment but knew his stop was next, so he prepared to leave this brief magical encounter behind.",
+    "metadata": {
+      "category": "Category: Urban Fantasy Adventure",
+      "subCategory": "Public Transit Encounters"
+    }
+  },
+  {
+    "text": "Oberon decided to indulge in a rare day off by visiting the local art museum. He wandered through galleries filled with vibrant paintings and ancient sculptures, losing track of time as he immersed himself in stories depicted on canvas and in stone. Each artwork inspired him to sketch ideas for his next graphic novel—a mix of myth and modern struggles. By closing time, his mind buzzed with creativity, eager to transfer his sketches into vivid scenes.",
+    "metadata": {
+      "category": "Category: Creativity and Inspiration",
+      "subCategory": "Art and Creativity"
+    }
+  },
+  {
+    "text": "While walking his dog in the park, Shaw discovered a hidden, ancient-looking map stuck behind a loose brick near the old fountain. Curious and excited, he followed the map's winding trail, which led him to a buried chest filled with turn-of-the-century coins in a secluded part of the woods.",
+    "metadata": {
+      "category": "Adventure and Discovery",
+      "subCategory": "Adventure_Discovery"
+    }
+  },
+  {
+    "text": "Tobin decided to challenge himself with a culinary adventure, aiming to cook dishes from different countries for an entire week. His tiny apartment was soon filled with the aromas of Indian spices, Italian herbs, and Japanese seasonings. The week’s pinnacle was his successful attempt at a complex French dish which he shared with his food-loving friends over laughter and good wine.",
+    "metadata": {
+      "category": "Category: Lifestyle & Cooking",
+      "subCategory": "International Cuisine Challenge"
+    }
+  },
+  {
+    "text": "Winston decided to try his luck at gardening. After weeks of nurturing, his backyard transformed into a splendid display of colorful blooms. Inspired by his success, he entered a local gardening contest and, to his delight, won first prize for his vibrant tulips. His neighbors, impressed by his skills, started seeking his advice, turning Winston into the local gardening guru.",
+    "metadata": {
+      "category": "Category: Hobby and Community Engagement",
+      "subCategory": "Backyard Transformation"
+    }
+  },
+  {
+    "text": "Antigone spent her morning organizing a community clean-up, rallying her neighbors with her infectious enthusiasm. By afternoon, the park was spotless, and everyone celebrated with a picnic under the newly visible sun, sharing stories and homemade lemonade. Antigone felt a deep satisfaction, knowing she had not only cleaned the environment but also strengthened community bonds.",
+    "metadata": {
+      "category": "Category: Community Engagement & Environmentalism",
+      "subCategory": "Community Service"
+    }
+  },
+  {
+    "text": "Antonia raced through the crowded streets, her heart pounding as she clutched the last golden ticket to the midnight art gala. As the city lights blurred past, she dodged a cyclist and leaped over a sleeping dog, determined not to miss the showcase that could launch her hidden photography talent into the limelight. The grand old clock tower struck 11:45; she was almost there, the lights of the gallery flickering like stars just ahead. With her hopes high, she pushed forward",
+    "metadata": {
+      "category": "Category: Urban Adventure",
+      "subCategory": "Urban Adventure"
+    }
+  },
+  {
+    "text": "Aurelia spent the afternoon organizing a community garden clean-up. Under the warm sun, neighbors of all ages gathered, pulling weeds and planting flowers. Their laughter and chatter filled the air, creating a tapestry of camaraderie. As the day ended, Aurelia looked around at the vibrant blooms and the smiling faces, feeling a deep sense of accomplishment and connection.",
+    "metadata": {
+      "category": "Community Service",
+      "subCategory": "Community Volunteering"
+    }
+  },
+  {
+    "text": "Beatrix spent her morning in a bustling café, tirelessly sketching the passersby from her quiet corner. Each person unwittingly contributed to her grand mural envisioned for the local gallery. Her afternoon was a whirlwind of colors and brushes, as she transferred her morning inspirations onto a vast canvas, her vision slowly coming to life.",
+    "metadata": {
+      "category": "Art and Creativity",
+      "subCategory": "Urban Artistry"
+    }
+  },
+  {
+    "text": "Bluebell woke up to a quiet house with a note on the fridge: \"Meet us at the pier.\" Puzzled, she grabbed her bike and headed to the seaside. Arriving, she found her friends with a seaside picnic ready, celebrating her surprise job promotion that she hadn’t told anyone about yet.",
+    "metadata": {
+      "category": "Category: Friendship and Celebration",
+      "subCategory": "Surprise Celebration"
+    }
+  },
+  {
+    "text": "Cecily rushed through the bustling market, her basket brimming with fresh produce. She was preparing a grand feast to celebrate her promotion at work. As she haggled with vendors and gathered ingredients, her excitement grew. With every vegetable and spice, she could almost taste the success of the evening that awaited.",
+    "metadata": {
+      "category": "Category: Celebration Preparation",
+      "subCategory": "Market Adventures"
+    }
+  },
+  {
+    "text": "Clementine hurried through her morning routine, grabbing her reusable coffee cup and messenger bag as she dashed out the door. Today was the grand opening of her dream project, a community garden designed to reconnect city dwellers with nature. As she arrived, volunteers from around the neighborhood were already digging and planting under the early morning sun, their laughter blending with the chirps of waking birds. Clementine's heart swelled with pride and excitement, knowing her efforts would blossom into a green oasis amidst the concrete",
+    "metadata": {
+      "category": "Category: Community and Sustainability",
+      "subCategory": "Urban Greening Initiatives"
+    }
+  },
+  {
+    "text": "Coco spent her Sunday mastering the art of homemade pizza. In her tiny kitchen, surrounded by flour clouds and tomato sauce splatters, she discovered that adding a sprinkle of basil from her windowsill garden gave the pizzas an unexpected, delightful twist. The magic truly happened when she shared the steaming slices with her neighbors, turning a quiet day into an impromptu pizza party that lasted into the night.",
+    "metadata": {
+      "category": "Category: Culinary Adventures",
+      "subCategory": "Gourmet Home Cooking"
+    }
+  },
+  {
+    "text": "Constance decided to turn her routine jog into a scavenger hunt around the city. Each park she visited, she collected a unique leaf. By sunset, she had 20 different leaves pinned in her scrapbook, each representing a mile conquered and a new discovery made.",
+    "metadata": {
+      "category": "Outdoor Adventure",
+      "subCategory": "Urban Adventure"
+    }
+  },
+  {
+    "text": "Cosima raced through the bustling streets of the city, dodging pedestrians and street vendors as she tried to make it to the old bookstore before it closed. Inside the cramped, dusty shop, a treasure awaited her—a rare, ancient manuscript that supposedly contained the secrets of forgotten magic. As she finally grasped the leather-bound tome in her hands, she felt a surge of excitement, knowing that her life was about to change forever.",
+    "metadata": {
+      "category": "Category: Adventure",
+      "subCategory": "Urban Adventure"
+    }
+  },
+  {
+    "text": "Dorothy spent the afternoon perfecting her homemade pizza recipe. She kneaded the dough, spun it in the air, and topped it with fresh basil and mozzarella. As the aroma filled her apartment, neighbors knocked, drawn by the scent. Together, they enjoyed slices on her balcony, laughing under the twinkling city lights.",
+    "metadata": {
+      "category": "Category: Culinary Delights",
+      "subCategory": "\"Urban Culinary Delights\""
+    }
+  },
+  {
+    "text": "Flora spent her morning sifting through vintage records at the local flea market. By sunset, she found herself at a cozy beachside café, sipping tea and sketching the vibrant horizon. An old man nearby shared tales of his youthful adventures at sea, and Flora listened, inspired and sketching his portrait on a napkin, capturing the intricate lines of his life-worn face. A day of simple yet fulfilling connections.",
+    "metadata": {
+      "category": "Category: Daily Activities",
+      "subCategory": "Flea Market Finds & Beachside Inspirations"
+    }
+  },
+  {
+    "text": "Henrietta decided to repurpose her old, dusty attic into a cozy reading nook. She spent the morning clearing out boxes and found a forgotten collection of classic novels. With a fresh coat of paint, some string lights, and a comfy chair, she transformed the space. By evening, Henrietta settled into her new nook, lost in a book as rain pattered softly on the window.",
+    "metadata": {
+      "category": "Home Improvement",
+      "subCategory": "Home Renovation"
+    }
+  },
+  {
+    "text": "Hester rushed through the crowded market, her basket brimming with fresh fruits. Amidst the chaos, she unexpectedly bumped into an old friend she hadn't seen in years, leading to a spontaneous coffee date where they reminisced and planned a future reunion trip to Greece.",
+    "metadata": {
+      "category": "Category: Reunion",
+      "subCategory": "Market Encounter"
+    }
+  },
+  {
+    "text": "Honor, renowned for her green thumb, found an unusual seed nestled in her mailbox. Intrigued, she planted it in her garden. The next morning, she woke to find a shimmering tree dripping with golden apples, each bite revealing visions of far-off lands and forgotten tales.",
+    "metadata": {
+      "category": "Category: Fantasy Gardening",
+      "subCategory": "Mystical Gardening"
+    }
+  },
+  {
+    "text": "Ida spent her morning biking through the winding trails of her local park, enjoying the fresh air and the sounds of nature. As she reached the top of a particularly steep hill, she paused to catch her breath and looked out over the city below, feeling a sense of accomplishment wash over her. After her descent, she treated herself to a homemade smoothie at a nearby cafe, savoring the sweet blend of berries and yogurt.",
+    "metadata": {
+      "category": "Outdoor Activities",
+      "subCategory": "Outdoor Activities"
+    }
+  },
+  {
+    "text": "Jemima forgot her umbrella during a sudden downpour and had to take shelter in a quirky little bookshop. As she browsed the shelves, her fingers brushed against a peculiar, ancient-looking tome. When she opened it, a map fell out, leading to a hidden room right there in the shop. Curiosity piqued, she followed it, finding a trove of old, mystical artifacts that hinted at adventures yet to come.",
+    "metadata": {
+      "category": "Category: Adventure/Mystery",
+      "subCategory": "Urban Exploration"
+    }
+  },
+  {
+    "text": "Kitty decided to reorganize her entire wardrobe today. As she sorted through piles of clothes, she discovered an old, forgotten letter tucked inside a jacket. Curiosity piqued, she sat on the floor, unfolding the letter. It turned out to be a heartfelt note from an old friend that brought back a flood of warm memories and a smile to her face. Inspired, Kitty finished her task with a newfound sense of nostalgia, planning to reconnect with her old friend soon.",
+    "metadata": {
+      "category": "Category: Lifestyle & Relationships",
+      "subCategory": "Rediscovery"
+    }
+  },
+  {
+    "text": "Loveday forgot her phone at home, but as she reached the park, the serendipity of leaving technology behind felt refreshing. She saw an old man struggling with his shoelaces, bent down to help, and they ended up sharing a bench and stories of their world travels for hours.",
+    "metadata": {
+      "category": "Category: Serendipitous Encounters",
+      "subCategory": "Unplanned Connections"
+    }
+  },
+  {
+    "text": "Marina spent her afternoon at a bustling flea market, searching for vintage vinyl records. Amidst the chaos, she stumbled upon a rare 1960s Beatles album. Thrilled, she bought it and headed to the nearby park, where she played it on a portable record player, attracting a small crowd who shared her appreciation for classic tunes.",
+    "metadata": {
+      "category": "Category: Vintage Shopping and Music Enjoyment",
+      "subCategory": "Vintage Hunting"
+    }
+  },
+  {
+    "text": "Maud briskly tied her sneakers and stepped out into the crisp morning air. Today was her attempt at breaking her personal record for the park's 5K loop. As she ran, her breath made little clouds. Determined, she pushed past the point of fatigue, cheered on by the local squirrels. As she crossed her imaginary finish line, her watch beeped—she did it, a new record! Maud punched the air, a victory against her own limits.",
+    "metadata": {
+      "category": "Exercise Achievement",
+      "subCategory": "Outdoor Running Achievement"
+    }
+  },
+  {
+    "text": "Olympia rushed through her morning routine, spilling coffee as she balanced her laptop bag and keys. At work, she expertly handled a tricky client call that won her praise from her boss. Back home, she soaked in the tub, proud of navigating her hectic yet successful day.",
+    "metadata": {
+      "category": "Category: Daily Work-Life Balance",
+      "subCategory": "Work-Life Balance"
+    }
+  },
+  {
+    "text": "Ottilie decided to make her famous lemon cupcakes for the neighborhood bake sale. As she prepped the ingredients, she realized she was out of sugar. Frantically, she dashed to her neighbor, Mr. Thompson. To her delight, not only did he have sugar, but he also shared his secret recipe for the fluffiest frosting. The cupcakes were a hit, and Ottilie returned home with a smile, her basket empty but her heart full.",
+    "metadata": {
+      "category": "Category: Community Interaction",
+      "subCategory": "Neighborhood Collaboration"
+    }
+  },
+  {
+    "text": "Rosanna, a pastry chef, woke up early to prepare her signature chocolate eclairs. Today was special; she was invited to compete in the local baking contest. As she added the final touches to her eclairs, her oven malfunctioned. Thinking quickly, Rosanna used her neighbor's oven. She rushed to the contest, eclairs in hand, just in time. The judges were impressed with her skills and her quick thinking, awarding her first place.",
+    "metadata": {
+      "category": "Category: Culinary Triumph",
+      "subCategory": "Culinary Challenge"
+    }
+  },
+  {
+    "text": "Sybil hurried through the crowded market, her basket heavy with fresh produce. As she navigated the narrow alleys, she caught a glimpse of a fluttering blue scarf. Curious, she followed it to a small, secluded booth selling handmade jewelry. There, she found an old friend she hadn’t seen in years. They spent the afternoon catching up, surrounded by the vibrant sights and sounds of the bustling market.",
+    "metadata": {
+      "category": "Category: Friendship and Markets",
+      "subCategory": "Market Adventure"
+    }
+  },
+  {
+    "text": "Tabitha woke up to the soft chirping of birds outside her window. Inspired to start gardening, she spent her morning planting vibrant tulips and roses. Little did she know, under the calm soil, she unearthed a time capsule left by the previous homeowner filled with trinkets and old letters, sparking a day filled with mystery and nostalgia.",
+    "metadata": {
+      "category": "Gardening and Discovery",
+      "subCategory": "Backyard Discoveries"
+    }
+  },
+  {
+    "text": "Xenia sprinted towards the bus stop, her mind racing as fast as her legs. She had overslept and couldn't afford to be late for her job interview. As she rounded the corner, she saw the bus starting to pull away. Desperate, she shouted and waved her arms wildly. The bus driver noticed her in the rearview mirror and stopped. Breathing a sigh of relief, Xenia thanked the driver profusely as she boarded. Little did she know that the kindness",
+    "metadata": {
+      "category": "Category: Urban Commute Drama",
+      "subCategory": "Urban Commute Drama"
+    }
+  },
+  {
+    "text": "Balthazar, a retired clockmaker, spent his afternoons in his quiet workshop tinkering with the mysterious, ancient lockbox he found in his attic. One late evening, a series of soft clicks echoed through the room, and the lock sprung open, revealing a dusty set of handwritten notes about hidden mechanics in the town's old clock tower that, if solved, could display the lunar eclipse every timelapse. Eagerly, he set out to unravel a secret older than himself.",
+    "metadata": {
+      "category": "Category: Mystery & Adventure",
+      "subCategory": "Mystery Discovery"
+    }
+  },
+  {
+    "text": "Barnaby decided to create a homemade kite using old newspapers and sticks. In the local park, with a slight breeze teasing the leaves, he launched his creation. To his delight and the cheers of nearby children, the kite danced gracefully above the treetops, a testament to simple joys crafted by hand.",
+    "metadata": {
+      "category": "Category: Outdoor Activities",
+      "subCategory": "DIY Crafts"
+    }
+  },
+  {
+    "text": "Bertie, always a culinary enthusiast, decided to create her own fusion dish. She combined flavors from Italy and Japan to make sushi pasta. At her dinner party, guests were amazed by the unique blend as chopsticks twirled spaghetti topped with spicy tuna. Bertie smiled, proud of her kitchen adventure.",
+    "metadata": {
+      "category": "Category: Culinary Exploration",
+      "subCategory": "Culinary Fusion"
+    }
+  },
+  {
+    "text": "Cosmo woke up to his alarm blaring at 6 a.m., and groggily got ready for his daily jog. As he hit the park, he noticed more joggers than usual, all training for the upcoming city marathon. Inspired, he pushed his limits and managed his best time yet. After catching his breath, he struck up a conversation with a fellow runner, planning to join the marathon group training sessions starting next week.",
+    "metadata": {
+      "category": "Category: Fitness and Social Interaction",
+      "subCategory": "Fitness Motivation"
+    }
+  },
+  {
+    "text": "Digby woke up to a strange silence in his usually bustling city neighborhood. Curious, he stepped outside and found the streets empty, the usual morning chaos paused. Deciding to investigate, he grabbed his bike and pedaled towards the park. As he arrived, he discovered everyone gathered around a giant, mysterious book that had appeared overnight. Fascinated, Digby joined in, reading alongside neighbors, as the book unveiled untold secrets of their city, making that day an unforgettable adventure in unity and",
+    "metadata": {
+      "category": "Category: Urban Mystery Adventure",
+      "subCategory": "\"Mystery Discovery in the City\""
+    }
+  },
+  {
+    "text": "Edmund spent his afternoon trying to teach his old dog, Buster, a new trick: playing fetch with a frisbee instead of a ball. Despite Buster's confusion and several failed attempts, Edmund's patience paid off. The park echoed with laughter as Buster finally soared, catching the frisbee mid-air for the first time.",
+    "metadata": {
+      "category": "Category: Pet Training",
+      "subCategory": "Pet Training Success"
+    }
+  },
+  {
+    "text": "Ernest found an old map tucked in a library book about secret city tunnels. Curious, he spent his day off exploring these hidden paths, discovering forgotten underground art and bits of history that even locals were unaware of. By sunset, he had a camera full of incredible images and a heart full of adventure.",
+    "metadata": {
+      "category": "Urban Exploration",
+      "subCategory": "Urban Exploration"
+    }
+  },
+  {
+    "text": "Fergus, after waking up unusually early, decided to take a rare jog in the park. Mid-run, he stumbled upon a lost parrot that could spout hilarious jokes. Amused and curious, he spent hours with the bird, finally helping it find its way back home to a local comedian who had been worried sick. The day left him with sore muscles but a happy heart.",
+    "metadata": {
+      "category": "Category: Unexpected Encounters",
+      "subCategory": "Unexpected Encounters"
+    }
+  },
+  {
+    "text": "Fraser spent the afternoon attempting to teach his cat, Whiskers, to fetch. After countless treats and failed attempts, Whiskers finally chased after the small, crumpled paper ball, returning it triumphantly. Fraser couldn't help but laugh, proud of their small, silly victory.",
+    "metadata": {
+      "category": "Pet Training Achievements",
+      "subCategory": "Pet Training Triumph"
+    }
+  },
+  {
+    "text": "Guy, a keen bird watcher, woke up early and ventured into the dense forest with his binoculars. As he navigated through the woods, he stumbled upon a hidden pond where a rare species of owl bathed in the morning sun. Excited, he quietly set up his camera and captured stunning shots, immortalizing his unexpected discovery.",
+    "metadata": {
+      "category": "Wildlife Photography Adventure",
+      "subCategory": "Nature Photography"
+    }
+  },
+  {
+    "text": "Horatio decided to venture into the uncharted forest behind his house. As he delved deeper, he stumbled upon a glowing stone. Without hesitation, he pocketed it, unknowingly releasing a cascade of luck. The following week, Horatio found random money on the streets, aced a job interview, and even won a small lottery.",
+    "metadata": {
+      "category": "Adventure & Supernatural",
+      "subCategory": "Adventure and Fortune"
+    }
+  },
+  {
+    "text": "Hugh discovered an old, dusty keyboard in his attic. Each key he pressed played a unique sound, not just musical notes but also whispers of past conversations. Determined to decode these snippets, he spent his evenings piecing together tales of long-lost love, secret deals, and forgotten friendships, immersing himself in a melodic narrative of histories never recorded.",
+    "metadata": {
+      "category": "Category: Mystery and Discoveries",
+      "subCategory": "Mystery Sounds Exploration"
+    }
+  },
+  {
+    "text": "Laurence spent his Sunday morning at the bustling farmers' market, browsing through stands of fresh vegetables and homemade jams. After selecting a jar of strawberry jam, he shared a laugh with the vendor about a mischievous squirrel stealing tomatoes. Feeling content with his purchases, he pedaled home on his vintage bike, the basket full of vibrant produce.",
+    "metadata": {
+      "category": "Category: Lifestyle & Leisure",
+      "subCategory": "Farmers' Market Adventures"
+    }
+  },
+  {
+    "text": "Leopold decided to walk his cat, Mr. Whiskers, through the bustling Sunday market. As they meandered past antique stalls and street-food vendors, the cat spotted a glistening fake jewel. Assuming it was a real gem, Mr. Whiskers pounced, knocking over displays and causing a delightful chaos that ended with Leopold and several amused vendors chasing a very proud cat through the market.",
+    "metadata": {
+      "category": "Category: Daily Life and Pets",
+      "subCategory": "Pet Adventures"
+    }
+  },
+  {
+    "text": "Ludo decided to experiment with his usual morning jog by taking a different route through the city. He zigzagged through bustling markets, quiet alleys, and even stumbled upon a hidden garden full of vibrant flowers. Each turn brought new sights and sounds, enriching his morning exercise with unexpected adventures. As he paused to catch his breath, Ludo realized that sometimes, a little change in routine can lead to extraordinary discoveries.",
+    "metadata": {
+      "category": "Category: Urban Exploration",
+      "subCategory": "Urban Exploration"
+    }
+  },
+  {
+    "text": "Lysander woke up at dawn to prepare for his big presentation. After double-checking his slides, he grabbed his lucky pen and cycled to work. Midway, a sudden rain shower forced him to take shelter under a tree, where he met an old friend he hadn't seen in years. They shared coffee at a nearby cafe, reminiscing and laughing over past adventures. Energized by the reunion, Lysander reached his office with minutes to spare, delivered a stellar presentation, and",
+    "metadata": {
+      "category": "Category: Daily Activities",
+      "subCategory": "received applause from his colleagues."
+    }
+  },
+  {
+    "text": "Maximilian decided to break his routine, swapping his office chair for a mountain bike. As dawn broke, he tackled the steep trails of Shadow Peak, navigating through foggy turns and narrowly missing mischievous squirrels. At the summit, breathless, he watched the sunrise, vowing to make adventure a new part of his daily life.",
+    "metadata": {
+      "category": "Outdoor Adventure",
+      "subCategory": "Outdoor Adventure"
+    }
+  },
+  {
+    "text": "One rainy afternoon, Otis decided to try his luck at the new artisanal bakery that had opened around the corner. While sampling a delectable raspberry tart, he bumped into a long-lost friend from college. Over cups of steaming hot chocolate, they reminisced about old times and planned a summer reunion trip.",
+    "metadata": {
+      "category": "Category: Chance Encounters",
+      "subCategory": "Unexpected Reunions"
+    }
+  },
+  {
+    "text": "Percival, a librarian, discovered a mysterious, ancient book hidden behind other dusty tomes on medieval literature. As he flipped through it, the characters started leaping off the pages, pulling him into an adventure where he had to solve riddles based on the works of Chaucer to return to the real world. Every solved riddle brought him closer to his own time, weaving through historical events as a silent observer. Finally, after the last riddle, Percival emerged, forever changed",
+    "metadata": {
+      "category": "Category: Fantasy Adventure",
+      "subCategory": "Mystical Adventures in Literature"
+    }
+  },
+  {
+    "text": "Percy forgot his glasses at a cafe. Realizing only at home, he dashed back. There, he found a toddler amusingly trying them on, guided by laughs from surrounding patrons. With a smile, Percy exchanged his glasses for a balloon from his pocket, earning cheer from the crowd.",
+    "metadata": {
+      "category": "Lost and Found",
+      "subCategory": "Lost and Found"
+    }
+  },
+  {
+    "text": "Rafe usually took his morning jog by the lake, but today he decided on the bustling city streets instead. As he rounded a corner, he bumped into an old lady who smiled and handed him a crumpled map, whispering, \"Find the red door, and you shall gain your heart's deepest desire.\" With a mixture of curiosity and excitement, Rafe spent the afternoon tracing the map's clues, which led him through hidden alleys and quaint bookshops. By evening, he stood",
+    "metadata": {
+      "category": "Urban Adventure",
+      "subCategory": "Urban Adventure"
+    }
+  },
+  {
+    "text": "Rafferty always preferred cycling over driving. Every morning, he'd pedal through city streets, weaving swiftly between cars. Today was different; he stumbled upon a curious maze of vintage shops and quirky cafes tucked away in a hidden alley. Deciding to explore, he parked his bike and spent hours lost among antiques, old books, and the rich aroma of freshly brewed coffee. A simple detour turned into an unexpected adventure, sparking his new weekend ritual.",
+    "metadata": {
+      "category": "Urban Exploration",
+      "subCategory": "Urban Exploration"
+    }
+  },
+  {
+    "text": "Rex woke up late and realized he had missed his morning jog. Instead, he quickly dressed and headed to the local bakery to grab his favorite blueberry muffin. As he enjoyed his breakfast on a park bench, a friendly squirrel hopped up beside him, seemingly interested in his meal. Chuckling, Rex tore off a small piece and shared his treat, making a tiny new friend before rushing off to work.",
+    "metadata": {
+      "category": "Category: Daily Life & Animal Encounters",
+      "subCategory": "Morning Routine Twist"
+    }
+  },
+  {
+    "text": "Roland decided to challenge himself to a day without technology. From sunrise, he read books by the window, wrote letters on old stationery, and took long walks in the nearby woods. By sunset, disconnected from the digital world, he felt a serene connection to everything around him.",
+    "metadata": {
+      "category": "Category: Mindfulness and Well-being",
+      "subCategory": "Digital Detox Experience"
+    }
+  },
+  {
+    "text": "Rupert decided to try his hand at baking for the first time. Despite the kitchen chaos, with flour everywhere and eggs on the floor, his homemade cookies came out surprisingly delicious, earning him rave reviews from his skeptical family.",
+    "metadata": {
+      "category": "Category: Baking_Success",
+      "subCategory": "Hobby Baking Success"
+    }
+  },
+  {
+    "text": "Wilfred decided to try yoga for the first time today. Surprisingly flexible, he managed a perfect downward dog pose in his first session, impressing the instructor and making new friends in the class. Feeling invigorated, he promised to make it a part of his daily routine.",
+    "metadata": {
+      "category": "Category: Health & Wellness",
+      "subCategory": "Health and Wellness"
+    }
+  },
+  {
+    "text": "Ziggy, an enthusiastic birdwatcher, ventured into the dense forests early one morning. With his camera and binoculars, he hoped to spot the elusive emerald-feathered parakeet. As daylight broke, Ziggy, perched quietly near an old oak, finally caught a glimpse and snapped the perfect shot, his heart swelling with triumph.",
+    "metadata": {
+      "category": "Outdoor Adventure",
+      "subCategory": "Birdwatching Adventures"
+    }
+  },
+  {
+    "text": "Allegra spent her Saturday morning searching for the perfect hat to wear to the outdoor jazz festival. After visiting three boutiques, she found a wide-brimmed, floral sunhat that matched her flowery sundress. As she strolled through the festival, several admirers complimented her style, making her smile brighter than the sunny day.",
+    "metadata": {
+      "category": "Category: Fashion and Events",
+      "subCategory": "Fashion Adventures"
+    }
+  },
+  {
+    "text": "Elettra spent her afternoon exploring a secret garden hidden behind her bustling city street. Surrounded by ancient oaks and whispers of forgotten lore, she stumbled upon an intricately carved stone well that promised to grant a wish to those who truly believed. With a hopeful heart, she tossed in a coin, wishing for a glimpse of magical creatures. To her delight, shadows danced, revealing playful pixies who twirled around her in joyous revelry until dusk.",
+    "metadata": {
+      "category": "Urban Fantasy Exploration",
+      "subCategory": "Urban Fantasy Exploration"
+    }
+  },
+  {
+    "text": "Leonora misplaced her keys in the busy marketplace. She retraced her steps, searching every stall she had visited, until a child waved her keychain from atop a nearby fountain. Grateful, Leonora bought the child an ice cream cone, and they laughed about the adventure.",
+    "metadata": {
+      "category": "Category: Lost and Found",
+      "subCategory": "Lost and Found"
+    }
+  },
+  {
+    "text": "Nephele spent her afternoon visiting a local animal shelter. While there, she met an elderly dog named Max who was often overlooked by potential adopters. Touched by his gentle eyes, she decided to adopt him, promising him a loving home and a future filled with cuddles and treats. As they walked home together, Max wagged his tail, knowing he had found his forever friend.",
+    "metadata": {
+      "category": "Category: Heartwarming Acts",
+      "subCategory": "Animal Adoption"
+    }
+  },
+  {
+    "text": "Christabel decided to bake 50 cupcakes for her neighborhood block party. Each cupcake was a masterpiece, adorned with a tiny edible version of their town's famous statue. The party turned into a sweet success, and everyone praised Christabel's creativity and baking skills.",
+    "metadata": {
+      "category": "Category: Community Events",
+      "subCategory": "Baking Mastery"
+    }
+  },
+  {
+    "text": "Georgiana spent her afternoon perfecting her grandmother's old recipe for blueberry scones. In the midst of flour clouds and buttery fingers, she discovered the joy of baking, which transformed her gloomy Sunday into a delightful feast, capped off by an unexpected visit from her best friend who was lured by the irresistible aroma.",
+    "metadata": {
+      "category": "Category: Culinary Adventures",
+      "subCategory": "Baking and Friendship"
+    }
+  },
+  {
+    "text": "In a small coastal town, Prudence stumbled upon an ancient map hidden inside a library book about local legends. Enthralled by the promise of undiscovered treasure, she embarked on a quest that led her through whispering caves, past cunning traps, and across moonlit beaches. Finally, in the hollow of an age-old oak tree, she unearthed a chest brimming with golden doubloons, proving the legends true.",
+    "metadata": {
+      "category": "Adventure",
+      "subCategory": "Adventure and Discovery"
+    }
+  },
+  {
+    "text": "Winifred spent her entire Saturday afternoon meticulously organizing her vast collection of vintage vinyl records. Each one had its own special memory and she enjoyed reminiscing as she wiped them down and carefully placed them back into their sleeves. The highlight of her day was discovering an old Beatles album she thought she had lost years ago.",
+    "metadata": {
+      "category": "Category: Leisure and Hobbies",
+      "subCategory": "Hobby Organization"
+    }
+  },
+  {
+    "text": "Milou, a curious dog with a nose for adventure, accidentally hopped on a city bus during his morning stroll through the park. As skyscrapers rammed past him, he spent his afternoon navigating through bustling sidewalks, dodging pedestrians, and stopping by every friendly face for a quick pet before finally boarding the right bus home, a hero in his own epic city tale.",
+    "metadata": {
+      "category": "Category: Animal Adventures",
+      "subCategory": "Urban Animal Adventure"
+    }
+  },
+  {
+    "text": "Posy sprinted through the bustling farmers' market, eyes set on the last bouquet of sunflowers. As she reached for them, so did another hand. A friendly face smiled back at her, sparking conversation over coffee, bonding them over shared love for blooms and lazy Sundays.",
+    "metadata": {
+      "category": "Category: Romance",
+      "subCategory": "Unexpected Encounters"
+    }
+  },
+  {
+    "text": "Suki hurried through the bustling market, her basket brimming with fresh ingredients. Today, she planned to surprise her grandmother with a special dish from her homeland, a delicious meal that carried the aroma of nostalgia and the warmth of family love. As the sun dipped below the horizon, Suki added the final touches, her heart swelling with anticipation and joy.",
+    "metadata": {
+      "category": "Category: Family Traditions",
+      "subCategory": "Market Adventures"
+    }
+  },
+  {
+    "text": "Tiggy grabbed her vibrant umbrella as rain splashed the city streets. Despite the weather, her spirits were high; she was on a mission to find the most delectable cupcake in town. Shop after shop, taste after taste, until finally, at a quaint corner bakery, she discovered a chocolate cherry delight that danced on her taste buds, making the rainy day adventure entirely worth it.",
+    "metadata": {
+      "category": "Category: Urban Adventure",
+      "subCategory": "Urban Culinary Quest"
+    }
+  },
+  {
+    "text": "After his morning run, Carew discovered a curious old map tucked inside a library book on local history. Deciding to follow its trail, he embarked on a spontaneous adventure across town, uncovering hidden art murals and secret gardens that even longtime residents knew nothing about. His day ended with a sunset viewed from the city's highest hill, a spot he would never have found without the mysterious map guiding his steps.",
+    "metadata": {
+      "category": "Adventure, Exploration, Discovery",
+      "subCategory": "Urban Exploration"
+    }
+  },
+  {
+    "text": "Hamish decided to dedicate his morning to baking sourdough bread from scratch. After hours of kneading and waiting, he proudly pulled a golden loaf from the oven. Just as he was about to slice it, his cat, Whiskers, jumped on the counter and swatted the bread onto the floor, making it a game of soccer instead.",
+    "metadata": {
+      "category": "Category: Daily Life Disruptions",
+      "subCategory": "Domestic Adventures"
+    }
+  },
+  {
+    "text": "Kenelm decided to turn his mundane evening into an adventure by exploring the labyrinthine alleys of the local flea market. Amidst the clutter of ancient artifacts and eclectic goods, he stumbled upon an old, dusty lamp. With a curious rub, the lamp released a cloud of smoke and a mischievous genie who granted Kenelm three unpredictable wishes that turned his life into an uproarious sequence of events.",
+    "metadata": {
+      "category": "Category: Fantasy Adventure",
+      "subCategory": "Urban Exploration"
+    }
+  },
+  {
+    "text": "Jolyon, an amateur astronomer, had been eagerly awaiting the clearest night to observe a predicted meteor shower. With his trusted telescope perched on the hill behind his house, he marveled as streaks of light danced across the sky, noting each one in his observation log. Suddenly, a much brighter comet not mentioned in any guidebook graced the heavens. Excited, Jolyon recorded its path, realizing he might have discovered a new celestial body.",
+    "metadata": {
+      "category": "Category: Astronomy and Discovery",
+      "subCategory": "Stargazing Discoveries"
+    }
+  },
+  {
+    "text": "Peregrine decided to try a new hobby, birdwatching in the marshes. Equipped with only a pair of old binoculars and a guidebook, he stumbled upon a rare azure-winged magpie. Captivated by its beauty, he spent the whole afternoon tracking its movements, forgetting about the time, until the sunset painted the sky in hues of orange and pink.",
+    "metadata": {
+      "category": "Nature and Adventure",
+      "subCategory": "Outdoor Adventures"
+    }
+  },
+  {
+    "text": "Zebedee decided to bring vibrancy to his monotonous routine. Every morning, he now takes a different route to work, each path leading him to unexpected cafés and charming little bookshops. His favorite discovery has been a vintage record store where he’s started a modest collection of jazz vinyls that play every evening as he relaxes. This small change brought a new rhythm to his life, making every day uniquely delightful.",
+    "metadata": {
+      "category": "Category: Lifestyle Change",
+      "subCategory": "Urban Explorations"
+    }
+  },
+  {
+    "text": "Rizal missed his bus to work and decided to walk the distance instead. Along the way, he found a stray puppy shivering under a park bench. Without a second thought, he scooped it up and spent the day caring for it, only to discover that the little dog belonged to a nearby shelter that offered him a job as a caretaker. Rizal never made it to his original job, but he found his calling in unexpected circumstances.",
+    "metadata": {
+      "category": "Category: Unexpected Encounters & Life Changes",
+      "subCategory": "Commuting Challenges and Heartwarming Encounters"
+    }
+  },
+  {
+    "text": "Mastani hurried through the bustling market, weaving between stalls to find the perfect spice blend for her grandmother’s 90th birthday feast. As she picked up a packet, the aroma teased stories of past family gatherings, filling her with warmth and a dash of nostalgia. She rushed home, eager to create a meal that would add another beautiful chapter to their family history.",
+    "metadata": {
+      "category": "Category: Family Traditions",
+      "subCategory": "\"Family Traditions\""
+    }
+  },
+  {
+    "text": "Loveth spent the morning perfecting her banana bread recipe, hoping to impress her brunch guests. As the delicious aroma filled her kitchen, her cat, Mr. Whiskers, leaped onto the counter, causing a flour explosion. Laughter echoed through the apartment as Loveth chased the mischievous cat, forgetting the oven timer. Her friends arrived, greeted by a slightly charred loaf, but the warm, hearty laughs made the brunch unforgettable.",
+    "metadata": {
+      "category": "Category: Daily Life & Cooking Misadventures",
+      "subCategory": "Kitchen Mishaps"
+    }
+  },
+  {
+    "text": "Hauwa spent her afternoon in a lively pottery class, carefully molding a delicate vase. As the wheel spun, her focus was unmatched, fingers dancing with the clay. The vase slowly took shape, each curve a testament to her patience and creativity. At the end of the day, not only did she leave with a beautiful piece of art, but also a newfound appreciation for the craft.",
+    "metadata": {
+      "category": "Category: Arts and Crafts",
+      "subCategory": "Art and Craft Experience"
+    }
+  },
+  {
+    "text": "Jotaro, a seasoned detective, trudges through the murky streets of the city with his trusty sidekick, a clever corgi named Max. They are hot on the trail of a mysterious jewel thief who has been evading capture for months. Under the dim streetlights, they uncover a clue concealed within an abandoned glove, setting the stage for a thrilling chase across the rooftops, ending with Jotaro cleverly outsmarting the thief, securing the jewels, and earning",
+    "metadata": {
+      "category": "Category: Crime Mystery",
+      "subCategory": "Urban Detective Adventures"
+    }
+  },
+  {
+    "text": "Zarlish, always zealous about her garden, decided to plant a mysterious seed she found nestled in an antique silk pouch at the local market. Weeks later, to her astonishment, the plant sprouted sparkles every sunset, enchanting the whole neighborhood with glimmers of twilight magic.",
+    "metadata": {
+      "category": "Category: Urban Fantasy Gardening",
+      "subCategory": "Mystical Gardening"
+    }
+  },
+  {
+    "text": "Ayzin, a retired opera singer, found unexpected joy teaching stray cats in his neighborhood to respond to classical music. Each morning, as the sun rose, he played different arias from his balcony and delighted in watching the cats gather, their tails swaying in rhythmic appreciation.",
+    "metadata": {
+      "category": "Category: Lifestyle and Animals",
+      "subCategory": "Pet Music Therapy"
+    }
+  },
+  {
+    "text": "Nivetha spent her morning at the farmers market, feeling a buzz of excitement for fresh herbs and sun-ripened tomatoes. With a basket full of vibrant produce, she decided on a whim to host a spontaneous garden dinner for her friends. Under fairy lights and stars, they savored homemade pasta and laughed late into the evening, celebrating simple joys and impromptu gatherings.",
+    "metadata": {
+      "category": "Category: Lifestyle and Entertainment",
+      "subCategory": "\"Market Visit and Garden Dinner\""
+    }
+  }
+]

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.12",
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
+    "@azure/cosmos": "^4.1.1",
     "@azure/identity": "^4.4.1",
     "@datastax/astra-db-ts": "^1.4.1",
     "@llamaindex/core": "^0.4.0",

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -23,6 +23,7 @@
     "@anthropic-ai/sdk": "0.27.1",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-sso-oidc": "^3.679.0",
+    "@azure/cosmos": "^4.1.1",
     "@azure/identity": "^4.4.1",
     "@datastax/astra-db-ts": "^1.4.1",
     "@discoveryjs/json-ext": "^0.6.1",

--- a/packages/llamaindex/src/readers/SimpleCosmosDBReader.ts
+++ b/packages/llamaindex/src/readers/SimpleCosmosDBReader.ts
@@ -1,0 +1,94 @@
+import type { CosmosClient, SqlQuerySpec } from "@azure/cosmos";
+import type { Metadata } from "@llamaindex/core/schema";
+import { type BaseReader, Document } from "@llamaindex/core/schema";
+
+export type SimpleCosmosReaderLoaderConfig = {
+  /**
+   * The name of the database to read.
+   */
+  databaseName: string;
+  /**
+   * The name of the container to read.
+   */
+  containerName: string;
+  /**
+   * An array of field names to retrieve from each document. Defaults to ["text"].
+   */
+  fields?: string[];
+  /**
+   * The separator to join multiple field values. Defaults to an empty string.
+   */
+  fieldSeparator?: string;
+  /**
+   * A custom query to filter the documents. Defaults to `SELECT * FROM c`.
+   */
+  query?: string | SqlQuerySpec;
+  /**
+   * An optional array of metadata field names. If specified extracts this information as metadata.
+   */
+  metadataFields?: string[];
+};
+
+/**
+ * Read data from CosmosDB.
+ */
+export class SimpleCosmosDBReader implements BaseReader {
+  /**
+   * The CosmosDB client.
+   */
+  private client: CosmosClient;
+
+  constructor(client: CosmosClient) {
+    this.client = client;
+  }
+
+  /**
+   * Flattens an array of strings or string arrays into a single-dimensional array of strings.
+   * @param texts - The array of strings or string arrays to flatten.
+   * @returns The flattened array of strings.
+   */
+  private flatten(texts: Array<string | string[]>): string[] {
+    return texts.flat();
+  }
+
+  /**
+   * Loads data from a Cosmos DB container
+   * @returns {Promise<Document[]>}
+   */
+  public async loadData(
+    config: SimpleCosmosReaderLoaderConfig,
+  ): Promise<Document[]> {
+    const database = this.client.database(config.databaseName);
+    const container = database.container(config.containerName);
+    const query = config.query || "SELECT * FROM c";
+    const fields = config.fields || ["text"];
+    const fieldSeparator = config.fieldSeparator || "";
+    const metadataFields = config.metadataFields;
+
+    let res;
+    try {
+      res = await container.items.query(query).fetchAll();
+      const documents: Document[] = [];
+
+      for (const item of res.resources) {
+        const texts: Array<string | string[]> = fields.map(
+          (name) => item[name],
+        );
+        const flattenedTexts = this.flatten(texts);
+        const text = flattenedTexts.join(fieldSeparator);
+
+        let metadata: Metadata = {};
+        if (metadataFields) {
+          metadata = Object.fromEntries(
+            metadataFields.map((name) => [name, item[name]]),
+          );
+        }
+        documents.push(new Document({ id_: item.id, text, metadata }));
+      }
+
+      return documents;
+    } catch (error) {
+      throw new Error(`Error loading data from Cosmos DB: ${error}`);
+    }
+  }
+}

--- a/packages/llamaindex/src/readers/index.ts
+++ b/packages/llamaindex/src/readers/index.ts
@@ -4,6 +4,7 @@ export {
   type ResultType,
 } from "@llamaindex/cloud/reader";
 export * from "@llamaindex/readers/assembly-ai";
+export * from "@llamaindex/readers/cosmosdb";
 export * from "@llamaindex/readers/csv";
 export * from "@llamaindex/readers/directory";
 export * from "@llamaindex/readers/discord";

--- a/packages/llamaindex/src/vector-store/AzureCosmosDBNoSqlVectorStore.ts
+++ b/packages/llamaindex/src/vector-store/AzureCosmosDBNoSqlVectorStore.ts
@@ -1,0 +1,334 @@
+import { CosmosClient, Container, type VectorEmbeddingPolicy, type IndexingPolicy, type DatabaseRequest, type ContainerRequest, type CosmosClientOptions, VectorEmbeddingDataType, VectorEmbeddingDistanceFunction, VectorIndexType, type VectorIndex } from "@azure/cosmos";
+import { DefaultAzureCredential, type TokenCredential } from "@azure/identity";
+import type { BaseEmbedding } from "@llamaindex/core/embeddings";
+import { getEnv } from "@llamaindex/env";
+import { metadataDictToNode, nodeToMetadata } from "./utils.js";
+import { BaseNode, MetadataMode } from "@llamaindex/core/schema";
+
+import {
+  VectorStoreBase,
+  type VectorStoreNoEmbedModel,
+  type VectorStoreQuery,
+  type VectorStoreQueryResult,
+} from "./types.js";
+
+/** Azure Cosmos DB for NoSQL database creation options. */
+export type AzureCosmosDBNoSqlCreateDatabaseOptions = Partial<
+  Omit<DatabaseRequest, "id">
+>;
+/** Azure Cosmos DB for NoSQL container creation options. */
+export type AzureCosmosDBNoSqlCreateContainerOptions = Partial<
+  Omit<ContainerRequest, "id" | "vectorEmbeddingPolicy" | "indexingPolicy">
+>;
+
+export interface AzureCosmosDBNoSQLInitOptions {
+  readonly vectorEmbeddingPolicy?: VectorEmbeddingPolicy | undefined;
+  readonly indexingPolicy?: IndexingPolicy | undefined;
+  readonly createContainerOptions?: AzureCosmosDBNoSqlCreateContainerOptions | undefined;
+  readonly createDatabaseOptions?: AzureCosmosDBNoSqlCreateDatabaseOptions | undefined;
+}
+
+/**
+ * Configuration options for the `AzureCosmosDBNoSQLVectorStore` constructor.
+ */
+export interface AzureCosmosDBNoSQLConfig
+  extends AzureCosmosDBNoSQLInitOptions {
+  readonly client?: CosmosClient;
+  readonly connectionString?: string;
+  readonly endpoint?: string;
+  readonly credentials?: TokenCredential;
+  readonly databaseName?: string;
+  readonly containerName?: string;
+  readonly textKey?: string;
+  readonly metadataKey?: string;
+  readonly flatMetadata?: boolean;
+  readonly idKey?: string;
+}
+
+const USER_AGENT_PREFIX = "LlamaIndex-CDBNoSQL-VectorStore-JavaScript";
+
+const DEFAULT_VECTOR_EMBEDDING_POLICY = {
+  vectorEmbeddings: [{
+    path: "/embedding",
+    dataType: VectorEmbeddingDataType.Float32,
+    distanceFunction: VectorEmbeddingDistanceFunction.Cosine,
+    dimensions: 1536,
+  }]
+}
+
+const DEFAULT_VECTOR_INDEXING_POLICY: VectorIndex[] = [{ path: "/embedding", type: VectorIndexType.QuantizedFlat }];
+
+function parseConnectionString(connectionString: string): { endpoint: string, key: string } {
+  const parts = connectionString.split(';');
+  let endpoint = '';
+  let accountKey = '';
+
+  parts.forEach(part => {
+    const [key, value] = part.split('=');
+    if (key && key.trim() === 'AccountEndpoint') {
+      endpoint = value?.trim() ?? '';
+    } else if ((key ?? '').trim() === 'AccountKey') {
+      accountKey = value?.trim() ?? '';
+    }
+  });
+
+  if (!endpoint || !accountKey) {
+    throw new Error('Invalid connection string: missing AccountEndpoint or AccountKey.');
+  }
+
+  return { endpoint, key: accountKey };
+}
+
+export class AzureCosmosDBNoSqlVectorStore
+  extends VectorStoreBase
+  implements VectorStoreNoEmbedModel {
+  storesText: boolean = true;
+
+  private initPromise?: Promise<void>;
+
+  private container!: Container;
+
+  /**
+   * The CosmosDB client. This is either passed in or created.
+   */
+  cosmosClient: CosmosClient;
+  /**
+   * The key to use for the text field in the CosmosDB container.
+   * Default: "text"
+   */
+  textKey: string;
+
+  flatMetadata: boolean = true;
+
+  /**
+   * The key to use for the id field in the CosmosDB container.
+   * Default: "id"
+   */
+  idKey: string;
+
+  /**
+   * The key to use for the metadata field in the CosmosDB container.
+   * Default: "metadata"
+   */
+  metadataKey: string;
+
+  /**
+   * The key to use for the vector embedding field in the CosmosDB container.
+   * Default: "embedding"
+  */
+  embeddingKey: string;
+
+  private initialize: () => Promise<void>;
+
+  get client(): any {
+    return this.cosmosClient;
+  }
+
+  constructor(dbConfig: AzureCosmosDBNoSQLConfig,
+    embedModel?: BaseEmbedding) {
+    super(embedModel);
+    const connectionString =
+      dbConfig.connectionString ??
+      getEnv("AZURE_COSMOSDB_NOSQL_CONNECTION_STRING");
+
+    const endpoint =
+      dbConfig.endpoint ??
+      getEnv("AZURE_COSMOSDB_NOSQL_ENDPOINT");
+
+    if (!dbConfig.client && !connectionString && !endpoint) {
+      throw new Error(
+        "AzureCosmosDBNoSQLVectorStore client, connection string or endpoint must be set."
+      );
+    }
+
+    if (!dbConfig.client) {
+      if (connectionString) {
+        const { endpoint, key } = parseConnectionString(connectionString);
+        this.cosmosClient = new CosmosClient({
+          endpoint,
+          key,
+          userAgentSuffix: USER_AGENT_PREFIX,
+        } as CosmosClientOptions);
+
+      } else {
+        // Use managed identity
+        this.cosmosClient = new CosmosClient({
+          endpoint,
+          aadCredentials: dbConfig.credentials ?? new DefaultAzureCredential(),
+          userAgentSuffix: USER_AGENT_PREFIX,
+        } as CosmosClientOptions);
+      }
+    }
+    else {
+      this.cosmosClient = dbConfig.client;
+    }
+
+    const client = this.cosmosClient;
+    const databaseName = dbConfig.databaseName ?? "vectorSearchDB";
+    const containerName = dbConfig.containerName ?? "vectorSearchContainer";
+    this.idKey = dbConfig.idKey ?? "id";
+    this.textKey = dbConfig.textKey ?? "text";
+    this.flatMetadata = dbConfig.flatMetadata ?? true;
+    this.metadataKey = dbConfig.metadataKey ?? "metadata";
+    const vectorEmbeddingPolicy = dbConfig.vectorEmbeddingPolicy ?? DEFAULT_VECTOR_EMBEDDING_POLICY;
+    const indexingPolicy: IndexingPolicy = dbConfig.indexingPolicy ?? { vectorIndexes: DEFAULT_VECTOR_INDEXING_POLICY };
+
+    this.embeddingKey = vectorEmbeddingPolicy.vectorEmbeddings?.[0]?.path?.slice(1) ?? '';
+
+    if (!this.embeddingKey) {
+      throw new Error(
+        "AzureCosmosDBNoSQLVectorStore requires a valid vectorEmbeddings path"
+      );
+    }
+
+    // Deferring initialization to the first call to `initialize`
+    this.initialize = () => {
+      if (this.initPromise === undefined) {
+        this.initPromise = this.init(client, databaseName, containerName, {
+          vectorEmbeddingPolicy,
+          indexingPolicy,
+          createContainerOptions: dbConfig.createContainerOptions,
+          createDatabaseOptions: dbConfig.createDatabaseOptions,
+        }).catch((error) => {
+          console.error(
+            "Error during AzureCosmosDBNoSQLVectorStore initialization",
+            error
+          );
+        });
+      }
+      return this.initPromise;
+    };
+  }
+
+  /**
+   * Adds document to the CosmosDB container.
+   *
+   * @returns an array of document ids which were added
+   */
+  async add(nodes: BaseNode[]): Promise<string[]> {
+    await this.initialize();
+    if (!nodes || nodes.length === 0) {
+      return [];
+    }
+
+    const docs = nodes.map((node) => {
+      const metadata = nodeToMetadata(
+        node,
+        true,
+        this.textKey,
+        this.flatMetadata,
+      );
+
+      return {
+        [this.idKey]: node.id_,
+        [this.embeddingKey]: node.getEmbedding(),
+        [this.textKey]: node.getContent(MetadataMode.NONE) || "",
+        [this.metadataKey]: metadata,
+      };
+    });
+
+    const ids: string[] = [];
+    const results = await Promise.allSettled(
+      docs.map((doc) => this.container.items.create(doc))
+    );
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        ids.push(result.value.resource?.id ?? '');
+      }
+      else {
+        ids.push('error: could not create item');
+      }
+    }
+    return ids;
+  };
+
+  /**
+   * Delete a document from the CosmosDB container.
+   *
+   * @param refDocId - The id of the document to delete
+   * @param deleteOptions - Any options to pass to the container.item.delete function
+   * @returns Promise that resolves if the delete query did not throw an error.
+   */
+  async delete(refDocId: string, deleteOptions?: any): Promise<void> {
+    await this.initialize();
+    await this.container.item(refDocId).delete(deleteOptions);
+  };
+
+  /**
+   * Performs a vector similarity search query in the CosmosDB container.
+   *
+   * @param query VectorStoreQuery
+   * @returns List of nodes along with similarityScore
+   */
+  async query(
+    query: VectorStoreQuery,
+    options?: any,
+  ): Promise<VectorStoreQueryResult> {
+    await this.initialize();
+    const params = {
+      vector: query.queryEmbedding!,
+      k: query.similarityTopK,
+    }
+
+    const nodes: BaseNode[] = [];
+    const ids: string[] = [];
+    const similarities: number[] = [];
+    const queryResults = await this.container.items.query({
+      query: "SELECT TOP @k c[@id] as id, c[@text] as text, c[@metadata] as metadata, VectorDistance(c[@embeddingKey],@embedding) AS SimilarityScore FROM c ORDER BY VectorDistance(c[@embeddingKey],@embedding)",
+      parameters: [
+        { name: "@k", value: params.k },
+        { name: "@id", value: this.idKey },
+        { name: "@text", value: this.textKey },
+        { name: "@metadata", value: this.metadataKey },
+        { name: "@embedding", value: params.vector },
+        { name: "@embeddingKey", value: this.embeddingKey },
+      ],
+    }).fetchAll();
+
+    for (const item of queryResults.resources) {
+      const node = metadataDictToNode(item["metadata"], {
+        fallback: {
+          id_: item["id"],
+          text: item["text"],
+          ...item["metadata"],
+        },
+      });
+      node.setContent(item["text"]);
+      const node_id = item["id"];
+      const node_score = item["SimilarityScore"];
+      nodes.push(node);
+      ids.push(node_id);
+      similarities.push(node_score);
+    }
+
+    const result = {
+      nodes,
+      similarities,
+      ids,
+    };
+    return result;
+  };
+
+  /**
+   * Initialize the CosmosDB container.
+   */
+  private async init(
+    client: CosmosClient,
+    databaseName: string,
+    containerName: string,
+    initOptions: AzureCosmosDBNoSQLInitOptions
+  ): Promise<void> {
+    const { database } = await client.databases.createIfNotExists({
+      ...(initOptions?.createDatabaseOptions ?? {}),
+      id: databaseName,
+    });
+
+    const { container } = await database.containers.createIfNotExists({
+      ...(initOptions?.createContainerOptions ?? { partitionKey: { paths: ["/id"] } }),
+      indexingPolicy: initOptions.indexingPolicy || { vectorIndexes: DEFAULT_VECTOR_INDEXING_POLICY },
+      vectorEmbeddingPolicy: initOptions?.vectorEmbeddingPolicy || DEFAULT_VECTOR_EMBEDDING_POLICY,
+      id: containerName,
+    });
+    this.container = container;
+  }
+}

--- a/packages/llamaindex/src/vector-store/index.ts
+++ b/packages/llamaindex/src/vector-store/index.ts
@@ -1,4 +1,5 @@
 export * from "./AstraDBVectorStore.js";
+export * from "./AzureCosmosDBNoSqlVectorStore.js";
 export * from "./ChromaVectorStore.js";
 export * from "./MilvusVectorStore.js";
 export * from "./MongoDBAtlasVectorStore.js";
@@ -8,4 +9,3 @@ export * from "./QdrantVectorStore.js";
 export * from "./SimpleVectorStore.js";
 export * from "./types.js";
 export * from "./WeaviateVectorStore.js";
-export * from "./AzureCosmosDBNoSqlVectorStore.js";

--- a/packages/llamaindex/src/vector-store/index.ts
+++ b/packages/llamaindex/src/vector-store/index.ts
@@ -8,3 +8,4 @@ export * from "./QdrantVectorStore.js";
 export * from "./SimpleVectorStore.js";
 export * from "./types.js";
 export * from "./WeaviateVectorStore.js";
+export * from "./AzureCosmosDBNoSqlVectorStore.js";

--- a/packages/llamaindex/tests/mocks/TestableAzureCosmosDBNoSqlVectorStore.ts
+++ b/packages/llamaindex/tests/mocks/TestableAzureCosmosDBNoSqlVectorStore.ts
@@ -4,6 +4,7 @@ import { AzureCosmosDBNoSqlVectorStore } from "../../src/vector-store.js";
 
 export class TestableAzureCosmosDBNoSqlVectorStore extends AzureCosmosDBNoSqlVectorStore {
   public nodes: BaseNode[] = [];
+  public client;
 
   private fakeTimeout = (ms: number) => {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -23,6 +24,7 @@ export class TestableAzureCosmosDBNoSqlVectorStore extends AzureCosmosDBNoSqlVec
   }
 
   constructor(config: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     client: Mocked<any>;
     endpoint: string;
     idKey: string;
@@ -30,6 +32,7 @@ export class TestableAzureCosmosDBNoSqlVectorStore extends AzureCosmosDBNoSqlVec
     metadataKey: string;
   }) {
     super(config);
+    this.client = config.client;
     this.client.databases.createIfNotExists();
     this.client.databases.containers.createIfNotExists();
   }

--- a/packages/llamaindex/tests/mocks/TestableAzureCosmosDBNoSqlVectorStore.ts
+++ b/packages/llamaindex/tests/mocks/TestableAzureCosmosDBNoSqlVectorStore.ts
@@ -1,0 +1,36 @@
+import type { BaseNode } from "@llamaindex/core/schema";
+import type { Mocked } from "vitest";
+import { AzureCosmosDBNoSqlVectorStore } from "../../src/vector-store.js";
+
+export class TestableAzureCosmosDBNoSqlVectorStore extends AzureCosmosDBNoSqlVectorStore {
+  public nodes: BaseNode[] = [];
+
+  private fakeTimeout = (ms: number) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
+
+  public async add(nodes: BaseNode[]): Promise<string[]> {
+    this.nodes.push(...nodes);
+    await this.fakeTimeout(100);
+    for (const node of nodes) {
+      await this.client.databases.containers.items.create(node);
+    }
+    return nodes.map((node) => node.id_);
+  }
+
+  public async delete(nodeId: string): Promise<void> {
+    await this.client.databases.containers.item(nodeId).delete();
+  }
+
+  constructor(config: {
+    client: Mocked<any>;
+    endpoint: string;
+    idKey: string;
+    textKey: string;
+    metadataKey: string;
+  }) {
+    super(config);
+    this.client.databases.createIfNotExists();
+    this.client.databases.containers.createIfNotExists();
+  }
+}

--- a/packages/llamaindex/tests/package.json
+++ b/packages/llamaindex/tests/package.json
@@ -10,6 +10,7 @@
     "@faker-js/faker": "^9.0.1",
     "llamaindex": "workspace:*",
     "msw": "^2.6.0",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "dotenv": "^16.4.5"
   }
 }

--- a/packages/llamaindex/tests/readers/SimpleCosmosDBReader.test.ts
+++ b/packages/llamaindex/tests/readers/SimpleCosmosDBReader.test.ts
@@ -1,0 +1,99 @@
+import { CosmosClient } from "@azure/cosmos";
+import { Document } from "@llamaindex/core/schema";
+import {
+  SimpleCosmosDBReader,
+  type SimpleCosmosReaderLoaderConfig,
+} from "llamaindex";
+import { describe, expect, it } from "vitest";
+import { createMockClient } from "../utility/mockCosmosClient.js"; // Import the mock client
+
+describe("SimpleCosmosDBReader", () => {
+  let reader: SimpleCosmosDBReader;
+
+  it("should load data from Cosmos DB container", async () => {
+    const mockData = [
+      {
+        id: "1",
+        text1: ["Sample text 1", "Sample text 2"],
+        text2: "Sample text 3",
+        metadataField1: "Metadata 1",
+        metadaField2: { field3: 1, field4: 2 },
+      },
+      {
+        id: "2",
+        text1: "Sample text 4",
+        text2: "Sample text 5",
+        metadataField1: ["prop1", "prop2"],
+        metadaField2: { field3: 3, field4: 4 },
+      },
+    ];
+
+    const mockCosmosClient = createMockClient(
+      mockData,
+    ) as unknown as CosmosClient;
+    reader = new SimpleCosmosDBReader(mockCosmosClient);
+
+    const simpleCosmosReaderConfig: SimpleCosmosReaderLoaderConfig = {
+      databaseName: "testDatabase",
+      containerName: "testContainer",
+      fields: ["text1", "text2"],
+      fieldSeparator: "\n",
+      query: "SELECT * FROM c",
+      metadataFields: ["metadataField1", "metadaField2"],
+    };
+
+    const res = await reader.loadData(simpleCosmosReaderConfig);
+
+    expect(res).toEqual([
+      new Document({
+        id_: "1",
+        text: "Sample text 1\nSample text 2\nSample text 3",
+        metadata: {
+          metadataField1: "Metadata 1",
+          metadaField2: { field3: 1, field4: 2 },
+        },
+      }),
+      new Document({
+        id_: "2",
+        text: "Sample text 4\nSample text 5",
+        metadata: {
+          metadataField1: ["prop1", "prop2"],
+          metadaField2: { field3: 3, field4: 4 },
+        },
+      }),
+    ]);
+  });
+
+  it("undefined fields should be empty", async () => {
+    const mockData = [
+      {
+        id: "1",
+        text: ["Sample text 1", "Sample text 2"],
+        metadataField1: "Metadata 1",
+      },
+    ];
+
+    const mockCosmosClient = createMockClient(
+      mockData,
+    ) as unknown as CosmosClient;
+    reader = new SimpleCosmosDBReader(mockCosmosClient);
+
+    const simpleCosmosReaderConfig: SimpleCosmosReaderLoaderConfig = {
+      databaseName: "testDatabase",
+      containerName: "testContainer",
+      fields: ["text", "text1"],
+      fieldSeparator: "\n",
+      query: "SELECT * FROM c",
+      metadataFields: ["metadataField1", "metadaField2"],
+    };
+
+    const res = await reader.loadData(simpleCosmosReaderConfig);
+    expect(res).toEqual([
+      new Document({
+        id_: "1",
+        text: "Sample text 1\nSample text 2\n",
+        metadata: { metadataField1: "Metadata 1", metadaField2: undefined },
+      }),
+    ]);
+  });
+});

--- a/packages/llamaindex/tests/utility/mockCosmosClient.ts
+++ b/packages/llamaindex/tests/utility/mockCosmosClient.ts
@@ -1,12 +1,13 @@
 // mockCosmosClient.ts
 import { vi } from "vitest";
 
-export const createMockClient = (mockData?: any[]) => {
+export const createMockClient = (mockData?: unknown[]) => {
   let id = 0;
   const client = {
     database: vi.fn().mockReturnValue({
       container: vi.fn().mockReturnValue({
         items: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           create: vi.fn().mockImplementation((doc: any) => ({
             resource: { id: doc.id ?? `${id++}` },
           })),
@@ -34,6 +35,7 @@ export const createMockClient = (mockData?: any[]) => {
           return this;
         },
         items: {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           create: vi.fn().mockImplementation((doc: any) => ({
             resource: { id: doc.id ?? `${id++}` },
           })),

--- a/packages/llamaindex/tests/utility/mockCosmosClient.ts
+++ b/packages/llamaindex/tests/utility/mockCosmosClient.ts
@@ -1,0 +1,53 @@
+// mockCosmosClient.ts
+import { vi } from "vitest";
+
+export const createMockClient = (mockData?: any[]) => {
+  let id = 0;
+  const client = {
+    database: vi.fn().mockReturnValue({
+      container: vi.fn().mockReturnValue({
+        items: {
+          create: vi.fn().mockImplementation((doc: any) => ({
+            resource: { id: doc.id ?? `${id++}` },
+          })),
+          query: vi.fn().mockReturnThis(),
+          fetchAll: vi.fn().mockImplementation(() => ({
+            resources: mockData
+              ? mockData
+              : Array(id)
+                  .fill(0)
+                  .map((_, i) => ({ id: i })),
+          })),
+        },
+        item: vi.fn().mockReturnThis(),
+        delete: vi.fn(),
+      }),
+    }),
+    databases: {
+      createIfNotExists: vi.fn().mockReturnThis(),
+      get database() {
+        return this;
+      },
+      containers: {
+        createIfNotExists: vi.fn().mockReturnThis(),
+        get container() {
+          return this;
+        },
+        items: {
+          create: vi.fn().mockImplementation((doc: any) => ({
+            resource: { id: doc.id ?? `${id++}` },
+          })),
+          query: vi.fn().mockReturnThis(),
+          fetchAll: vi.fn().mockImplementation(() => ({
+            resources: Array(id)
+              .fill(0)
+              .map((_, i) => ({ id: i })),
+          })),
+        },
+        item: vi.fn().mockReturnThis(),
+        delete: vi.fn(),
+      },
+    },
+  };
+  return client;
+};

--- a/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
+++ b/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-process-env */
 import {
   CosmosClient,
   VectorEmbeddingDataType,
@@ -17,7 +16,8 @@ import {
   type VectorStoreQueryResult,
 } from "llamaindex";
 import { beforeEach, describe, expect, it } from "vitest";
-/* eslint-disable turbo/no-undeclared-env-vars */
+import * as dotenv from "dotenv";
+dotenv.config();
 /*
  * To run this test, you need have an Azure Cosmos DB for NoSQL instance
  * running. You can deploy a free version on Azure Portal without any cost,
@@ -40,7 +40,7 @@ import { beforeEach, describe, expect, it } from "vitest";
  * To use regular OpenAI instead of Azure OpenAI, configure the Settings.llm and Settings.embedModel accordingly.
  */
 
-const DATABASE_NAME = "langchainTestDB";
+const DATABASE_NAME = "llamaIndexTestDatabase";
 const CONTAINER_NAME = "testContainer";
 let client: CosmosClient;
 

--- a/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
+++ b/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
@@ -5,6 +5,7 @@ import {
   VectorIndexType,
 } from "@azure/cosmos";
 import { DefaultAzureCredential } from "@azure/identity";
+import * as dotenv from "dotenv";
 import {
   AzureCosmosDBNoSqlVectorStore,
   Document,
@@ -16,7 +17,6 @@ import {
   type VectorStoreQueryResult,
 } from "llamaindex";
 import { beforeEach, describe, expect, it } from "vitest";
-import * as dotenv from "dotenv";
 dotenv.config();
 /*
  * To run this test, you need have an Azure Cosmos DB for NoSQL instance

--- a/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
+++ b/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
@@ -62,7 +62,7 @@ const embedModelInit = {
 
 Settings.llm = new OpenAI(llmInit);
 Settings.embedModel = new OpenAIEmbedding(embedModelInit);
-
+// This test is skipped because it requires an Azure Cosmos DB instance and OpenAI API keys
 describe.skip("AzureCosmosDBNoSQLVectorStore", () => {
   beforeEach(async () => {
     if (process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING) {

--- a/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
+++ b/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.int.test.ts
@@ -1,0 +1,183 @@
+/* eslint-disable no-process-env */
+import {
+  CosmosClient,
+  VectorEmbeddingDataType,
+  VectorEmbeddingDistanceFunction,
+  VectorIndexType,
+} from "@azure/cosmos";
+import { DefaultAzureCredential } from "@azure/identity";
+import {
+  AzureCosmosDBNoSqlVectorStore,
+  Document,
+  OpenAI,
+  OpenAIEmbedding,
+  Settings,
+  VectorStoreQueryMode,
+  type AzureCosmosDBNoSQLConfig,
+  type VectorStoreQueryResult,
+} from "llamaindex";
+import { beforeEach, describe, expect, it } from "vitest";
+/* eslint-disable turbo/no-undeclared-env-vars */
+/*
+ * To run this test, you need have an Azure Cosmos DB for NoSQL instance
+ * running. You can deploy a free version on Azure Portal without any cost,
+ * following this guide:
+ * https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search
+ *
+ * You do not need to create a database or collection, it will be created
+ * automatically by the test.
+ *
+ * Once you have the instance running, you need to set the following environment
+ * variables before running the test:
+ * - AZURE_COSMOSDB_NOSQL_CONNECTION_STRING or AZURE_COSMOSDB_NOSQL_ENDPOINT
+ * - AZURE_OPENAI_LLM_API_VERSION
+ * - AZURE_OPENAI_LLM_ENDPOINT
+ * - AZURE_OPENAI_LLM_API_KEY
+ * - AZURE_OPENAI_EMBEDDING_API_VERSION
+ * - AZURE_OPENAI_EMBEDDING_ENDPOINT
+ * - AZURE_OPENAI_EMBEDDING_API_KEY
+ *
+ * To use regular OpenAI instead of Azure OpenAI, configure the Settings.llm and Settings.embedModel accordingly.
+ */
+
+const DATABASE_NAME = "langchainTestDB";
+const CONTAINER_NAME = "testContainer";
+let client: CosmosClient;
+
+const llmInit = {
+  azure: {
+    apiVersion: process.env.AZURE_OPENAI_LLM_API_VERSION,
+    endpoint: process.env.AZURE_OPENAI_LLM_ENDPOINT,
+    apiKey: process.env.AZURE_OPENAI_LLM_API_KEY,
+  },
+};
+
+const embedModelInit = {
+  azure: {
+    apiVersion: process.env.AZURE_OPENAI_EMBEDDING_API_VERSION,
+    endpoint: process.env.AZURE_OPENAI_EMBEDDING_ENDPOINT,
+    apiKey: process.env.AZURE_OPENAI_EMBEDDING_API_KEY,
+  },
+};
+
+Settings.llm = new OpenAI(llmInit);
+Settings.embedModel = new OpenAIEmbedding(embedModelInit);
+
+describe.skip("AzureCosmosDBNoSQLVectorStore", () => {
+  beforeEach(async () => {
+    if (process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING) {
+      client = new CosmosClient(
+        process.env.AZURE_COSMOSDB_NOSQL_CONNECTION_STRING,
+      );
+    } else if (process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT) {
+      client = new CosmosClient({
+        endpoint: process.env.AZURE_COSMOSDB_NOSQL_ENDPOINT,
+        aadCredentials: new DefaultAzureCredential(),
+      });
+    } else {
+      throw new Error(
+        "Please set the environment variable AZURE_COSMOSDB_NOSQL_CONNECTION_STRING or AZURE_COSMOSDB_NOSQL_ENDPOINT",
+      );
+    }
+
+    // Make sure the database does not exists
+    try {
+      await client.database(DATABASE_NAME).delete();
+    } catch {
+      // Ignore error if the database does not exist
+    }
+  });
+  it("perform query", async () => {
+    const config: AzureCosmosDBNoSQLConfig = {
+      idKey: "name",
+      textKey: "customText",
+      metadataKey: "customMetadata",
+      client: client,
+      databaseName: DATABASE_NAME,
+      containerName: CONTAINER_NAME,
+      createContainerOptions: {
+        throughput: 1000,
+        partitionKey: { paths: ["/key"] },
+      },
+      vectorEmbeddingPolicy: {
+        vectorEmbeddings: [
+          {
+            path: "/vector",
+            dataType: VectorEmbeddingDataType.Float32,
+            distanceFunction: VectorEmbeddingDistanceFunction.Euclidean,
+            dimensions: 1000,
+          },
+        ],
+      },
+      indexingPolicy: {
+        indexingMode: "consistent",
+        automatic: true,
+        includedPaths: [
+          {
+            path: "/*",
+          },
+        ],
+        excludedPaths: [
+          {
+            path: "/_etag/?",
+          },
+          {
+            path: "/metadata/?",
+          },
+        ],
+        vectorIndexes: [
+          {
+            path: "/vector",
+            type: VectorIndexType.QuantizedFlat,
+          },
+        ],
+      },
+    };
+
+    const vectorStore = new AzureCosmosDBNoSqlVectorStore(config);
+
+    const embeddings = await Settings.embedModel.getTextEmbeddings([
+      "This book is about politics",
+      "Cats sleeps a lot.",
+      "Sandwiches taste good.",
+      "The house is open",
+      "Sandwich",
+    ]);
+
+    expect(vectorStore).toBeDefined();
+    await vectorStore.add([
+      new Document({
+        id_: "1",
+        text: "This book is about politics",
+        embedding: embeddings[0],
+        metadata: { key: "politics" },
+      }),
+      new Document({
+        id_: "2",
+        text: "Cats sleeps a lot.",
+        embedding: embeddings[1],
+        metadata: { key: "cats" },
+      }),
+      new Document({
+        id_: "3",
+        text: "Sandwiches taste good.",
+        embedding: embeddings[2],
+        metadata: { key: "sandwiches" },
+      }),
+      new Document({
+        id_: "4",
+        text: "The house is open",
+        embedding: embeddings[3],
+        metadata: { key: "house" },
+      }),
+    ]);
+
+    const results: VectorStoreQueryResult = await vectorStore.query({
+      queryEmbedding: embeddings[4] || [],
+      similarityTopK: 1,
+      mode: VectorStoreQueryMode.DEFAULT,
+    });
+    expect(results.ids.length).toEqual(1);
+    expect(results.ids[0]).toEqual("3");
+  }, 1000000);
+});

--- a/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.test.ts
+++ b/packages/llamaindex/tests/vector-stores/AzureCosmosDBNoSqlVectorStore.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { BaseNode } from "@llamaindex/core/schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TestableAzureCosmosDBNoSqlVectorStore } from "../mocks/TestableAzureCosmosDBNoSqlVectorStore.js";
+import { createMockClient } from "../utility/mockCosmosClient.js"; // Import the mock client
+
+const createNodes = (n: number) => {
+  const nodes: BaseNode[] = [];
+  for (let i = 0; i < n; i += 1) {
+    nodes.push({
+      id_: `node-${i}`,
+      getEmbedding: () => [0.1, 0.2, 0.3, 0.4],
+      getContent: () => `content ${i}`,
+    } as unknown as BaseNode);
+  }
+  return nodes;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AzureCosmosDBNoSqlVectorStore Tests", () => {
+  it("should initialize correctly", async () => {
+    const client = createMockClient();
+    const store = new TestableAzureCosmosDBNoSqlVectorStore({
+      client: client as any,
+      endpoint: "https://example.com",
+      idKey: "id",
+      textKey: "text",
+      metadataKey: "metadata",
+    });
+
+    await store.add(createNodes(10));
+
+    expect(store).toBeDefined();
+
+    expect(client.databases.createIfNotExists).toHaveBeenCalledTimes(1);
+    expect(client.databases.containers.createIfNotExists).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it("should add nodes", async () => {
+    const client = createMockClient();
+    const store = new TestableAzureCosmosDBNoSqlVectorStore({
+      client: client as any,
+      endpoint: "https://example.com",
+      idKey: "id",
+      textKey: "text",
+      metadataKey: "metadata",
+    });
+
+    expect(store).toBeDefined();
+
+    const nodes = createNodes(1500);
+    await store.add(nodes);
+
+    expect(client.databases.containers.items.create).toHaveBeenCalledTimes(
+      1500,
+    );
+  });
+
+  it("should delete nodes", async () => {
+    const client = createMockClient();
+    const store = new TestableAzureCosmosDBNoSqlVectorStore({
+      client: client as any,
+      endpoint: "https://example.com",
+      idKey: "id",
+      textKey: "text",
+      metadataKey: "metadata",
+    });
+
+    const nodes = createNodes(10);
+    await store.add(nodes);
+
+    await store.delete("node-0");
+
+    expect(client.databases.containers.item().delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use specified IDs", async () => {
+    const client = createMockClient();
+    const store = new TestableAzureCosmosDBNoSqlVectorStore({
+      client: client as any,
+      endpoint: "https://example.com",
+      idKey: "id",
+      textKey: "text",
+      metadataKey: "metadata",
+    });
+
+    expect(store).toBeDefined();
+
+    const result = await store.add(createNodes(2));
+    expect(client.databases.containers.items.create).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(["node-0", "node-1"]);
+  });
+});

--- a/packages/readers/cosmosdb/package.json
+++ b/packages/readers/cosmosdb/package.json
@@ -1,0 +1,14 @@
+{
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "edge-light": "./dist/index.edge-light.js",
+      "workerd": "./dist/index.workerd.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "private": true
+}

--- a/packages/readers/package.json
+++ b/packages/readers/package.json
@@ -24,6 +24,24 @@
         "default": "./assembly-ai/dist/index.js"
       }
     },
+    "./cosmosdb": {
+      "edge-light": {
+        "types": "./cosmosdb/dist/index.edge-light.d.ts",
+        "default": "./cosmosdb/dist/index.edge-light.js"
+      },
+      "workerd": {
+        "types": "./cosmosdb/dist/index.workerd.d.ts",
+        "default": "./cosmosdb/dist/index.workerd.js"
+      },
+      "require": {
+        "types": "./cosmosdb/dist/index.d.cts",
+        "default": "./cosmosdb/dist/index.cjs"
+      },
+      "import": {
+        "types": "./cosmosdb/dist/index.d.ts",
+        "default": "./cosmosdb/dist/index.js"
+      }
+    },
     "./csv": {
       "edge-light": {
         "types": "./csv/dist/index.edge-light.d.ts",
@@ -243,6 +261,7 @@
   },
   "files": [
     "assembly-ai",
+    "cosmosdb",
     "csv",
     "directory",
     "discord",
@@ -279,6 +298,7 @@
     "@llamaindex/env": "workspace:*"
   },
   "dependencies": {
+    "@azure/cosmos": "^4.1.1",
     "@discordjs/rest": "^2.3.0",
     "@discoveryjs/json-ext": "^0.6.1",
     "assemblyai": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,6 +341,9 @@ importers:
       '@aws-crypto/sha256-js':
         specifier: ^5.2.0
         version: 5.2.0
+      '@azure/cosmos':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@azure/identity':
         specifier: ^4.4.1
         version: 4.5.0
@@ -9068,6 +9071,9 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
+  jsbi@4.3.0:
+    resolution: {integrity: sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==}
+
   jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
@@ -10966,6 +10972,9 @@ packages:
   printable-characters@1.0.42:
     resolution: {integrity: sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==}
 
+  priorityqueuejs@2.0.0:
+    resolution: {integrity: sha512-19BMarhgpq3x4ccvVi8k2QpJZcymo/iFUcrhPd4V96kYGovOdTsWwy7fxChYi4QY+m2EnGBWSX9Buakz+tWNQQ==}
+
   prism-react-renderer@2.4.0:
     resolution: {integrity: sha512-327BsVCD/unU4CNLZTWVHyUHKnsqcvj2qbPlQ8MiBE2eq2rgctjigPA1Gp9HLF83kZ20zNN6jgizHJeEsyFYOw==}
     peerDependencies:
@@ -11653,6 +11662,10 @@ packages:
   selfsigned@2.4.1:
     resolution: {integrity: sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==}
     engines: {node: '>=10'}
+
+  semaphore@1.1.0:
+    resolution: {integrity: sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==}
+    engines: {node: '>=0.8.0'}
 
   semver-diff@4.0.0:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
@@ -14363,7 +14376,6 @@ snapshots:
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
-    optional: true
 
   '@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))':
     dependencies:
@@ -14387,6 +14399,7 @@ snapshots:
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
+    optional: true
 
   '@aws-sdk/middleware-host-header@3.667.0':
     dependencies:
@@ -23219,6 +23232,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbi@4.3.0: {}
+
   jsesc@0.5.0: {}
 
   jsesc@2.5.2: {}
@@ -25522,6 +25537,8 @@ snapshots:
 
   printable-characters@1.0.42: {}
 
+  priorityqueuejs@2.0.0: {}
+
   prism-react-renderer@2.4.0(react@18.3.1):
     dependencies:
       '@types/prismjs': 1.26.4
@@ -26423,6 +26440,8 @@ snapshots:
     dependencies:
       '@types/node-forge': 1.3.11
       node-forge: 1.3.1
+
+  semaphore@1.1.0: {}
 
   semver-diff@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,10 +174,10 @@ importers:
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vercel/functions':
         specifier: ^1.5.0
-        version: 1.5.0(@aws-sdk/credential-provider-web-identity@3.679.0)
+        version: 1.5.0(@aws-sdk/credential-provider-web-identity@3.679.0(@aws-sdk/client-sts@3.682.0))
       ai:
         specifier: ^3.4.31
-        version: 3.4.31(openai@4.69.0(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8)
+        version: 3.4.31(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -258,7 +258,7 @@ importers:
         version: 1.22.2
       shiki-magic-move:
         specifier: ^0.5.0
-        version: 0.5.0(react@18.3.1)(shiki@1.22.2)(vue@3.5.12(typescript@5.6.3))
+        version: 0.5.0(react@18.3.1)(shiki@1.22.2)(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))
       swr:
         specifier: ^2.2.5
         version: 2.2.5(react@18.3.1)
@@ -373,7 +373,7 @@ importers:
         version: 2.4.9
       chromadb:
         specifier: ^1.8.1
-        version: 1.9.2(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13))
+        version: 1.9.2(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -505,7 +505,7 @@ importers:
         version: 1.1.0(@types/react@18.3.12)(react@18.3.1)
       ai:
         specifier: ^3.3.21
-        version: 3.4.31(openai@4.69.0(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8)
+        version: 3.4.31(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -730,6 +730,9 @@ importers:
       '@aws-sdk/client-sso-oidc':
         specifier: ^3.679.0
         version: 3.682.0(@aws-sdk/client-sts@3.678.0)
+      '@azure/cosmos':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@azure/identity':
         specifier: ^4.4.1
         version: 4.5.0
@@ -972,7 +975,7 @@ importers:
     dependencies:
       ai:
         specifier: ^3.3.21
-        version: 3.4.31(openai@4.69.0(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8)
+        version: 3.4.31(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8)
       llamaindex:
         specifier: workspace:*
         version: link:../../..
@@ -1323,6 +1326,9 @@ importers:
 
   packages/readers:
     dependencies:
+      '@azure/cosmos':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@discordjs/rest':
         specifier: ^2.3.0
         version: 2.4.0
@@ -1906,6 +1912,10 @@ packages:
 
   '@azure/core-util@1.11.0':
     resolution: {integrity: sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/cosmos@4.1.1':
+    resolution: {integrity: sha512-EKcRHZy3enhz7hU/qlwW2urcoF7haFkQRbLhR+rUaAtzDaN6+F/rH4xJtNc94NjOEoeHUI+bkze63ZA55Gca0A==}
     engines: {node: '>=18.0.0'}
 
   '@azure/identity@4.5.0':
@@ -14171,6 +14181,26 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.682.0(@aws-sdk/client-sts@3.682.0)':
+    dependencies:
+      '@aws-sdk/client-sts': 3.682.0
+      '@aws-sdk/core': 3.679.0
+      '@aws-sdk/credential-provider-env': 3.679.0
+      '@aws-sdk/credential-provider-http': 3.679.0
+      '@aws-sdk/credential-provider-process': 3.679.0
+      '@aws-sdk/credential-provider-sso': 3.682.0
+      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
+      '@aws-sdk/types': 3.679.0
+      '@smithy/credential-provider-imds': 3.2.5
+      '@smithy/property-provider': 3.1.8
+      '@smithy/shared-ini-file-loader': 3.1.9
+      '@smithy/types': 3.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+    optional: true
+
   '@aws-sdk/credential-provider-node@3.678.0(@aws-sdk/client-sso-oidc@3.678.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.678.0)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.678.0
@@ -14251,9 +14281,9 @@ snapshots:
     dependencies:
       '@aws-sdk/credential-provider-env': 3.679.0
       '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.682.0)
+      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sts@3.682.0)
       '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
+      '@aws-sdk/credential-provider-sso': 3.682.0
       '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
       '@aws-sdk/types': 3.679.0
       '@smithy/credential-provider-imds': 3.2.5
@@ -14298,6 +14328,21 @@ snapshots:
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
+
+  '@aws-sdk/credential-provider-sso@3.682.0':
+    dependencies:
+      '@aws-sdk/client-sso': 3.682.0
+      '@aws-sdk/core': 3.679.0
+      '@aws-sdk/token-providers': 3.679.0
+      '@aws-sdk/types': 3.679.0
+      '@smithy/property-provider': 3.1.8
+      '@smithy/shared-ini-file-loader': 3.1.9
+      '@smithy/types': 3.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+    optional: true
 
   '@aws-sdk/credential-provider-sso@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))':
     dependencies:
@@ -14363,10 +14408,10 @@ snapshots:
       '@aws-sdk/credential-provider-cognito-identity': 3.682.0
       '@aws-sdk/credential-provider-env': 3.679.0
       '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.682.0)
+      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sts@3.682.0)
       '@aws-sdk/credential-provider-node': 3.682.0(@aws-sdk/client-sts@3.682.0)
       '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
+      '@aws-sdk/credential-provider-sso': 3.682.0
       '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
       '@aws-sdk/types': 3.679.0
       '@smithy/credential-provider-imds': 3.2.5
@@ -14376,6 +14421,7 @@ snapshots:
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
+    optional: true
 
   '@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))':
     dependencies:
@@ -14399,7 +14445,6 @@ snapshots:
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
-    optional: true
 
   '@aws-sdk/middleware-host-header@3.667.0':
     dependencies:
@@ -14497,6 +14542,15 @@ snapshots:
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
       tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.679.0':
+    dependencies:
+      '@aws-sdk/types': 3.679.0
+      '@smithy/property-provider': 3.1.8
+      '@smithy/shared-ini-file-loader': 3.1.9
+      '@smithy/types': 3.6.0
+      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/token-providers@3.679.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))':
     dependencies:
@@ -14621,6 +14675,21 @@ snapshots:
     dependencies:
       '@azure/abort-controller': 2.1.2
       tslib: 2.8.0
+
+  '@azure/cosmos@4.1.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.9.0
+      '@azure/core-rest-pipeline': 1.17.0
+      '@azure/core-tracing': 1.1.2
+      '@azure/core-util': 1.11.0
+      fast-json-stable-stringify: 2.1.0
+      jsbi: 4.3.0
+      priorityqueuejs: 2.0.0
+      semaphore: 1.1.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@azure/identity@4.5.0':
     dependencies:
@@ -19234,9 +19303,9 @@ snapshots:
 
   '@upstash/vector@1.1.7': {}
 
-  '@vercel/functions@1.5.0(@aws-sdk/credential-provider-web-identity@3.679.0)':
+  '@vercel/functions@1.5.0(@aws-sdk/credential-provider-web-identity@3.679.0(@aws-sdk/client-sts@3.682.0))':
     optionalDependencies:
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.678.0)
+      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
 
   '@vercel/postgres@0.10.0':
     dependencies:
@@ -19562,7 +19631,7 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@3.4.31(openai@4.69.0(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8):
+  ai@3.4.31(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))(react@18.3.1)(sswr@2.1.0(svelte@5.1.9))(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3))(zod@3.23.8):
     dependencies:
       '@ai-sdk/provider': 0.0.26
       '@ai-sdk/provider-utils': 1.0.22(zod@3.23.8)
@@ -19578,7 +19647,7 @@ snapshots:
       secure-json-parse: 2.7.0
       zod-to-json-schema: 3.23.5(zod@3.23.8)
     optionalDependencies:
-      openai: 4.69.0(zod@3.23.8)
+      openai: 4.69.0(encoding@0.1.13)(zod@3.23.8)
       react: 18.3.1
       sswr: 2.1.0(svelte@5.1.9)
       svelte: 5.1.9
@@ -20262,7 +20331,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  chromadb@1.9.2(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13)):
+  chromadb@1.9.2(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13)(zod@3.23.8)):
     dependencies:
       cliui: 8.0.1
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
@@ -21355,7 +21424,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.13.0(jiti@2.4.0)
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
+      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@2.4.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.1.0
@@ -21368,18 +21437,17 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.13.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)):
+  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -21401,7 +21469,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.13.0(jiti@2.4.0))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -24810,21 +24878,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@4.69.0(zod@3.23.8):
-    dependencies:
-      '@types/node': 18.19.63
-      '@types/node-fetch': 2.6.11
-      abort-controller: 3.0.0
-      agentkeepalive: 4.5.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0(encoding@0.1.13)
-    optionalDependencies:
-      zod: 3.23.8
-    transitivePeerDependencies:
-      - encoding
-    optional: true
-
   openapi-sampler@1.5.1:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -26602,13 +26655,14 @@ snapshots:
       interpret: 1.4.0
       rechoir: 0.6.2
 
-  shiki-magic-move@0.5.0(react@18.3.1)(shiki@1.22.2)(vue@3.5.12(typescript@5.6.3)):
+  shiki-magic-move@0.5.0(react@18.3.1)(shiki@1.22.2)(svelte@5.1.9)(vue@3.5.12(typescript@5.6.3)):
     dependencies:
       diff-match-patch-es: 0.1.1
       ohash: 1.1.4
     optionalDependencies:
       react: 18.3.1
       shiki: 1.22.2
+      svelte: 5.1.9
       vue: 3.5.12(typescript@5.6.3)
 
   shiki@1.22.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1452,6 +1452,9 @@ importers:
         specifier: ^0.23.0
         version: 0.23.0(tree-sitter@0.22.0)
     devDependencies:
+      '@azure/cosmos':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@faker-js/faker':
         specifier: ^9.0.1
         version: 9.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.5.2
-        version: 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        version: 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/remark-plugin-npm2yarn':
         specifier: 3.5.2
         version: 3.5.2
@@ -96,16 +96,16 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: 3.5.2
-        version: 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/preset-classic':
         specifier: 3.5.2
-        version: 3.5.2(@algolia/client-search@5.12.0)(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)
+        version: 3.5.2(@algolia/client-search@5.12.0)(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)
       '@docusaurus/theme-classic':
         specifier: 3.5.2
-        version: 3.5.2(@types/react@18.3.12)(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+        version: 3.5.2(@types/react@18.3.12)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/types':
         specifier: 3.5.2
-        version: 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tsconfig/docusaurus':
         specifier: 2.0.3
         version: 2.0.3
@@ -388,7 +388,7 @@ importers:
         version: link:../packages/llamaindex
       mongodb:
         specifier: ^6.7.0
-        version: 6.10.0(@aws-sdk/credential-providers@3.682.0)
+        version: 6.10.0(@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0)))
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
@@ -729,7 +729,7 @@ importers:
         version: 5.2.0
       '@aws-sdk/client-sso-oidc':
         specifier: ^3.679.0
-        version: 3.682.0(@aws-sdk/client-sts@3.678.0)
+        version: 3.682.0(@aws-sdk/client-sts@3.682.0)
       '@azure/cosmos':
         specifier: ^4.1.1
         version: 4.1.1
@@ -828,13 +828,13 @@ importers:
         version: 4.7.1(bufferutil@4.0.8)
       chromadb:
         specifier: 1.9.2
-        version: 1.9.2(@google/generative-ai@0.12.0)(cohere-ai@7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))
+        version: 1.9.2(@google/generative-ai@0.12.0)(cohere-ai@7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13)(zod@3.23.8))
       chromadb-default-embed:
         specifier: ^2.13.2
         version: 2.13.2
       cohere-ai:
         specifier: 7.13.0
-        version: 7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(encoding@0.1.13)
+        version: 7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(encoding@0.1.13)
       gpt-tokenizer:
         specifier: ^2.5.0
         version: 2.5.1
@@ -852,7 +852,7 @@ importers:
         version: 1.10.0
       mongodb:
         specifier: ^6.7.0
-        version: 6.10.0(@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0)))
+        version: 6.10.0(@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0)))
       openai:
         specifier: ^4.60.0
         version: 4.69.0(encoding@0.1.13)(zod@3.23.8)
@@ -1121,6 +1121,9 @@ importers:
       '@faker-js/faker':
         specifier: ^9.0.1
         version: 9.1.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       llamaindex:
         specifier: workspace:*
         version: link:..
@@ -1349,7 +1352,7 @@ importers:
         version: 1.8.0
       mongodb:
         specifier: ^6.7.0
-        version: 6.10.0(@aws-sdk/credential-providers@3.682.0)
+        version: 6.10.0(@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0)))
       notion-md-crawler:
         specifier: ^1.0.0
         version: 1.0.0(encoding@0.1.13)
@@ -13759,51 +13762,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0)':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.678.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/credential-provider-node': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.678.0)
-      '@aws-sdk/middleware-host-header': 3.679.0
-      '@aws-sdk/middleware-logger': 3.679.0
-      '@aws-sdk/middleware-recursion-detection': 3.679.0
-      '@aws-sdk/middleware-user-agent': 3.682.0
-      '@aws-sdk/region-config-resolver': 3.679.0
-      '@aws-sdk/types': 3.679.0
-      '@aws-sdk/util-endpoints': 3.679.0
-      '@aws-sdk/util-user-agent-browser': 3.679.0
-      '@aws-sdk/util-user-agent-node': 3.682.0
-      '@smithy/config-resolver': 3.0.10
-      '@smithy/core': 2.5.1
-      '@smithy/fetch-http-handler': 3.2.9
-      '@smithy/hash-node': 3.0.8
-      '@smithy/invalid-dependency': 3.0.8
-      '@smithy/middleware-content-length': 3.0.10
-      '@smithy/middleware-endpoint': 3.2.1
-      '@smithy/middleware-retry': 3.0.25
-      '@smithy/middleware-serde': 3.0.8
-      '@smithy/middleware-stack': 3.0.8
-      '@smithy/node-config-provider': 3.1.9
-      '@smithy/node-http-handler': 3.2.5
-      '@smithy/protocol-http': 4.1.5
-      '@smithy/smithy-client': 3.4.2
-      '@smithy/types': 3.6.0
-      '@smithy/url-parser': 3.0.8
-      '@smithy/util-base64': 3.0.0
-      '@smithy/util-body-length-browser': 3.0.0
-      '@smithy/util-body-length-node': 3.0.0
-      '@smithy/util-defaults-mode-browser': 3.0.25
-      '@smithy/util-defaults-mode-node': 3.0.25
-      '@smithy/util-endpoints': 2.1.4
-      '@smithy/util-middleware': 3.0.8
-      '@smithy/util-retry': 3.0.8
-      '@smithy/util-utf8': 3.0.0
-      tslib: 2.8.0
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -14124,44 +14082,6 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.678.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.678.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/credential-provider-env': 3.679.0
-      '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.678.0)
-      '@aws-sdk/types': 3.679.0
-      '@smithy/credential-provider-imds': 3.2.5
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
-  '@aws-sdk/credential-provider-ini@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.682.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.682.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/credential-provider-env': 3.679.0
-      '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/types': 3.679.0
-      '@smithy/credential-provider-imds': 3.2.5
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
   '@aws-sdk/credential-provider-ini@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(@aws-sdk/client-sts@3.682.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.682.0
@@ -14181,26 +14101,6 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.682.0(@aws-sdk/client-sts@3.682.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.682.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/credential-provider-env': 3.679.0
-      '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/types': 3.679.0
-      '@smithy/credential-provider-imds': 3.2.5
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-    optional: true
-
   '@aws-sdk/credential-provider-node@3.678.0(@aws-sdk/client-sso-oidc@3.678.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.678.0)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.678.0
@@ -14215,44 +14115,6 @@ snapshots:
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - '@aws-sdk/client-sts'
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.678.0)':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.679.0
-      '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.678.0)
-      '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.678.0)
-      '@aws-sdk/types': 3.679.0
-      '@smithy/credential-provider-imds': 3.2.5
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.0
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - '@aws-sdk/client-sts'
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.682.0)':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.679.0
-      '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/types': 3.679.0
-      '@smithy/credential-provider-imds': 3.2.5
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.0
     transitivePeerDependencies:
       - '@aws-sdk/client-sso-oidc'
       - '@aws-sdk/client-sts'
@@ -14276,26 +14138,6 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - '@aws-sdk/client-sts'
       - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.682.0(@aws-sdk/client-sts@3.682.0)':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.679.0
-      '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/types': 3.679.0
-      '@smithy/credential-provider-imds': 3.2.5
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.0
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - '@aws-sdk/client-sts'
-      - aws-crt
-    optional: true
 
   '@aws-sdk/credential-provider-process@3.678.0':
     dependencies:
@@ -14329,35 +14171,6 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-sso@3.682.0':
-    dependencies:
-      '@aws-sdk/client-sso': 3.682.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/token-providers': 3.679.0
-      '@aws-sdk/types': 3.679.0
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-    optional: true
-
-  '@aws-sdk/credential-provider-sso@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))':
-    dependencies:
-      '@aws-sdk/client-sso': 3.682.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/token-providers': 3.679.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
-      '@aws-sdk/types': 3.679.0
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-
   '@aws-sdk/credential-provider-sso@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))':
     dependencies:
       '@aws-sdk/client-sso': 3.682.0
@@ -14381,15 +14194,6 @@ snapshots:
       '@smithy/types': 3.6.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-web-identity@3.679.0(@aws-sdk/client-sts@3.678.0)':
-    dependencies:
-      '@aws-sdk/client-sts': 3.678.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/types': 3.679.0
-      '@smithy/property-provider': 3.1.8
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-web-identity@3.679.0(@aws-sdk/client-sts@3.682.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.682.0
@@ -14399,7 +14203,7 @@ snapshots:
       '@smithy/types': 3.6.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-providers@3.682.0':
+  '@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))':
     dependencies:
       '@aws-sdk/client-cognito-identity': 3.682.0
       '@aws-sdk/client-sso': 3.682.0
@@ -14408,34 +14212,10 @@ snapshots:
       '@aws-sdk/credential-provider-cognito-identity': 3.682.0
       '@aws-sdk/credential-provider-env': 3.679.0
       '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/credential-provider-node': 3.682.0(@aws-sdk/client-sts@3.682.0)
+      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(@aws-sdk/client-sts@3.682.0)
+      '@aws-sdk/credential-provider-node': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(@aws-sdk/client-sts@3.682.0)
       '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0
-      '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/types': 3.679.0
-      '@smithy/credential-provider-imds': 3.2.5
-      '@smithy/property-provider': 3.1.8
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
-    optional: true
-
-  '@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))':
-    dependencies:
-      '@aws-sdk/client-cognito-identity': 3.682.0
-      '@aws-sdk/client-sso': 3.682.0
-      '@aws-sdk/client-sts': 3.682.0
-      '@aws-sdk/core': 3.679.0
-      '@aws-sdk/credential-provider-cognito-identity': 3.682.0
-      '@aws-sdk/credential-provider-env': 3.679.0
-      '@aws-sdk/credential-provider-http': 3.679.0
-      '@aws-sdk/credential-provider-ini': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/credential-provider-node': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(@aws-sdk/client-sts@3.682.0)
-      '@aws-sdk/credential-provider-process': 3.679.0
-      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
+      '@aws-sdk/credential-provider-sso': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))
       '@aws-sdk/credential-provider-web-identity': 3.679.0(@aws-sdk/client-sts@3.682.0)
       '@aws-sdk/types': 3.679.0
       '@smithy/credential-provider-imds': 3.2.5
@@ -14538,24 +14318,6 @@ snapshots:
     dependencies:
       '@aws-sdk/client-sso-oidc': 3.678.0(@aws-sdk/client-sts@3.678.0)
       '@aws-sdk/types': 3.667.0
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.679.0':
-    dependencies:
-      '@aws-sdk/types': 3.679.0
-      '@smithy/property-provider': 3.1.8
-      '@smithy/shared-ini-file-loader': 3.1.9
-      '@smithy/types': 3.6.0
-      tslib: 2.8.1
-    optional: true
-
-  '@aws-sdk/token-providers@3.679.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))':
-    dependencies:
-      '@aws-sdk/client-sso-oidc': 3.682.0(@aws-sdk/client-sts@3.678.0)
-      '@aws-sdk/types': 3.679.0
       '@smithy/property-provider': 3.1.8
       '@smithy/shared-ini-file-loader': 3.1.9
       '@smithy/types': 3.6.0
@@ -15854,7 +15616,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/core@3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/generator': 7.25.6
@@ -15868,10 +15630,10 @@ snapshots:
       '@babel/traverse': 7.25.6
       '@docusaurus/cssnano-preset': 3.5.2
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       '@mdx-js/react': 3.0.1(@types/react@18.3.12)(react@18.3.1)
       autoprefixer: 10.4.20(postcss@8.4.47)
       babel-loader: 9.1.3(@babel/core@7.25.2)(webpack@5.96.1)
@@ -15959,11 +15721,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/mdx-loader@3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       '@mdx-js/mdx': 3.1.0(acorn@8.13.0)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -15997,9 +15759,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/module-type-aliases@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -16016,17 +15778,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-content-blog@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.2.0
@@ -16059,17 +15821,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/module-type-aliases': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/module-type-aliases': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
@@ -16100,13 +15862,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-content-pages@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16132,11 +15894,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-debug@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16162,11 +15924,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-google-analytics@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -16190,11 +15952,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-google-gtag@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16219,11 +15981,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-google-tag-manager@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -16247,14 +16009,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/plugin-sitemap@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       fs-extra: 11.2.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -16280,21 +16042,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.5.2(@algolia/client-search@5.12.0)(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)':
+  '@docusaurus/preset-classic@3.5.2(@algolia/client-search@5.12.0)(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-debug': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-google-analytics': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-google-gtag': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-google-tag-manager': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-sitemap': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-classic': 3.5.2(@types/react@18.3.12)(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-search-algolia': 3.5.2(@algolia/client-search@5.12.0)(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-debug': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-google-analytics': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-google-gtag': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-google-tag-manager': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-sitemap': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-classic': 3.5.2(@types/react@18.3.12)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-search-algolia': 3.5.2(@algolia/client-search@5.12.0)(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -16335,20 +16097,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@docusaurus/theme-classic@3.5.2(@types/react@18.3.12)(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/theme-classic@3.5.2(@types/react@18.3.12)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/module-type-aliases': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/module-type-aliases': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-pages': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/theme-translations': 3.5.2
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       '@mdx-js/react': 3.0.1(@types/react@18.3.12)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -16384,13 +16146,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
+  '@docusaurus/theme-common@3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/module-type-aliases': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/mdx-loader': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/module-type-aliases': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -16411,16 +16173,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.5.2(@algolia/client-search@5.12.0)(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)':
+  '@docusaurus/theme-search-algolia@3.5.2(@algolia/client-search@5.12.0)(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)(typescript@5.6.3)':
     dependencies:
       '@docsearch/react': 3.6.1(@algolia/client-search@5.12.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.2)
-      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/core': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
-      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(acorn@8.13.0)(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/plugin-content-docs': 3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
+      '@docusaurus/theme-common': 3.5.2(@docusaurus/plugin-content-docs@3.5.2(@mdx-js/react@3.0.1(@types/react@18.3.12)(react@18.3.1))(bufferutil@4.0.8)(eslint@9.13.0(jiti@2.4.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3))(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)
       '@docusaurus/theme-translations': 3.5.2
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-validation': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
       algoliasearch: 4.24.0
       algoliasearch-helper: 3.22.4(algoliasearch@4.24.0)
       clsx: 2.1.1
@@ -16460,7 +16222,7 @@ snapshots:
       fs-extra: 11.2.0
       tslib: 2.8.1
 
-  '@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.13.0)
       '@types/history': 4.7.11
@@ -16481,17 +16243,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@docusaurus/utils-common@3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       tslib: 2.8.1
     optionalDependencies:
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@docusaurus/utils-validation@3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)':
+  '@docusaurus/utils-validation@3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)':
     dependencies:
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       fs-extra: 11.2.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -16506,10 +16268,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)':
+  '@docusaurus/utils@3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)':
     dependencies:
       '@docusaurus/logger': 3.5.2
-      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-common': 3.5.2(@docusaurus/types@3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@svgr/webpack': 8.1.0(typescript@5.6.3)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.96.1)
@@ -16529,7 +16291,7 @@ snapshots:
       utility-types: 3.11.0
       webpack: 5.96.1
     optionalDependencies:
-      '@docusaurus/types': 3.5.2(acorn@8.13.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -20320,13 +20082,13 @@ snapshots:
     optionalDependencies:
       onnxruntime-node: 1.14.0
 
-  chromadb@1.9.2(@google/generative-ai@0.12.0)(cohere-ai@7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13)(zod@3.23.8)):
+  chromadb@1.9.2(@google/generative-ai@0.12.0)(cohere-ai@7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(encoding@0.1.13))(encoding@0.1.13)(openai@4.69.0(encoding@0.1.13)(zod@3.23.8)):
     dependencies:
       cliui: 8.0.1
       isomorphic-fetch: 3.0.0(encoding@0.1.13)
     optionalDependencies:
       '@google/generative-ai': 0.12.0
-      cohere-ai: 7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(encoding@0.1.13)
+      cohere-ai: 7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(encoding@0.1.13)
       openai: 4.69.0(encoding@0.1.13)(zod@3.23.8)
     transitivePeerDependencies:
       - encoding
@@ -20418,10 +20180,10 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  cohere-ai@7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))(encoding@0.1.13):
+  cohere-ai@7.13.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(encoding@0.1.13):
     dependencies:
       '@aws-sdk/client-sagemaker': 3.678.0
-      '@aws-sdk/credential-providers': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
+      '@aws-sdk/credential-providers': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))
       '@aws-sdk/protocol-http': 3.374.0
       '@aws-sdk/signature-v4': 3.374.0
       form-data: 4.0.1
@@ -20440,7 +20202,7 @@ snapshots:
   cohere-ai@7.14.0(encoding@0.1.13):
     dependencies:
       '@aws-sdk/client-sagemaker': 3.678.0
-      '@aws-sdk/credential-providers': 3.682.0
+      '@aws-sdk/credential-providers': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))
       '@aws-sdk/protocol-http': 3.374.0
       '@aws-sdk/signature-v4': 3.374.0
       form-data: 4.0.1
@@ -21389,8 +21151,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.13.0(jiti@2.4.0))
       eslint-plugin-react: 7.37.2(eslint@9.13.0(jiti@2.4.0))
       eslint-plugin-react-hooks: 5.0.0(eslint@9.13.0(jiti@2.4.0))
@@ -21418,47 +21180,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0)):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.13.0(jiti@2.4.0)
-      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@2.4.0))
+      eslint-module-utils: 2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.13.0(jiti@2.4.0)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
-      eslint: 9.13.0(jiti@2.4.0)
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.13.0(jiti@2.4.0)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
       eslint: 9.13.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.4.0))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)):
+  eslint-module-utils@2.8.2(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
+      eslint: 9.13.0(jiti@2.4.0)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -21469,7 +21232,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.13.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0)))(eslint@9.13.0(jiti@2.4.0))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -21481,7 +21244,7 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
+      '@typescript-eslint/parser': 7.2.0(eslint@9.13.0(jiti@2.4.0))(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -24382,21 +24145,13 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 13.0.0
 
-  mongodb@6.10.0(@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))):
+  mongodb@6.10.0(@aws-sdk/credential-providers@3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))):
     dependencies:
       '@mongodb-js/saslprep': 1.1.7
       bson: 6.8.0
       mongodb-connection-string-url: 3.0.1
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.678.0))
-
-  mongodb@6.10.0(@aws-sdk/credential-providers@3.682.0):
-    dependencies:
-      '@mongodb-js/saslprep': 1.1.7
-      bson: 6.8.0
-      mongodb-connection-string-url: 3.0.1
-    optionalDependencies:
-      '@aws-sdk/credential-providers': 3.682.0
+      '@aws-sdk/credential-providers': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))
 
   mongodb@6.7.0(@aws-sdk/credential-providers@3.682.0):
     dependencies:
@@ -24404,7 +24159,7 @@ snapshots:
       bson: 6.8.0
       mongodb-connection-string-url: 3.0.1
     optionalDependencies:
-      '@aws-sdk/credential-providers': 3.682.0
+      '@aws-sdk/credential-providers': 3.682.0(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))
 
   mongoose@8.5.1(@aws-sdk/credential-providers@3.682.0):
     dependencies:

--- a/unit/package.json
+++ b/unit/package.json
@@ -11,7 +11,8 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "msw": "^2.6.0",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "@azure/cosmos": "^4.1.1"
   },
   "dependencies": {
     "@llamaindex/cloud": "workspace:*",


### PR DESCRIPTION
This PR makes following changes to the project:
- Add support for using Azure Cosmos DB NoSQL API as a vector-store.
- Add a simple Cosmos DB reader to read the data from the Cosmos DB.
- Add a shortStories JSON dataset.
- Add CosmosDBNoSqlVectorStore RAG example.

