### PR TITLE
Update qdrant.mdx documentation

### DIFF
--- a/apps/next/src/content/docs/llamaindex/modules/data_stores/vector_stores/qdrant.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/data_stores/vector_stores/qdrant.mdx
@@ -58,7 +58,7 @@ const vectorStore = new QdrantVectorStore({
 const document = new Document({ text: essay, id_: path });
 
 const index = await VectorStoreIndex.fromDocuments([document], {
-  vectorStore,
+  vectorStores: { TEXT: vectorStore },
 });
 ```
 
@@ -93,7 +93,7 @@ async function main() {
   const document = new Document({ text: essay, id_: path });
 
   const index = await VectorStoreIndex.fromDocuments([document], {
-    vectorStore,
+    vectorStores: { TEXT: vectorStore },
   });
 
   const queryEngine = index.asQueryEngine();

--- a/apps/next/src/content/docs/llamaindex/modules/data_stores/vector_stores/qdrant.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/data_stores/vector_stores/qdrant.mdx
@@ -56,10 +56,10 @@ const vectorStore = new QdrantVectorStore({
 
 ```ts
 const document = new Document({ text: essay, id_: path });
-
-const index = await VectorStoreIndex.fromDocuments([document], {
-  vectorStores: { TEXT: vectorStore },
-});
+const storageContext = await storageContextFromDefaults({ vectorStore });
+  const index = await VectorStoreIndex.fromDocuments([document], {
+    storageContext,
+  });
 ```
 
 ## Query the index
@@ -91,11 +91,11 @@ async function main() {
   });
 
   const document = new Document({ text: essay, id_: path });
-
+  const storageContext = await storageContextFromDefaults({ vectorStore });
   const index = await VectorStoreIndex.fromDocuments([document], {
-    vectorStores: { TEXT: vectorStore },
+    storageContext,
   });
-
+  
   const queryEngine = index.asQueryEngine();
 
   const response = await queryEngine.query({


### PR DESCRIPTION
when trying to user Quadrant vector store I was having issues with the configuration. The error I got was:

```
Object literal may only specify known properties, but 'vectorStore' does not exist in type 'VectorIndexOptions & { docStoreStrategy?: DocStoreStrategy | undefined; }'. Did you mean to write 'vectorStores'?ts(2561) 
```

The way I was able to fix it is:

```
const vectorStore = new QdrantVectorStore({
      url: "http://localhost:6333",
    });

    await VectorStoreIndex.fromDocuments(documents, {
      vectorStores: { TEXT: vectorStore },
    });
Please check this PR.