### PR TITLE
Upgrade the chromadb npm client to version 1.10.3

### DIFF
--- a/examples/chromadb/test.ts
+++ b/examples/chromadb/test.ts
@@ -8,7 +8,7 @@ import {
 const collectionName = "movie_reviews";
 
 async function main() {
-  const sourceFile: string = "./data/movie_reviews.csv";
+  const sourceFile: string = "../data/movie_reviews.csv";
 
   try {
     console.log(`Loading data from ${sourceFile}`);

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -55,7 +55,7 @@
     "@zilliz/milvus2-sdk-node": "^2.4.6",
     "ajv": "^8.17.1",
     "assemblyai": "^4.8.0",
-    "chromadb": "1.9.2",
+    "chromadb": "1.10.3",
     "chromadb-default-embed": "^2.13.2",
     "cohere-ai": "7.14.0",
     "gpt-tokenizer": "^2.6.2",

--- a/packages/llamaindex/src/vector-store/ChromaVectorStore.ts
+++ b/packages/llamaindex/src/vector-store/ChromaVectorStore.ts
@@ -210,7 +210,6 @@ export class ChromaVectorStore extends BaseVectorStore {
       QueryRecordsParams
     >{
       queryEmbeddings: query.queryEmbedding ?? undefined,
-      queryTexts: query.queryStr ?? undefined,
       nResults: query.similarityTopK,
       where: Object.keys(chromaWhere).length ? chromaWhere : undefined,
       whereDocument: options?.whereDocument,
@@ -219,7 +218,7 @@ export class ChromaVectorStore extends BaseVectorStore {
     });
 
     const vectorStoreQueryResult: VectorStoreQueryResult = {
-      nodes: queryResponse.ids[0]!.map((id, index) => {
+      nodes: queryResponse.ids[0]!.map((_, index) => {
         const text = (queryResponse.documents as string[][])[0]![index];
         const metaData = queryResponse.metadatas[0]![index] ?? {};
         const node = metadataDictToNode(metaData);


### PR DESCRIPTION
The version `1.9.2` that is currently in the repo is not compatible with the latest chroma Docker [image (0.6.3)](https://hub.docker.com/layers/chromadb/chroma/latest/images/sha256-f6ef0a521878209c07942e865afe93defc950661c3275bbdeb7ab2cf4ccdca98)

Steps to reproduce:

```bash
docker pull chromadb/chroma
docker run -p 8000:8000 chromadb/chroma
```

then run the example from `examples/chromadb`

```bash
npx ts-node test.ts
```

_side note:_ first there will be an error regarding the incorrect path do the `data.csv` file. This fix included to the MR as well, and after that the actual issue:

```bash
npx ts-node test.ts
llamaindex was already imported. This breaks constructor checks and will lead to issues!
Loading data from ../data/movie_reviews.csv
(node:73164) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:73164) ExperimentalWarning: CommonJS module /home/my8bit/github/LlamaIndexTS-pikisoft/packages/providers/storage/azure/dist/index.cjs is loading ES Module /home/my8bit/github/LlamaIndexTS-pikisoft/packages/providers/storage/azure/dist/storage.edge-light.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
Creating ChromaDB vector store
Embedding documents and adding to index
Error: Could not connect to tenant default_tenant. Are you sure it exists? Underlying error:
ChromaClientError: Bad request to http://localhost:8000/api/v1/tenants/default_tenant with status: Bad Request
    at validateTenantDatabase (/home/my8bit/github/LlamaIndexTS-pikisoft/node_modules/.pnpm/chromadb@1.9.2_@google+generative-ai@0.21.0_cohere-ai@7.14.0_@aws-sdk+client-sso-oidc@3.693.0_2xai75z4avcyvpce2vhtfaypoi/node_modules/chromadb/src/utils.ts:61:11)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async ChromaClient.getOrCreateCollection (/home/my8bit/github/LlamaIndexTS-pikisoft/node_modules/.pnpm/chromadb@1.9.2_@google+generative-ai@0.21.0_cohere-ai@7.14.0_@aws-sdk+client-sso-oidc@3.693.0_2xai75z4avcyvpce2vhtfaypoi/node_modules/chromadb/src/ChromaClient.ts:229:5)
    at async ChromaVectorStore.getCollection (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/vector-store/ChromaVectorStore.js:33:26)
    at async ChromaVectorStore.add (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/vector-store/ChromaVectorStore.js:54:28)
    at async addNodesToVectorStores (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/ingestion/IngestionPipeline.js:115:28)
    at async VectorStoreIndex.insertNodes (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:208:9)
    at async VectorStoreIndex.buildIndexFromNodes (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:115:9)
    at async Function.init (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:65:13)
    at async Function.fromDocuments (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:145:20)
    at async main (/home/my8bit/github/LlamaIndexTS-pikisoft/examples/chromadb/test.ts:23:19)
```


and from Docker image

```
docker run -p 8000:8000  chromadb/chroma:latest
Starting 'uvicorn chromadb.app:app' with args: --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config chromadb/log_config.yml --timeout-keep-alive 30
WARNING:  [27-01-2025 14:27:36] chroma_server_nofile is set to 65536, but this is less than current soft limit of 1048576. chroma_server_nofile will not be set.
INFO:     [27-01-2025 14:27:36] Anonymized telemetry enabled. See                     https://docs.trychroma.com/telemetry for more information.
DEBUG:    [27-01-2025 14:27:36] Starting component System
DEBUG:    [27-01-2025 14:27:36] Starting component OpenTelemetryClient
DEBUG:    [27-01-2025 14:27:36] Starting component SqliteDB
DEBUG:    [27-01-2025 14:27:36] Starting component SimpleQuotaEnforcer
DEBUG:    [27-01-2025 14:27:36] Starting component Posthog
DEBUG:    [27-01-2025 14:27:36] Starting component SimpleRateLimitEnforcer
DEBUG:    [27-01-2025 14:27:36] Starting component LocalSegmentManager
DEBUG:    [27-01-2025 14:27:36] Starting component LocalExecutor
DEBUG:    [27-01-2025 14:27:36] Starting component SegmentAPI
DEBUG:    [27-01-2025 14:27:36] Starting component SimpleAsyncRateLimitEnforcer
INFO:     [27-01-2025 14:27:37] Started server process [1]
INFO:     [27-01-2025 14:27:37] Waiting for application startup.
INFO:     [27-01-2025 14:27:37] Application startup complete.
INFO:     [27-01-2025 14:27:37] Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     [27-01-2025 14:29:17] 172.17.0.1:38940 - "GET /api/v1/tenants/default_tenant HTTP/1.1" 400
```

with the update version from this PR it works as expected.


I didn't include the changeset as was not sure if this should trigger the `major` bump, so I'd like to ask your guidance on that