### PR TITLE
fix: supports vercel bundling

### DIFF
--- a/.changeset/cuddly-geckos-clap.md
+++ b/.changeset/cuddly-geckos-clap.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: supports Vercel bundling

--- a/packages/llamaindex/src/vector-store/PGVectorStore.ts
+++ b/packages/llamaindex/src/vector-store/PGVectorStore.ts
@@ -176,7 +176,12 @@ export class PGVectorStore extends BaseVectorStore {
     if ("clientConfig" in config) {
       this.clientConfig = config.clientConfig;
     } else {
-      if (config.client.constructor.name.includes("Vercel")) {
+      if (
+        config.client.constructor.name.includes("Vercel") ||
+        (!!(config.client as VercelPool).connect &&
+          !!(config.client as VercelPool).query &&
+          !(config.client as Sql).unsafe)
+      ) {
         this.isDBConnected = true;
         this.db = fromVercelPool(config.client as unknown as VercelPool);
       } else if (typeof config.client === "function") {


### PR DESCRIPTION
As described in https://github.com/run-llama/LlamaIndexTS/issues/1508

Inside a Server Action deployed on Vercel, the check done in the constructor of PGVectorStore fails to identify the vercel/posgres pool used.

In this change, I propose to check the presence or absence of some methods.
(Note that the methods also will be bond)

```ts
if (
    config.client.constructor.name.includes("Vercel") ||
    (!!(config.client as VercelPool).connect &&
      !!(config.client as VercelPool).query &&
      !(config.client as Sql).unsafe)
   )
```