### PR TITLE
fix: using new workflow with npm by forcing to use the current versio…

### DIFF
--- a/.changeset/fresh-crabs-move.md
+++ b/.changeset/fresh-crabs-move.md
@@ -1,0 +1,5 @@
+---
+"llamaindex": patch
+---
+
+Fix using new workflow with npm by forcing to use the current version of core in llamaindex (and not the one from the old workflow)

--- a/packages/llamaindex/package.json
+++ b/packages/llamaindex/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "@llamaindex/cloud": "workspace:*",
-    "@llamaindex/core": "workspace:*",
+    "@llamaindex/core": "0.6.3",
     "@llamaindex/env": "workspace:*",
     "@llamaindex/node-parser": "workspace:*",
     "@llamaindex/openai": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,7 +1028,7 @@ importers:
         specifier: workspace:*
         version: link:../cloud
       '@llamaindex/core':
-        specifier: workspace:*
+        specifier: 0.6.3
         version: link:../core
       '@llamaindex/env':
         specifier: workspace:*


### PR DESCRIPTION
…n of core in llamaindex (and not the one from the old workflow)