### PR TITLE
fix: unhandled server error when accessing not found pages

### DIFF
--- a/apps/next/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/next/src/app/docs/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
+import { AutoTypeTable } from "@/components/type-table";
 import { createMetadata, metadataImage } from "@/lib/metadata";
 import { openapi, source } from "@/lib/source";
 import { Popup, PopupContent, PopupTrigger } from "fumadocs-twoslash/ui";
-import { createTypeTable } from "fumadocs-typescript/ui";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import {
   DocsBody,
@@ -20,7 +20,6 @@ export default async function Page(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
-  const { AutoTypeTable } = createTypeTable();
   const MDX = page.data.body;
 
   return (

--- a/apps/next/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/next/src/app/docs/[[...slug]]/page.tsx
@@ -11,8 +11,6 @@ import {
 } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 
-const { AutoTypeTable } = createTypeTable();
-
 export const revalidate = false;
 
 export default async function Page(props: {
@@ -22,6 +20,7 @@ export default async function Page(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
+  const { AutoTypeTable } = createTypeTable();
   const MDX = page.data.body;
 
   return (

--- a/apps/next/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/next/src/app/docs/[[...slug]]/page.tsx
@@ -1,7 +1,7 @@
-import { AutoTypeTable } from "@/components/type-table";
 import { createMetadata, metadataImage } from "@/lib/metadata";
 import { openapi, source } from "@/lib/source";
 import { Popup, PopupContent, PopupTrigger } from "fumadocs-twoslash/ui";
+import { createTypeTable } from "fumadocs-typescript/ui";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import {
   DocsBody,
@@ -20,6 +20,7 @@ export default async function Page(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
+  const { AutoTypeTable } = createTypeTable();
   const MDX = page.data.body;
 
   return (

--- a/apps/next/src/components/type-table.ts
+++ b/apps/next/src/components/type-table.ts
@@ -1,3 +1,0 @@
-import { createTypeTable } from "fumadocs-typescript/ui";
-
-export const { AutoTypeTable } = createTypeTable();

--- a/apps/next/src/components/type-table.ts
+++ b/apps/next/src/components/type-table.ts
@@ -1,0 +1,3 @@
+import { createTypeTable } from "fumadocs-typescript/ui";
+
+export const { AutoTypeTable } = createTypeTable();


### PR DESCRIPTION
Fix issue #1732 

Root Cause:
AutoTypeTable cannot load tsconfig.json when the page is not found.
See: https://fumadocs.vercel.app/docs/ui/components/auto-type-table#deep-dive

Solution: use AutoTypeTable only when the page is found
