### PR TITLE
Allow files_via_content retrieval from LlamaCloud

### DIFF
--- a/.changeset/late-apricots-yell.md
+++ b/.changeset/late-apricots-yell.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/core": patch
+---
+
+Remove chunk size limit for prompt helper (use LLM default)

--- a/.changeset/thick-ways-visit.md
+++ b/.changeset/thick-ways-visit.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/examples": patch
+---
+
+Add files_via_content example for LlamaCloud retrieval

--- a/examples/cloud/query.ts
+++ b/examples/cloud/query.ts
@@ -12,7 +12,8 @@ async function main() {
   });
 
   const queryEngine = index.asQueryEngine({
-    similarityTopK: 5,
+    // retrieve the whole content of a file instead of just chunks of the file
+    retrieval_mode: "files_via_content",
   });
 
   const rl = readline.createInterface({ input, output });

--- a/packages/core/src/indices/prompt-helper.ts
+++ b/packages/core/src/indices/prompt-helper.ts
@@ -1,7 +1,6 @@
 import { type Tokenizer, tokenizers } from "@llamaindex/env";
 import {
   DEFAULT_CHUNK_OVERLAP_RATIO,
-  DEFAULT_CHUNK_SIZE,
   DEFAULT_CONTEXT_WINDOW,
   DEFAULT_NUM_OUTPUTS,
   DEFAULT_PADDING,
@@ -171,7 +170,7 @@ export class PromptHelper {
   ) {
     const {
       chunkOverlapRatio = DEFAULT_CHUNK_OVERLAP_RATIO,
-      chunkSizeLimit = DEFAULT_CHUNK_SIZE,
+      chunkSizeLimit = undefined,
       tokenizer = Settings.tokenizer,
       separator = " ",
     } = options ?? {};


### PR DESCRIPTION
- remove chunk size limit for prompt helper (as in Python framework). This allows utilizing the whole context window of an LLM for response synthesizers and therefore `files_via_content` retrieval is not resulting in a 'hanging' process anymore
- add example for files_via_content_retrieval