### PR TITLE
fix: update the version of chromadb client to 1.10.3 that is compatible with the latest Docker version of chroma (0.6.3)

### DIFF
--- a/.changeset/violet-panthers-rescue.md
+++ b/.changeset/violet-panthers-rescue.md
@@ -1,0 +1,6 @@
+---
+"@llamaindex/chroma": patch
+"@llamaindex/examples": patch
+---
+
+Update the chromadb npm client to support the latest chromadb image (0.6.3)

--- a/examples/chromadb/test.ts
+++ b/examples/chromadb/test.ts
@@ -8,7 +8,7 @@ import {
 const collectionName = "movie_reviews";
 
 async function main() {
-  const sourceFile: string = "./data/movie_reviews.csv";
+  const sourceFile: string = "../data/movie_reviews.csv";
 
   try {
     console.log(`Loading data from ${sourceFile}`);

--- a/packages/providers/storage/chroma/package.json
+++ b/packages/providers/storage/chroma/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@llamaindex/core": "workspace:*",
     "@llamaindex/env": "workspace:*",
-    "chromadb": "1.9.2",
+    "chromadb": "1.10.3",
     "chromadb-default-embed": "^2.13.2"
   }
 }

--- a/packages/providers/storage/chroma/src/ChromaVectorStore.ts
+++ b/packages/providers/storage/chroma/src/ChromaVectorStore.ts
@@ -210,7 +210,6 @@ export class ChromaVectorStore extends BaseVectorStore {
       QueryRecordsParams
     >{
       queryEmbeddings: query.queryEmbedding ?? undefined,
-      queryTexts: query.queryStr ?? undefined,
       nResults: query.similarityTopK,
       where: Object.keys(chromaWhere).length ? chromaWhere : undefined,
       whereDocument: options?.whereDocument,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1372,8 +1372,8 @@ importers:
         specifier: workspace:*
         version: link:../../../env
       chromadb:
-        specifier: 1.9.2
-        version: 1.9.2(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.73.1(encoding@0.1.13)(zod@3.24.1))
+        specifier: 1.10.3
+        version: 1.10.3(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.73.1(encoding@0.1.13)(zod@3.24.1))
       chromadb-default-embed:
         specifier: ^2.13.2
         version: 2.13.2
@@ -6086,6 +6086,24 @@ packages:
 
   chromadb-default-embed@2.13.2:
     resolution: {integrity: sha512-mhqo5rLjkF2KkxAV0WS82vNIXWpVMzvz5y5ayIB2FxcebUbEBNlcRh6XSSqYChWMfJ9us1ZzLQU8RXqsy3sKaA==}
+
+  chromadb@1.10.3:
+    resolution: {integrity: sha512-8gudGHCLfuFIIb3O28hzrHQ5F+qRotw2TaD+xRSIJIdKUQ4yml0EqqynZCNb5KDgEN78hj8USDq96KNDi4YH9A==}
+    engines: {node: '>=14.17.0'}
+    peerDependencies:
+      '@google/generative-ai': ^0.1.1
+      cohere-ai: ^5.0.0 || ^6.0.0 || ^7.0.0
+      openai: ^3.0.0 || ^4.0.0
+      voyageai: ^0.0.3-1
+    peerDependenciesMeta:
+      '@google/generative-ai':
+        optional: true
+      cohere-ai:
+        optional: true
+      openai:
+        optional: true
+      voyageai:
+        optional: true
 
   chromadb@1.9.2:
     resolution: {integrity: sha512-JNeLKlrsPxld7oPJCNeF73yHyyYeyP950enWRkTa6WsJ6UohH2NQ1vXZu6lWO9WuA9EMypITyZFZ8KtcTV3y2Q==}
@@ -17628,6 +17646,16 @@ snapshots:
       sharp: 0.32.6
     optionalDependencies:
       onnxruntime-node: 1.14.0
+
+  chromadb@1.10.3(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.73.1(encoding@0.1.13)(zod@3.24.1)):
+    dependencies:
+      cliui: 8.0.1
+      isomorphic-fetch: 3.0.0(encoding@0.1.13)
+    optionalDependencies:
+      cohere-ai: 7.14.0(encoding@0.1.13)
+      openai: 4.73.1(encoding@0.1.13)(zod@3.24.1)
+    transitivePeerDependencies:
+      - encoding
 
   chromadb@1.9.2(cohere-ai@7.14.0(encoding@0.1.13))(encoding@0.1.13)(openai@4.73.1(encoding@0.1.13)(zod@3.24.1)):
     dependencies:


### PR DESCRIPTION
The version `1.9.2` that is currently in the repo is not compatible with the latest chroma Docker [image (0.6.3)](https://hub.docker.com/layers/chromadb/chroma/latest/images/sha256-f6ef0a521878209c07942e865afe93defc950661c3275bbdeb7ab2cf4ccdca98)

Steps to reproduce:

```bash
docker pull chromadb/chroma
docker run -p 8000:8000 chromadb/chroma
```

then run the example from `examples/chromadb`

```bash
npx ts-node test.ts
```

_side note:_ first there will be an error regarding the incorrect path do the `data.csv` file. This fix included to the MR as well, and after that the actual issue:

```bash
npx ts-node test.ts
llamaindex was already imported. This breaks constructor checks and will lead to issues!
Loading data from ../data/movie_reviews.csv
(node:73164) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:73164) ExperimentalWarning: CommonJS module /home/my8bit/github/LlamaIndexTS-pikisoft/packages/providers/storage/azure/dist/index.cjs is loading ES Module /home/my8bit/github/LlamaIndexTS-pikisoft/packages/providers/storage/azure/dist/storage.edge-light.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
Creating ChromaDB vector store
Embedding documents and adding to index
Error: Could not connect to tenant default_tenant. Are you sure it exists? Underlying error:
ChromaClientError: Bad request to http://localhost:8000/api/v1/tenants/default_tenant with status: Bad Request
    at validateTenantDatabase (/home/my8bit/github/LlamaIndexTS-pikisoft/node_modules/.pnpm/chromadb@1.9.2_@google+generative-ai@0.21.0_cohere-ai@7.14.0_@aws-sdk+client-sso-oidc@3.693.0_2xai75z4avcyvpce2vhtfaypoi/node_modules/chromadb/src/utils.ts:61:11)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async ChromaClient.getOrCreateCollection (/home/my8bit/github/LlamaIndexTS-pikisoft/node_modules/.pnpm/chromadb@1.9.2_@google+generative-ai@0.21.0_cohere-ai@7.14.0_@aws-sdk+client-sso-oidc@3.693.0_2xai75z4avcyvpce2vhtfaypoi/node_modules/chromadb/src/ChromaClient.ts:229:5)
    at async ChromaVectorStore.getCollection (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/vector-store/ChromaVectorStore.js:33:26)
    at async ChromaVectorStore.add (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/vector-store/ChromaVectorStore.js:54:28)
    at async addNodesToVectorStores (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/ingestion/IngestionPipeline.js:115:28)
    at async VectorStoreIndex.insertNodes (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:208:9)
    at async VectorStoreIndex.buildIndexFromNodes (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:115:9)
    at async Function.init (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:65:13)
    at async Function.fromDocuments (/home/my8bit/github/LlamaIndexTS-pikisoft/packages/llamaindex/dist/cjs/indices/vectorStore/index.js:145:20)
    at async main (/home/my8bit/github/LlamaIndexTS-pikisoft/examples/chromadb/test.ts:23:19)
```


and from Docker image

```
docker run -p 8000:8000  chromadb/chroma:latest
Starting 'uvicorn chromadb.app:app' with args: --workers 1 --host 0.0.0.0 --port 8000 --proxy-headers --log-config chromadb/log_config.yml --timeout-keep-alive 30
WARNING:  [27-01-2025 14:27:36] chroma_server_nofile is set to 65536, but this is less than current soft limit of 1048576. chroma_server_nofile will not be set.
INFO:     [27-01-2025 14:27:36] Anonymized telemetry enabled. See                     https://docs.trychroma.com/telemetry for more information.
DEBUG:    [27-01-2025 14:27:36] Starting component System
DEBUG:    [27-01-2025 14:27:36] Starting component OpenTelemetryClient
DEBUG:    [27-01-2025 14:27:36] Starting component SqliteDB
DEBUG:    [27-01-2025 14:27:36] Starting component SimpleQuotaEnforcer
DEBUG:    [27-01-2025 14:27:36] Starting component Posthog
DEBUG:    [27-01-2025 14:27:36] Starting component SimpleRateLimitEnforcer
DEBUG:    [27-01-2025 14:27:36] Starting component LocalSegmentManager
DEBUG:    [27-01-2025 14:27:36] Starting component LocalExecutor
DEBUG:    [27-01-2025 14:27:36] Starting component SegmentAPI
DEBUG:    [27-01-2025 14:27:36] Starting component SimpleAsyncRateLimitEnforcer
INFO:     [27-01-2025 14:27:37] Started server process [1]
INFO:     [27-01-2025 14:27:37] Waiting for application startup.
INFO:     [27-01-2025 14:27:37] Application startup complete.
INFO:     [27-01-2025 14:27:37] Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     [27-01-2025 14:29:17] 172.17.0.1:38940 - "GET /api/v1/tenants/default_tenant HTTP/1.1" 400
```

with the update version from this PR it works as expected.


I didn't include the changeset as was not sure if this should trigger the `major` bump, so I'd like to ask your guidance on that