### PR TITLE
Pass options through to userWebpack in withLlamaIndex

### DIFF
--- a/.changeset/weak-cats-smash.md
+++ b/.changeset/weak-cats-smash.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+withLlamaIndex now passes through webpack options to the passed in customized NextJS webpack config. Before it was only passing through the config.

--- a/packages/llamaindex/src/next.ts
+++ b/packages/llamaindex/src/next.ts
@@ -41,7 +41,7 @@ export default function withLlamaIndex(config: any) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config.webpack = function (webpackConfig: any, options: any) {
     if (userWebpack) {
-      webpackConfig = userWebpack(webpackConfig);
+      webpackConfig = userWebpack(webpackConfig, options);
     }
     webpackConfig.resolve.alias = {
       ...webpackConfig.resolve.alias,


### PR DESCRIPTION
## Description of Changes

Passes through the `options` parameter when calling the `userWebpack` to support existing NextJS configs that rely on those options being passed through.

#### Background
I ran into this issue when attempting to setup Langtrace in my NextJS app. Their recommended adjustment to the NextJS config relied on the webpack `options.isServer`. That's when I noticed this was a bug. Instead of trying to work around, I figured I would submit a quick fix.

From: https://docs.langtrace.ai/supported-integrations/web-frameworks/nextjs
```js
import { ModuleAlias } from '@langtrase/typescript-sdk/dist/webpack/plugins/ModuleAlias.js'
const nextConfig = {
  webpack: (config, { isServer }) => {
    if (isServer) {
        config.resolve.plugins = [
        ...(config.resolve.plugins || []),
        new ModuleAlias(process.cwd())
      ];
      config.module.rules.push({
        loader: "node-loader",
        test: /\.node$/,
      });
      config.ignoreWarnings = [{ module: /opentelemetry/ }];
    }
  return config;
  },
};
```
The above configuration wouldn't work since if you passed your NextJS config to `withLlamaIndex` it would never pass the options through so you had no access to the `isServer` option to be able to guard those config options.

### Current workaround
In order to work around this currently you can do the following:

```js
import { ModuleAlias } from '@langtrase/typescript-sdk/dist/webpack/plugins/ModuleAlias.js'
import withLlamaIndex from 'llamaindex/next';

const nextConfig = {
  webpack: (config) => {
    // ... customized webpack config
    return config;
  },
  // ... other custom NextJS config
};

const { webpack, ...rest } = withLlamaIndex(nextConfig);

export default {
  ...rest,
  webpack: (config, options) => {
    config = webpack(config, options);
    if (options.isServer) {
      config.resolve.plugins = [
        ...(config.resolve.plugins || []),
        new ModuleAlias(process.cwd()),
      ];
      config.module.rules.push({
        loader: 'node-loader',
        test: /\.node$/,
      });
      config.ignoreWarnings = [
        ...(config?.ignoreWarnings || []),
        { module: /opentelemetry/ },
      ];
    }

    return config;
  },
};
```
