### PR TITLE
fix(gemini): use function role for message contains tool-result

### DIFF
--- a/.changeset/itchy-tips-reflect.md
+++ b/.changeset/itchy-tips-reflect.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/google": patch
+---
+
+fix(gemini): use function role for message contains tool-result

--- a/examples/gemini/agent.ts
+++ b/examples/gemini/agent.ts
@@ -1,4 +1,18 @@
-import { FunctionTool, Gemini, GEMINI_MODEL, LLMAgent } from "llamaindex";
+import {
+  FunctionTool,
+  Gemini,
+  GEMINI_MODEL,
+  LLMAgent,
+  Settings,
+} from "llamaindex";
+
+Settings.callbackManager.on("llm-tool-call", (event) => {
+  console.log(event.detail);
+});
+
+Settings.callbackManager.on("llm-tool-result", (event) => {
+  console.log(event.detail);
+});
 
 const sumNumbers = FunctionTool.from(
   ({ a, b }: { a: number; b: number }) => `${a + b}`,
@@ -44,17 +58,39 @@ const divideNumbers = FunctionTool.from(
   },
 );
 
+const subtractNumbers = FunctionTool.from(
+  ({ a, b }: { a: number; b: number }) => `${a - b}`,
+  {
+    name: "subtractNumbers",
+    description: "Use this function to subtract two numbers",
+    parameters: {
+      type: "object",
+      properties: {
+        a: {
+          type: "number",
+          description: "The number to subtract from",
+        },
+        b: {
+          type: "number",
+          description: "The number to subtract",
+        },
+      },
+      required: ["a", "b"],
+    },
+  },
+);
+
 async function main() {
   const gemini = new Gemini({
     model: GEMINI_MODEL.GEMINI_PRO,
   });
   const agent = new LLMAgent({
     llm: gemini,
-    tools: [sumNumbers, divideNumbers],
+    tools: [sumNumbers, divideNumbers, subtractNumbers],
   });
 
   const response = await agent.chat({
-    message: "How much is 5 + 5? then divide by 2",
+    message: "How much is 5 + 5? then divide by 2 then subtract 1",
   });
 
   console.log(response.message);

--- a/packages/providers/google/src/types.ts
+++ b/packages/providers/google/src/types.ts
@@ -97,7 +97,7 @@ export type GenerativeModel =
 
 export type ChatContext = { message: Part[]; history: GeminiMessageContent[] };
 
-export type GeminiMessageRole = "user" | "model";
+export type GeminiMessageRole = "user" | "model" | "function";
 
 export type GeminiAdditionalChatOptions = object;
 

--- a/packages/providers/google/src/utils.ts
+++ b/packages/providers/google/src/utils.ts
@@ -196,6 +196,7 @@ export class GeminiHelper {
   > = {
     user: "user",
     model: "assistant",
+    function: "user",
   };
 
   public static mergeNeighboringSameRoleMessages(
@@ -278,12 +279,21 @@ export class GeminiHelper {
     return parts;
   }
 
+  public static getGeminiMessageRole(
+    message: ChatMessage<ToolCallLLMMessageOptions>,
+  ): GeminiMessageRole {
+    if (message.options && "toolResult" in message.options) {
+      return "function";
+    }
+    return GeminiHelper.ROLES_TO_GEMINI[message.role];
+  }
+
   public static chatMessageToGemini(
     message: ChatMessage<ToolCallLLMMessageOptions>,
     fnMap: Record<string, string>, // mapping of fn call id to fn call name
   ): GeminiMessageContent {
     return {
-      role: GeminiHelper.ROLES_TO_GEMINI[message.role],
+      role: GeminiHelper.getGeminiMessageRole(message),
       parts: GeminiHelper.messageContentToGeminiParts({ ...message, fnMap }),
     };
   }


### PR DESCRIPTION
Error: Content with role 'user' can't contain 'functionResponse' part

Chat History when debugging:
```
const chatHistory = [
	{ role: "user", parts: [{ text: "How much is 5 + 5? then divide by 2" }] },
	{ role: "model", parts: [{ functionCall: { name: "sumNumbers", args: { a: 5, b: 5 } } }] },
	{ role: "user", parts: [{ functionResponse: { name: "sumNumbers", response: { result: "10" } } }] },
	{ role: "model", parts: [{ functionCall: { name: "divideNumbers", args: { a: 10, b: 2 } } }] }
];
```

VALID_PARTS_PER_ROLE from @google/generative-ai package
https://github.com/google-gemini/generative-ai-js/blob/2df2af03bb07dcda23b07af1a7135a8b461ae64e/src/methods/chat-session-helpers.ts#L34
```
const VALID_PARTS_PER_ROLE = {
	user: ["text", "inlineData"],
	function: ["functionResponse"],
	model: ["text", "functionCall", "executableCode", "codeExecutionResult"],
	system: ["text"],
};
```