### PR TITLE
feat: qdrant search params

### DIFF
--- a/.changeset/silver-taxis-call.md
+++ b/.changeset/silver-taxis-call.md
@@ -1,0 +1,8 @@
+---
+"@llamaindex/doc": patch
+"@llamaindex/examples": patch
+"@llamaindex/core": patch
+"@llamaindex/qdrant": patch
+---
+
+Add functionality for search params when querying Qdrant vector store.

--- a/apps/next/src/content/docs/llamaindex/modules/data/stores/vector_stores/qdrant.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/data/stores/vector_stores/qdrant.mdx
@@ -88,7 +88,7 @@ async function main() {
 
   const response = await queryEngine.query({
     query: "What did the author do in college?",
-  });
+  }); // Additional filters and params can be passed as options
 
   // Output response
   console.log(response.toString());

--- a/examples/storage/qdrantdb/README.md
+++ b/examples/storage/qdrantdb/README.md
@@ -5,7 +5,11 @@ How to run `examples/qdrantdb/preFilters.ts`:
 Add your OpenAI API Key into a file called `.env` in the parent folder of this directory. It should look like this:
 
 ```
-OPEN_API_KEY=sk-you-key
+OPENAI_API_KEY=sk-you-key
 ```
 
 Now, open a new terminal window and inside `examples`, run `npx tsx qdrantdb/preFilters.ts`.
+
+## Notes
+
+- You should have a Qdrant instance running locally.

--- a/examples/storage/qdrantdb/searchParams.ts
+++ b/examples/storage/qdrantdb/searchParams.ts
@@ -1,0 +1,60 @@
+import { QdrantVectorStore } from "@llamaindex/qdrant";
+import * as dotenv from "dotenv";
+import {
+  Document,
+  MetadataMode,
+  NodeWithScore,
+  Settings,
+  VectorStoreIndex,
+  storageContextFromDefaults,
+} from "llamaindex";
+
+// Update callback manager
+Settings.callbackManager.on("retrieve-end", (event) => {
+  const { nodes } = event.detail;
+  console.log(
+    "The retrieved nodes are:",
+    nodes.map((node: NodeWithScore) => node.node.getContent(MetadataMode.NONE)),
+  );
+});
+
+dotenv.config();
+
+const collectionName = "dog_colors";
+const qdrantUrl = "http://127.0.0.1:6333";
+
+async function main() {
+  try {
+    const vectorStore = new QdrantVectorStore({
+      url: qdrantUrl,
+      collectionName,
+    });
+    const ctx = await storageContextFromDefaults({ vectorStore });
+
+    const docs = [
+      new Document({
+        text: "The dog is brown",
+      }),
+    ];
+
+    const index = await VectorStoreIndex.fromDocuments(docs, {
+      storageContext: ctx,
+    });
+
+    const queryEngine = index.asQueryEngine({
+      qdrant_search_params: {
+        hnsw_ef: 10,
+        exact: true,
+        indexed_only: true,
+      },
+    });
+    const response = await queryEngine.query({
+      query: "What is the color of the dog?",
+    });
+    console.log(response.toString());
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+void main();

--- a/examples/storage/qdrantdb/searchParams.ts
+++ b/examples/storage/qdrantdb/searchParams.ts
@@ -42,7 +42,7 @@ async function main() {
     });
 
     const queryEngine = index.asQueryEngine({
-      qdrant_search_params: {
+      customParams: {
         hnsw_ef: 10,
         exact: true,
         indexed_only: true,

--- a/packages/core/src/retriever/index.ts
+++ b/packages/core/src/retriever/index.ts
@@ -8,6 +8,7 @@ import { BaseNode, IndexNode, type NodeWithScore, ObjectType } from "../schema";
 export type RetrieveParams = {
   query: MessageContent;
   preFilters?: unknown;
+  qdrant_search_params?: unknown;
 };
 
 export type RetrieveStartEvent = {

--- a/packages/core/src/retriever/index.ts
+++ b/packages/core/src/retriever/index.ts
@@ -8,7 +8,7 @@ import { BaseNode, IndexNode, type NodeWithScore, ObjectType } from "../schema";
 export type RetrieveParams = {
   query: MessageContent;
   preFilters?: unknown;
-  qdrant_search_params?: unknown;
+  customParams?: unknown;
 };
 
 export type RetrieveStartEvent = {

--- a/packages/core/src/vector-store/index.ts
+++ b/packages/core/src/vector-store/index.ts
@@ -72,20 +72,6 @@ export interface MetadataFilters {
   condition?: `${FilterCondition}`; // and, or
 }
 
-export interface SearchParams {
-  hnsw_ef?: number | null;
-  exact?: boolean;
-  quantization?:
-    | Record<string, unknown>
-    | {
-        ignore?: boolean;
-        rescore?: boolean | null;
-        oversampling?: number | null;
-      }
-    | null;
-  indexed_only?: boolean;
-}
-
 export interface MetadataInfo {
   name: string;
   type: string;
@@ -97,7 +83,7 @@ export interface VectorStoreInfo {
   contentInfo: string;
 }
 
-export interface VectorStoreQuery {
+export interface VectorStoreQuery<T = unknown> {
   queryEmbedding?: number[];
   similarityTopK: number;
   docIds?: string[];
@@ -106,7 +92,7 @@ export interface VectorStoreQuery {
   alpha?: number;
   filters?: MetadataFilters | undefined;
   mmrThreshold?: number;
-  qdrant_search_params?: SearchParams | undefined;
+  customParams?: T | undefined;
 }
 
 // Supported types of vector stores (for each modality)
@@ -118,7 +104,7 @@ export type VectorStoreBaseParams = {
   embeddingModel?: BaseEmbedding | undefined;
 };
 
-export abstract class BaseVectorStore<Client = unknown> {
+export abstract class BaseVectorStore<Client = unknown, T = unknown> {
   embedModel: BaseEmbedding;
   abstract storesText: boolean;
   isEmbeddingQuery?: boolean;
@@ -126,7 +112,7 @@ export abstract class BaseVectorStore<Client = unknown> {
   abstract add(embeddingResults: BaseNode[]): Promise<string[]>;
   abstract delete(refDocId: string, deleteOptions?: object): Promise<void>;
   abstract query(
-    query: VectorStoreQuery,
+    query: VectorStoreQuery<T>,
     options?: object,
   ): Promise<VectorStoreQueryResult>;
 

--- a/packages/core/src/vector-store/index.ts
+++ b/packages/core/src/vector-store/index.ts
@@ -72,6 +72,20 @@ export interface MetadataFilters {
   condition?: `${FilterCondition}`; // and, or
 }
 
+export interface SearchParams {
+  hnsw_ef?: number | null;
+  exact?: boolean;
+  quantization?:
+    | Record<string, unknown>
+    | {
+        ignore?: boolean;
+        rescore?: boolean | null;
+        oversampling?: number | null;
+      }
+    | null;
+  indexed_only?: boolean;
+}
+
 export interface MetadataInfo {
   name: string;
   type: string;
@@ -92,6 +106,7 @@ export interface VectorStoreQuery {
   alpha?: number;
   filters?: MetadataFilters | undefined;
   mmrThreshold?: number;
+  qdrant_search_params?: SearchParams | undefined;
 }
 
 // Supported types of vector stores (for each modality)

--- a/packages/llamaindex/src/indices/vectorStore/index.ts
+++ b/packages/llamaindex/src/indices/vectorStore/index.ts
@@ -39,6 +39,7 @@ import { storageContextFromDefaults } from "../../storage/StorageContext.js";
 import type {
   BaseVectorStore,
   MetadataFilters,
+  SearchParams,
   VectorStoreByType,
   VectorStoreQueryResult,
 } from "../../vector-store/index.js";
@@ -65,6 +66,7 @@ export type VectorIndexChatEngineOptions = {
   retriever?: BaseRetriever;
   similarityTopK?: number;
   preFilters?: MetadataFilters;
+  qdrant_search_params?: SearchParams;
 } & Omit<ContextChatEngineOptions, "retriever">;
 
 /**
@@ -285,6 +287,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
     retriever?: BaseRetriever;
     responseSynthesizer?: BaseSynthesizer;
     preFilters?: MetadataFilters;
+    qdrant_search_params?: SearchParams;
     nodePostprocessors?: BaseNodePostprocessor[];
     similarityTopK?: number;
   }): RetrieverQueryEngine {
@@ -292,11 +295,17 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       retriever,
       responseSynthesizer,
       preFilters,
+      qdrant_search_params,
       nodePostprocessors,
       similarityTopK,
     } = options ?? {};
     return new RetrieverQueryEngine(
-      retriever ?? this.asRetriever({ similarityTopK, filters: preFilters }),
+      retriever ??
+        this.asRetriever({
+          similarityTopK,
+          filters: preFilters,
+          qdrant_search_params: qdrant_search_params ?? undefined,
+        }),
       responseSynthesizer,
       nodePostprocessors,
     );
@@ -312,11 +321,17 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       retriever,
       similarityTopK,
       preFilters,
+      qdrant_search_params,
       ...contextChatEngineOptions
     } = options;
     return new ContextChatEngine({
       retriever:
-        retriever ?? this.asRetriever({ similarityTopK, filters: preFilters }),
+        retriever ??
+        this.asRetriever({
+          similarityTopK,
+          filters: preFilters,
+          qdrant_search_params: qdrant_search_params ?? undefined,
+        }),
       ...contextChatEngineOptions,
     });
   }
@@ -407,6 +422,7 @@ export type VectorIndexRetrieverOptions = {
   index: VectorStoreIndex;
   filters?: MetadataFilters | undefined;
   mode?: VectorStoreQueryMode;
+  qdrant_search_params?: SearchParams | undefined;
 } & (
   | {
       topK?: TopKMap | undefined;
@@ -422,7 +438,7 @@ export class VectorIndexRetriever extends BaseRetriever {
 
   filters?: MetadataFilters | undefined;
   queryMode?: VectorStoreQueryMode | undefined;
-
+  qdrant_search_params?: SearchParams | undefined;
   constructor(options: VectorIndexRetrieverOptions) {
     super();
     this.index = options.index;
@@ -440,6 +456,7 @@ export class VectorIndexRetriever extends BaseRetriever {
       };
     }
     this.filters = options.filters;
+    this.qdrant_search_params = options.qdrant_search_params;
   }
 
   /**
@@ -468,6 +485,7 @@ export class VectorIndexRetriever extends BaseRetriever {
     type: ModalityType,
     vectorStore: BaseVectorStore,
     filters?: MetadataFilters,
+    qdrant_search_params?: SearchParams,
   ): Promise<NodeWithScore[]> {
     // convert string message to multi-modal format
 
@@ -491,6 +509,8 @@ export class VectorIndexRetriever extends BaseRetriever {
           mode: this.queryMode ?? VectorStoreQueryMode.DEFAULT,
           similarityTopK: this.topK[type]!,
           filters: this.filters ?? filters ?? undefined,
+          qdrant_search_params:
+            this.qdrant_search_params ?? qdrant_search_params ?? undefined,
         });
         nodes = nodes.concat(this.buildNodeListFromQueryResult(result));
       }

--- a/packages/llamaindex/src/indices/vectorStore/index.ts
+++ b/packages/llamaindex/src/indices/vectorStore/index.ts
@@ -39,7 +39,6 @@ import { storageContextFromDefaults } from "../../storage/StorageContext.js";
 import type {
   BaseVectorStore,
   MetadataFilters,
-  SearchParams,
   VectorStoreByType,
   VectorStoreQueryResult,
 } from "../../vector-store/index.js";
@@ -66,7 +65,7 @@ export type VectorIndexChatEngineOptions = {
   retriever?: BaseRetriever;
   similarityTopK?: number;
   preFilters?: MetadataFilters;
-  qdrant_search_params?: SearchParams;
+  customParams?: unknown;
 } & Omit<ContextChatEngineOptions, "retriever">;
 
 /**
@@ -287,7 +286,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
     retriever?: BaseRetriever;
     responseSynthesizer?: BaseSynthesizer;
     preFilters?: MetadataFilters;
-    qdrant_search_params?: SearchParams;
+    customParams?: unknown;
     nodePostprocessors?: BaseNodePostprocessor[];
     similarityTopK?: number;
   }): RetrieverQueryEngine {
@@ -295,7 +294,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       retriever,
       responseSynthesizer,
       preFilters,
-      qdrant_search_params,
+      customParams,
       nodePostprocessors,
       similarityTopK,
     } = options ?? {};
@@ -304,7 +303,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
         this.asRetriever({
           similarityTopK,
           filters: preFilters,
-          qdrant_search_params: qdrant_search_params ?? undefined,
+          customParams: customParams ?? undefined,
         }),
       responseSynthesizer,
       nodePostprocessors,
@@ -321,7 +320,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
       retriever,
       similarityTopK,
       preFilters,
-      qdrant_search_params,
+      customParams,
       ...contextChatEngineOptions
     } = options;
     return new ContextChatEngine({
@@ -330,7 +329,7 @@ export class VectorStoreIndex extends BaseIndex<IndexDict> {
         this.asRetriever({
           similarityTopK,
           filters: preFilters,
-          qdrant_search_params: qdrant_search_params ?? undefined,
+          customParams: customParams ?? undefined,
         }),
       ...contextChatEngineOptions,
     });
@@ -422,7 +421,7 @@ export type VectorIndexRetrieverOptions = {
   index: VectorStoreIndex;
   filters?: MetadataFilters | undefined;
   mode?: VectorStoreQueryMode;
-  qdrant_search_params?: SearchParams | undefined;
+  customParams?: unknown | undefined;
 } & (
   | {
       topK?: TopKMap | undefined;
@@ -438,7 +437,7 @@ export class VectorIndexRetriever extends BaseRetriever {
 
   filters?: MetadataFilters | undefined;
   queryMode?: VectorStoreQueryMode | undefined;
-  qdrant_search_params?: SearchParams | undefined;
+  customParams?: unknown | undefined;
   constructor(options: VectorIndexRetrieverOptions) {
     super();
     this.index = options.index;
@@ -456,7 +455,7 @@ export class VectorIndexRetriever extends BaseRetriever {
       };
     }
     this.filters = options.filters;
-    this.qdrant_search_params = options.qdrant_search_params;
+    this.customParams = options.customParams;
   }
 
   /**
@@ -485,7 +484,7 @@ export class VectorIndexRetriever extends BaseRetriever {
     type: ModalityType,
     vectorStore: BaseVectorStore,
     filters?: MetadataFilters,
-    qdrant_search_params?: SearchParams,
+    customParams?: unknown,
   ): Promise<NodeWithScore[]> {
     // convert string message to multi-modal format
 
@@ -509,8 +508,7 @@ export class VectorIndexRetriever extends BaseRetriever {
           mode: this.queryMode ?? VectorStoreQueryMode.DEFAULT,
           similarityTopK: this.topK[type]!,
           filters: this.filters ?? filters ?? undefined,
-          qdrant_search_params:
-            this.qdrant_search_params ?? qdrant_search_params ?? undefined,
+          customParams: this.customParams ?? customParams ?? undefined,
         });
         nodes = nodes.concat(this.buildNodeListFromQueryResult(result));
       }

--- a/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
+++ b/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
@@ -339,13 +339,12 @@ function buildQueryFilter(query: VectorStoreQuery): QdrantFilter | undefined {
 }
 
 function buildSearchParams(
-  query: VectorStoreQuery,
+  query: VectorStoreQuery<QdrantSearchParams>,
 ): QdrantSearchParams | undefined {
-  if (!query.docIds && !query.queryStr && !query.qdrant_search_params)
-    return undefined;
+  if (!query.docIds && !query.queryStr && !query.customParams) return undefined;
 
-  if (query.qdrant_search_params) {
-    return query.qdrant_search_params;
+  if (query.customParams) {
+    return query.customParams;
   }
 
   return undefined;

--- a/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
+++ b/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
@@ -273,7 +273,7 @@ export class QdrantVectorStore extends BaseVectorStore {
    * @returns Zero or more Document instances with data from the vector store.
    */
   async query(
-    query: VectorStoreQuery,
+    query: VectorStoreQuery<QdrantSearchParams | undefined>,
     options?: object,
   ): Promise<VectorStoreQueryResult> {
     const qdrantFilters =
@@ -339,7 +339,7 @@ function buildQueryFilter(query: VectorStoreQuery): QdrantFilter | undefined {
 }
 
 function buildSearchParams(
-  query: VectorStoreQuery<QdrantSearchParams>,
+  query: VectorStoreQuery<QdrantSearchParams | undefined>,
 ): QdrantSearchParams | undefined {
   if (!query.docIds && !query.queryStr && !query.customParams) return undefined;
 

--- a/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
+++ b/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
@@ -138,5 +138,35 @@ describe("QdrantVectorStore", () => {
         expect(searchResult.similarities).toEqual([0.1]);
       });
     });
+
+    describe("[QdrantVectorStore] search with params", () => {
+      it("should search in the vector store", async () => {
+        mockQdrantClient.search.mockResolvedValue([
+          {
+            id: "1",
+            score: 0.1,
+            version: 1,
+            payload: { _node_content: JSON.stringify({ text: "hello world" }) },
+          },
+        ]);
+
+        const searchResult = await store.query(
+          {
+            queryEmbedding: [0.1, 0.2],
+            similarityTopK: 1,
+            mode: VectorStoreQueryMode.DEFAULT,
+          },
+          {
+            qdrant_search_params: {
+              hnsw_ef: 10,
+            },
+          },
+        );
+
+        expect(mockQdrantClient.search).toHaveBeenCalled();
+        expect(searchResult.ids).toEqual(["1"]);
+        expect(searchResult.similarities).toEqual([0.1]);
+      });
+    });
   });
 });

--- a/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
+++ b/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
@@ -157,7 +157,7 @@ describe("QdrantVectorStore", () => {
             mode: VectorStoreQueryMode.DEFAULT,
           },
           {
-            qdrant_search_params: {
+            customParams: {
               hnsw_ef: 10,
             },
           },


### PR DESCRIPTION
This PR adds functionality to allow users to pass additional search params when using the `query` method of `QdrantVectorStore`.

## Major Changes

- Add `qdrant_search_params` as options when using the `query` method in `QdrantVectorStore`. 
- Update implementation of vector store and vector index to allow for search params.
- Create an example that uses search params when querying a `Qdrant` vector store.
- Tests incorporating search params.

## Minor Changes

- Typo in `Qdrant` example readme.
- Add a line in `docs` to mention setting search parameters.

closes #1910 