### PR TITLE
it seems we have to assign to vectorStores in a different way

### DIFF
--- a/apps/next/src/content/docs/llamaindex/modules/data_stores/vector_stores/qdrant.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/data_stores/vector_stores/qdrant.mdx
@@ -58,7 +58,7 @@ const vectorStore = new QdrantVectorStore({
 const document = new Document({ text: essay, id_: path });
 
 const index = await VectorStoreIndex.fromDocuments([document], {
-  vectorStore,
+  vectorStores: { TEXT: vectorStore },
 });
 ```
 
@@ -93,7 +93,7 @@ async function main() {
   const document = new Document({ text: essay, id_: path });
 
   const index = await VectorStoreIndex.fromDocuments([document], {
-    vectorStore,
+    vectorStores: { TEXT: vectorStore },
   });
 
   const queryEngine = index.asQueryEngine();


### PR DESCRIPTION
when trying to user Quadrant vector store I was having issues with the configuration. The error I got was:

```
Object literal may only specify known properties, but 'vectorStore' does not exist in type 'VectorIndexOptions & { docStoreStrategy?: DocStoreStrategy | undefined; }'. Did you mean to write 'vectorStores'?ts(2561)
```

The way I was able to fix it is:

```
const vectorStore = new QdrantVectorStore({
      url: "http://localhost:6333",
    });

    await VectorStoreIndex.fromDocuments(documents, {
      vectorStores: { TEXT: vectorStore },
    });
```

Please check this PR.