### PR TITLE
fix: enhance error message in llamacloud

### DIFF
--- a/.changeset/young-pans-pump.md
+++ b/.changeset/young-pans-pump.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+fix: enhance error message in llamacloud

--- a/packages/llamaindex/src/cloud/utils.ts
+++ b/packages/llamaindex/src/cloud/utils.ts
@@ -33,7 +33,7 @@ export function initService({ apiKey, baseUrl }: ClientParams = {}) {
   });
   client.interceptors.error.use((error) => {
     throw new Error(
-      `Error when using LlamaCloud client. Detail: ${JSON.stringify(error)}`,
+      `LlamaCloud API request failed. Error details: ${JSON.stringify(error, null, 2)}`,
     );
   });
   if (!token) {

--- a/packages/llamaindex/src/cloud/utils.ts
+++ b/packages/llamaindex/src/cloud/utils.ts
@@ -48,6 +48,10 @@ export async function getProjectId(
       organization_id: organizationId ?? null,
     },
     throwOnError: true,
+  }).catch((error: { detail?: string }) => {
+    throw new Error(
+      `Error fetching project: ${projectName}. Please verify that your API key is valid and has access to this project. Detail: ${error?.detail}`,
+    );
   });
 
   if (projects.length === 0) {
@@ -80,6 +84,10 @@ export async function getPipelineId(
       pipeline_name: name,
     },
     throwOnError: true,
+  }).catch((error: { detail?: string }) => {
+    throw new Error(
+      `Error fetching pipeline: ${name} in project ${projectName}. Detail: ${error?.detail}`,
+    );
   });
 
   if (pipelines.length === 0 || !pipelines[0]!.id) {

--- a/packages/llamaindex/src/cloud/utils.ts
+++ b/packages/llamaindex/src/cloud/utils.ts
@@ -31,6 +31,11 @@ export function initService({ apiKey, baseUrl }: ClientParams = {}) {
     request.headers.set("Authorization", `Bearer ${token}`);
     return request;
   });
+  client.interceptors.error.use((error) => {
+    throw new Error(
+      `Error when using LlamaCloud client. Detail: ${JSON.stringify(error)}`,
+    );
+  });
   if (!token) {
     throw new Error(
       "API Key is required for LlamaCloudIndex. Please pass the apiKey parameter",
@@ -48,10 +53,6 @@ export async function getProjectId(
       organization_id: organizationId ?? null,
     },
     throwOnError: true,
-  }).catch((error: { detail?: string }) => {
-    throw new Error(
-      `Error fetching project: ${projectName}. Please verify that your API key is valid and has access to this project. Detail: ${error?.detail}`,
-    );
   });
 
   if (projects.length === 0) {
@@ -84,10 +85,6 @@ export async function getPipelineId(
       pipeline_name: name,
     },
     throwOnError: true,
-  }).catch((error: { detail?: string }) => {
-    throw new Error(
-      `Error fetching pipeline: ${name} in project ${projectName}. Detail: ${error?.detail}`,
-    );
   });
 
   if (pipelines.length === 0 || !pipelines[0]!.id) {

--- a/packages/llamaindex/src/cloud/utils.ts
+++ b/packages/llamaindex/src/cloud/utils.ts
@@ -33,7 +33,7 @@ export function initService({ apiKey, baseUrl }: ClientParams = {}) {
   });
   client.interceptors.error.use((error) => {
     throw new Error(
-      `LlamaCloud API request failed. Error details: ${JSON.stringify(error, null, 2)}`,
+      `LlamaCloud API request failed. Error details: ${JSON.stringify(error)}`,
     );
   });
   if (!token) {


### PR DESCRIPTION
Try creating LlamaCloud with an invalid API key:
```
import { LlamaCloudIndex } from "llamaindex";

const index = new LlamaCloudIndex({
  name: "test",
  projectName: "Default",
  baseUrl: process.env.LLAMA_CLOUD_BASE_URL,
  apiKey: process.env.LLAMA_CLOUD_API_KEY,
});
await index.ensureIndex({ verbose: true });

```

I got this unclear error message:
```
node:internal/process/promises:289
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise 
which was not handled with .catch(). The promise rejected with the reason "#<Object>".] {
  code: 'ERR_UNHANDLED_REJECTION'
}

Node.js v20.9.0
```

After fixing:

```
...\LlamaIndexTS\packages\llamaindex\dist\cjs\cloud\utils.js:62
        throw new Error(`Error fetching project: ${projectName}. Please verify that your API key is valid and has access to this project. Detail: 
${error?.detail}`);
              ^

 Error: LlamaCloud API request failed. Error details: {"detail":"Project `Default` not found"}
    at ...\LlamaIndexTS\packages\llamaindex\dist\cjs\cloud\utils.js:62:15
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getProjectId (...\LlamaIndexTS\packages\llamaindex\dist\cjs\cloud\utils.js:55:32)
    at async LlamaCloudIndex.getProjectId (...\LlamaIndexTS\packages\llamaindex\dist\cjs\cloud\LlamaCloudIndex.js:103:16)     
    at async LlamaCloudIndex.ensureIndex (...\LlamaIndexTS\packages\llamaindex\dist\cjs\cloud\LlamaCloudIndex.js:232:27)      
    at main (...\LlamaIndexTS\examples\cloud\chat.ts:10:3)

Node.js v20.9.0
```