### PR TITLE
feat: log api response from failed parse jobs

### DIFF
--- a/.changeset/gold-cameras-wave.md
+++ b/.changeset/gold-cameras-wave.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/cloud": patch
+---
+
+Log Parse Job Errors when verbose is enabled

--- a/packages/cloud/src/reader.ts
+++ b/packages/cloud/src/reader.ts
@@ -269,6 +269,11 @@ export class LlamaParseReader extends FileReader {
         }
         tries++;
       } else {
+        if (this.verbose) {
+          console.error(
+            `Recieved Error response ${status} for job ${jobId}.  Got Error Code: ${data.error_code} and Error Message: ${data.error_message}`,
+          );
+        }
         throw new Error(
           `Failed to parse the file: ${jobId}, status: ${status}`,
         );


### PR DESCRIPTION
Parse Job failures fail with almost no useful information.  This includes the error code for visibiltiy.