### PR TITLE
fix: delete temp competely from params when calling openai o3

### DIFF
--- a/.changeset/smooth-shirts-shop.md
+++ b/.changeset/smooth-shirts-shop.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/openai": patch
+---
+
+fix: moved the temp exclusion lower level for o3 mini openai

--- a/packages/providers/openai/src/llm.ts
+++ b/packages/providers/openai/src/llm.ts
@@ -353,7 +353,7 @@ export class OpenAI extends ToolCallLLM<OpenAIAdditionalChatOptions> {
     const { messages, stream, tools, additionalChatOptions } = params;
     const baseRequestParams = <OpenAILLM.Chat.ChatCompletionCreateParams>{
       model: this.model,
-      temperature: isTemperatureSupported(this.model) ? this.temperature : null,
+      temperature: this.temperature,
       max_tokens: this.maxTokens,
       tools: tools?.map(OpenAI.toTool),
       messages: OpenAI.toOpenAIMessage(messages),
@@ -368,6 +368,9 @@ export class OpenAI extends ToolCallLLM<OpenAIAdditionalChatOptions> {
       // remove empty tools array to avoid OpenAI error
       delete baseRequestParams.tools;
     }
+
+    if (!isTemperatureSupported(baseRequestParams.model))
+      delete baseRequestParams.temperature;
 
     // Streaming
     if (stream) {


### PR DESCRIPTION
This is a follow up from the previous fix.

The previous fix stopped working for an unknown reason but this one for sure fixes the issue @marcusschiesser 