### PR TITLE
feat: add async support to BaseChatStore and BaseChatStoreMemory

### DIFF
--- a/.changeset/witty-worms-marry.md
+++ b/.changeset/witty-worms-marry.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/core": patch
+---
+
+feat: add async support to BaseChatStore and BaseChatStoreMemory

--- a/packages/core/src/memory/base.ts
+++ b/packages/core/src/memory/base.ts
@@ -71,15 +71,15 @@ export abstract class BaseChatStoreMemory<
     return this.chatStore.getMessages(this.chatStoreKey);
   }
 
-  put(messages: ChatMessage<AdditionalMessageOptions>) {
+  put(messages: ChatMessage<AdditionalMessageOptions>): void | Promise<void> {
     this.chatStore.addMessage(this.chatStoreKey, messages);
   }
 
-  set(messages: ChatMessage<AdditionalMessageOptions>[]) {
+  set(messages: ChatMessage<AdditionalMessageOptions>[]): void | Promise<void> {
     this.chatStore.setMessages(this.chatStoreKey, messages);
   }
 
-  reset() {
+  reset(): void | Promise<void> {
     this.chatStore.deleteMessages(this.chatStoreKey);
   }
 }

--- a/packages/core/src/storage/chat-store/base-chat-store.ts
+++ b/packages/core/src/storage/chat-store/base-chat-store.ts
@@ -19,5 +19,7 @@ export abstract class BaseChatStore<
   ): void;
   abstract deleteMessages(key: string): void;
   abstract deleteMessage(key: string, idx: number): void;
-  abstract getKeys(): IterableIterator<string>;
+  abstract getKeys():
+    | IterableIterator<string>
+    | Promise<IterableIterator<string>>;
 }


### PR DESCRIPTION
This PR adds async support to BaseChatStore and BaseChatStoreMemory.
Issue link: https://github.com/run-llama/LlamaIndexTS/issues/1469
Continuation of PR: https://github.com/run-llama/LlamaIndexTS/pull/1470