### PR TITLE
fix: context engine additional options not being passed

### DIFF
--- a/.changeset/cuddly-bulldogs-drive.md
+++ b/.changeset/cuddly-bulldogs-drive.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/core": patch
+---
+
+fix: include additional options for context chat engine

--- a/packages/core/src/chat-engine/context-chat-engine.ts
+++ b/packages/core/src/chat-engine/context-chat-engine.ts
@@ -102,6 +102,7 @@ export class ContextChatEngine extends PromptMixin implements BaseChatEngine {
       const stream = await this.chatModel.chat({
         messages: requestMessages.messages,
         stream: true,
+        additionalChatOptions: params.chatOptions as object,
       });
       return streamConverter(
         streamReducer({
@@ -117,6 +118,7 @@ export class ContextChatEngine extends PromptMixin implements BaseChatEngine {
     }
     const response = await this.chatModel.chat({
       messages: requestMessages.messages,
+      additionalChatOptions: params.chatOptions as object,
     });
     chatHistory.put(response.message);
     return EngineResponse.fromChatResponse(response, requestMessages.nodes);


### PR DESCRIPTION
This was the root cause of the GoogleStudio failing to generate images.