### PR TITLE
Add "thinking" and "thinking_signature" to chat response, and "thinking_signature" to chat stream

### DIFF
--- a/.changeset/yellow-carpets-return.md
+++ b/.changeset/yellow-carpets-return.md
@@ -1,0 +1,9 @@
+---
+"@llamaindex/anthropic": patch
+---
+
+added `option.thinking` and `option.thinking_signature` to Anthropic's chat response
+
+added `option.thinking_signature` to Anthropic's chat stream response
+
+handle `ChatMessages` with `option.thinking` and `option.thinking_signature`

--- a/examples/anthropic/thinking.ts
+++ b/examples/anthropic/thinking.ts
@@ -27,6 +27,8 @@ import { Anthropic } from "@llamaindex/anthropic";
       process.stdout.write(chunk.delta);
     } else if (chunk.options?.thinking) {
       process.stdout.write(chunk.options.thinking);
+    } else if (chunk.options?.thinking_signature) {
+      process.stdout.write(chunk.options.thinking_signature);
     }
   }
 })();

--- a/examples/anthropic/thinking.ts
+++ b/examples/anthropic/thinking.ts
@@ -31,4 +31,19 @@ import { Anthropic } from "@llamaindex/anthropic";
       process.stdout.write(chunk.options.thinking_signature);
     }
   }
+
+  console.log("Again, but without streaming");
+  const resultNoStream = await anthropic.chat({
+    messages: [
+      {
+        role: "user",
+        content:
+          "Are there an infinite number of prime numbers such that n mod 4 == 3?",
+      },
+    ],
+  });
+
+  console.log(resultNoStream.message.options?.thinking);
+  console.log(resultNoStream.message.options?.thinking_signature);
+  console.log(resultNoStream.message.content);
 })();

--- a/packages/providers/anthropic/src/llm.ts
+++ b/packages/providers/anthropic/src/llm.ts
@@ -135,6 +135,7 @@ export type AnthropicAdditionalChatOptions = Pick<
 export type AnthropicToolCallLLMMessageOptions = ToolCallLLMMessageOptions & {
   cache_control?: BetaCacheControlEphemeral | null;
   thinking?: string | undefined;
+  thinking_signature?: string | undefined;
 };
 
 export class Anthropic extends ToolCallLLM<
@@ -519,6 +520,12 @@ export class Anthropic extends ToolCallLLM<
           ? part.delta.thinking
           : undefined;
 
+      const thinkingSignature =
+        part.type === "content_block_delta" &&
+        part.delta.type === "signature_delta"
+          ? part.delta.signature
+          : undefined;
+
       if (
         part.type === "content_block_start" &&
         part.content_block.type === "tool_use"
@@ -559,13 +566,14 @@ export class Anthropic extends ToolCallLLM<
         continue;
       }
 
-      if (!textContent && !thinking) continue;
+      if (!textContent && !thinking && !thinkingSignature) continue;
 
       yield {
         raw: part,
         delta: textContent ?? "",
         options: {
           thinking: thinking,
+          thinking_signature: thinkingSignature,
         },
       };
     }


### PR DESCRIPTION
## Overview

This adds the `thinking` messages and their signatures (`thinking_signature`) to the `options` field when `stream` is `false`, and also adds `thinking_signature` to `options` when `stream` is `true`, 

## Changes
 
- I noticed the code at https://github.com/run-llama/LlamaIndexTS/blob/main/examples/anthropic/thinking.ts returns `thinking` in `options`, but no `signature` for the `thinking` messages was being returned
- I noticed that making `stream: false` wasn't returning `thinking` nor `thinking_signature` in `option`, so I added them both
- Since now the user may add the returned messages to the history, I changed `formatMessages` to handle the new keys in `options`, so that Anthropic receives the expected format

## Tests
I added tests to make sure `thinking` is correctly converted and to make sure it comes before `text' and tool calls.