### PR TITLE
fix: Add fromConnectionString method for Azure vCore storages

### DIFF
--- a/.changeset/rude-gifts-leave.md
+++ b/.changeset/rude-gifts-leave.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/azure": patch
+---
+
+Add `fromConnectionString` method to azure storage libs to track the usage vCore.

--- a/packages/providers/storage/azure/src/chatStore/AzureCosmosMongovCoreChatStore.ts
+++ b/packages/providers/storage/azure/src/chatStore/AzureCosmosMongovCoreChatStore.ts
@@ -57,6 +57,21 @@ export class AzureCosmosVCoreChatStore<
     });
   }
 
+  static fromConnectionString(
+    connectionString: string,
+    dbName: string = DEFAULT_CHAT_DATABASE,
+    collectionName: string = DEFAULT_CHAT_Collection,
+  ): AzureCosmosVCoreChatStore {
+    const mongoClient = new MongoClient(connectionString, {
+      appName: "LLAMAINDEX_JS",
+    });
+    return new AzureCosmosVCoreChatStore({
+      mongoClient,
+      dbName,
+      collectionName,
+    });
+  }
+
   client(): MongoClient {
     return this.mongoClient;
   }

--- a/packages/providers/storage/azure/src/docStore/AzureCosmosMongovCoreDocumentStore.ts
+++ b/packages/providers/storage/azure/src/docStore/AzureCosmosMongovCoreDocumentStore.ts
@@ -46,4 +46,33 @@ export class AzureCosmosVCoreDocumentStore extends KVDocumentStore {
       namespace,
     });
   }
+
+  /**
+   * Static method for creating an instance using a connection string.
+   * @returns Instance of AzureCosmosVCoreDocumentStore
+   * @param connectionString - MongoDB connection string
+   * @param dbName - Database name
+   * @param collectionName - Collection name
+   * @example
+   * ```ts
+   * const indexStore = AzureCosmosVCoreDocumentStore.fromConnectionString("mongodb://localhost:27017", "my_db", "my_collection");
+   * ```
+   */
+  static fromConnectionString(
+    connectionString: string,
+    dbName: string = DEFAULT_DATABASE,
+    collectionName: string = DEFAULT_COLLECTION,
+  ): AzureCosmosVCoreDocumentStore {
+    const mongoClient = new MongoClient(connectionString, {
+      appName: "LLAMAINDEX_JS",
+    });
+    return new AzureCosmosVCoreDocumentStore({
+      azureCosmosVCoreKVStore: new AzureCosmosVCoreKVStore({
+        mongoClient,
+        dbName,
+        collectionName,
+      }),
+      namespace: `${dbName}.${collectionName}`,
+    });
+  }
 }

--- a/packages/providers/storage/azure/src/indexStore/AzureCosmosMongovCoreIndexStore.ts
+++ b/packages/providers/storage/azure/src/indexStore/AzureCosmosMongovCoreIndexStore.ts
@@ -46,4 +46,33 @@ export class AzureCosmosVCoreIndexStore extends KVIndexStore {
       namespace,
     });
   }
+
+  /**
+   * Static method for creating an instance using a connection string.
+   * @returns Instance of AzureCosmosVCoreIndexStore
+   * @param connectionString - MongoDB connection string
+   * @param dbName - Database name
+   * @param collectionName - Collection name
+   * @example
+   * ```ts
+   * const indexStore = AzureCosmosVCoreIndexStore.fromConnectionString("mongodb://localhost:27017", "my_db", "my_collection");
+   * ```
+   */
+  static fromConnectionString(
+    connectionString: string,
+    dbName: string = DEFAULT_DATABASE,
+    collectionName: string = DEFAULT_COLLECTION,
+  ): AzureCosmosVCoreIndexStore {
+    const mongoClient = new MongoClient(connectionString, {
+      appName: "LLAMAINDEX_JS",
+    });
+    return new AzureCosmosVCoreIndexStore({
+      azureCosmosVCoreKVStore: new AzureCosmosVCoreKVStore({
+        mongoClient,
+        dbName,
+        collectionName,
+      }),
+      namespace: `${dbName}.${collectionName}`,
+    });
+  }
 }


### PR DESCRIPTION
Add fromConnectionString  to:

- AzureCosmosVCoreIndexStore
- AzureCosmosVCoreDocumentStore
- AzureCosmosVCoreChatStore

Add UA in order to track the usage of vCore