### PR TITLE
fix: return actual source nodes with compact and refine response synt…

### DIFF
--- a/.changeset/new-cups-dress.md
+++ b/.changeset/new-cups-dress.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/core": patch
+---
+
+The compact and refine response synthesizer (retrieved by using `getResponseSynthesizer('compact')`) has been fixed to return the original source nodes that were provided to it in its response. Previous to this it was returning the compacted text chunk documents.

--- a/packages/core/tests/response-synthesizers/compact-and-refine.test.ts
+++ b/packages/core/tests/response-synthesizers/compact-and-refine.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from "vitest";
+import type { LLMMetadata } from "../../llms/dist/index.js";
+import { getResponseSynthesizer } from "../../response-synthesizers/dist/index.js";
+import { Document } from "../../schema/dist/index.js";
+
+const mockLllm = () => ({
+  complete: vi.fn().mockImplementation(({ stream }) => {
+    const response = { text: "unimportant" };
+    if (!stream) {
+      return response;
+    }
+
+    function* gen() {
+      // yield a few times to make sure each chunk has the sourceNodes
+      yield response;
+      yield response;
+      yield response;
+    }
+
+    return gen();
+  }),
+  chat: vi.fn(),
+  metadata: {} as unknown as LLMMetadata,
+});
+
+describe("compact and refine response synthesizer", () => {
+  describe("synthesize", () => {
+    test("should return original sourceNodes with response when stream = false", async () => {
+      const synthesizer = getResponseSynthesizer("compact", {
+        llm: mockLllm(),
+      });
+
+      const sourceNode = { node: new Document({}), score: 1 };
+
+      const response = await synthesizer.synthesize(
+        {
+          query: "test",
+          nodes: [sourceNode],
+        },
+        false,
+      );
+
+      expect(response.sourceNodes).toEqual([sourceNode]);
+    });
+
+    test("should return original sourceNodes with response when stream = true", async () => {
+      const synthesizer = getResponseSynthesizer("compact", {
+        llm: mockLllm(),
+      });
+
+      const sourceNode = { node: new Document({}), score: 1 };
+
+      const response = await synthesizer.synthesize(
+        {
+          query: "test",
+          nodes: [sourceNode],
+        },
+        true,
+      );
+
+      for await (const chunk of response) {
+        expect(chunk.sourceNodes).toEqual([sourceNode]);
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Description of Changes

Updates the `Refine` responseSynthesizer to return the `sourceNodes` in the response as the original nodes that were provided to the synthesizer. This persists the behavior of it prior to 0.5.20 and the other synthesizers where `EngineResponse.sourceNodes` is set to the value of the original source nodes that were provided. With the prior implementation it was returning the packed text chunks which would lose context of the document information.

Fixes: #1552