### PR TITLE
fix: replicate deps warning in nextjs

### DIFF
--- a/.changeset/funny-drinks-argue.md
+++ b/.changeset/funny-drinks-argue.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: replicate deps warning in nextjs

--- a/packages/llamaindex/src/next.ts
+++ b/packages/llamaindex/src/next.ts
@@ -43,7 +43,7 @@ export default function withLlamaIndex(config: any) {
     const externals: Record<string, string> = {
       "onnxruntime-node": "commonjs onnxruntime-node",
       sharp: "commonjs sharp",
-      chromadb: "commonjs chromadb",
+      chromadb: "chromadb",
       unpdf: "unpdf",
     };
 

--- a/packages/llamaindex/src/next.ts
+++ b/packages/llamaindex/src/next.ts
@@ -38,7 +38,8 @@ export default function withLlamaIndex(config: any) {
       "onnxruntime-node": "commonjs onnxruntime-node",
       sharp: "commonjs sharp",
       chromadb: "commonjs chromadb",
-      unpdf: "commonjs unpdf",
+      unpdf: "unpdf",
+      replicate: "commonjs replicate",
     });
     return webpackConfig;
   };

--- a/packages/llamaindex/src/next.ts
+++ b/packages/llamaindex/src/next.ts
@@ -24,7 +24,7 @@ export default function withLlamaIndex(config: any) {
     "@xenova/transformers",
   );
   const userWebpack = config.webpack;
-  config.webpack = function (webpackConfig: any) {
+  config.webpack = function (webpackConfig: any, options: any) {
     if (userWebpack) {
       webpackConfig = userWebpack(webpackConfig);
     }
@@ -32,15 +32,26 @@ export default function withLlamaIndex(config: any) {
       ...webpackConfig.resolve.alias,
       "@google-cloud/vertexai": false,
     };
+
+    // Disable modules that are not supported in vercel edge runtime
+    if (options?.nextRuntime === "edge") {
+      webpackConfig.resolve.alias["replicate"] = false;
+    }
+
     // Following lines will fix issues with onnxruntime-node when using pnpm
     // See: https://github.com/vercel/next.js/issues/43433
-    webpackConfig.externals.push({
+    const externals: Record<string, string> = {
       "onnxruntime-node": "commonjs onnxruntime-node",
       sharp: "commonjs sharp",
       chromadb: "commonjs chromadb",
       unpdf: "unpdf",
-      replicate: "commonjs replicate",
-    });
+    };
+
+    if (options?.nextRuntime === "nodejs") {
+      externals.replicate = "commonjs replicate";
+    }
+
+    webpackConfig.externals.push(externals);
     return webpackConfig;
   };
   return config;


### PR DESCRIPTION
 I got this warning related to `replicate` package when using it in NextJs create-llama template
 
 ```
 ⚠ ../../../LlamaIndexTS/node_modules/.pnpm/replicate@1.0.1/node_modules/replicate/lib/util.js
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted

Import trace for requested module:
../../../LlamaIndexTS/node_modules/.pnpm/replicate@1.0.1/node_modules/replicate/lib/util.js
../../../LlamaIndexTS/node_modules/.pnpm/replicate@1.0.1/node_modules/replicate/index.js
../../../LlamaIndexTS/packages/providers/replicate/dist/index.js
../../../LlamaIndexTS/packages/llamaindex/dist/llm/replicate_ai.js
../../../LlamaIndexTS/packages/llamaindex/dist/llm/index.js
../../../LlamaIndexTS/packages/llamaindex/dist/index.edge.js
../../../LlamaIndexTS/packages/llamaindex/dist/index.react-server.js
```