### PR TITLE
fix: Voyage typescript configs + docs

### DIFF
--- a/.changeset/red-taxis-hope.md
+++ b/.changeset/red-taxis-hope.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/voyage-ai": patch
+---
+
+Fixing tsconfig for voyage-ai provider

--- a/packages/providers/voyage-ai/tsconfig.json
+++ b/packages/providers/voyage-ai/tsconfig.json
@@ -10,7 +10,7 @@
   "include": ["./src"],
   "references": [
     {
-      "path": "../openai/tsconfig.json"
+      "path": "../../core/tsconfig.json"
     },
     {
       "path": "../../env/tsconfig.json"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -172,6 +172,9 @@
     },
     {
       "path": "./packages/providers/cohere/tsconfig.json"
+    },
+    {
+      "path": "./packages/providers/voyage-ai/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
Fixing tsconfigs for the new Voyage.ai provider (see #1574). Should also fix broken link to the class documentation in the docs. 