### PR TITLE
fix: add peer deps from @llamaindex/env 

### DIFF
--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -30,7 +30,11 @@
     "ajv": "^8.17.1",
     "lodash": "^4.17.21",
     "magic-bytes.js": "^1.10.0",
-    "gpt-tokenizer": "^2.6.2"
+    "gpt-tokenizer": "^2.6.2",
+    "@aws-crypto/sha256-js": "^5.2.0",
+    "@huggingface/transformers": "^3.0.2",
+    "js-tiktoken": "^1.0.12",
+    "pathe": "^1.1.2"
   },
   "devDependencies": {
     "@swc/cli": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1039,6 +1039,12 @@ importers:
 
   packages/llamaindex:
     dependencies:
+      '@aws-crypto/sha256-js':
+        specifier: ^5.2.0
+        version: 5.2.0
+      '@huggingface/transformers':
+        specifier: ^3.0.2
+        version: 3.3.3
       '@llamaindex/cloud':
         specifier: workspace:*
         version: link:../cloud
@@ -1066,12 +1072,18 @@ importers:
       gpt-tokenizer:
         specifier: ^2.6.2
         version: 2.8.1
+      js-tiktoken:
+        specifier: ^1.0.12
+        version: 1.0.18
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
       magic-bytes.js:
         specifier: ^1.10.0
         version: 1.10.0
+      pathe:
+        specifier: ^1.1.2
+        version: 1.1.2
     devDependencies:
       '@swc/cli':
         specifier: ^0.5.0


### PR DESCRIPTION
I encountered an error when running scripts with llamaindex v0.9. To reproduce:

index.ts
```
import { Document, VectorStoreIndex } from "llamaindex";

async function main() {
	const index = await VectorStoreIndex.fromDocuments([
		new Document({
			text: "Develop a habit of working on your own projects. Don't let work mean something other people tell you to do. If you do manage to do great work one day, it will probably be on a project of your own. It may be within some bigger project, but you'll be driving your part of it.",
		}),
	]);
	const queryEngine = index.asQueryEngine();
	const response = await queryEngine.query({ query: "How to do great work?" });
	console.log(response.toString());
}

main().catch(console.error);
```

package.json
```
{
  "dependencies": {
    "llamaindex": "^0.9.0"
  }
}
```

```
npm i
npx tsx index.ts
```

Error:
```
Error: Cannot find module '@aws-crypto/sha256-js'
Require stack:
- C:\Users\...\node_modules\@llamaindex\env\dist\index.cjs
- C:\Users\...\node_modules\@llamaindex\core\agent\dist\index.cjs
- C:\Users\...\node_modules\@llamaindex\openai\dist\index.cjs
```