### PR TITLE
Fix: broken links in docs

### DIFF
--- a/.changeset/cold-bottles-wish.md
+++ b/.changeset/cold-bottles-wish.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/doc": patch
+---
+
+Fixed broken links in docs and validate-links script

--- a/apps/next/scripts/validate-links.mts
+++ b/apps/next/scripts/validate-links.mts
@@ -28,7 +28,7 @@ interface RelativeLinkResult {
  * Get all valid documentation routes from the content directory
  */
 async function getValidRoutes(): Promise<Set<string>> {
-  const mdxFiles = await glob("**/*.mdx?", { cwd: CONTENT_DIR });
+  const mdxFiles = await glob("**/*.{md,mdx}", { cwd: CONTENT_DIR });
 
   const routes = new Set<string>();
 
@@ -131,7 +131,7 @@ function findRelativeLinksInFile(
  * Find relative links in all MDX files
  */
 async function findRelativeLinks(): Promise<RelativeLinkResult[]> {
-  const mdxFiles = await glob("**/*.mdx?", { cwd: CONTENT_DIR });
+  const mdxFiles = await glob("**/*.mdx", { cwd: CONTENT_DIR });
   const results: RelativeLinkResult[] = [];
 
   for (const file of mdxFiles) {
@@ -150,7 +150,7 @@ async function findRelativeLinks(): Promise<RelativeLinkResult[]> {
 }
 
 async function validateLinks(): Promise<LinkValidationResult[]> {
-  const mdxFiles = await glob("**/*.mdx?", { cwd: CONTENT_DIR });
+  const mdxFiles = await glob("**/*.mdx", { cwd: CONTENT_DIR });
   const validRoutes = await getValidRoutes();
 
   const results: LinkValidationResult[] = [];

--- a/apps/next/src/content/docs/llamaindex/modules/agents/workflows.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/agents/workflows.mdx
@@ -12,7 +12,7 @@ To use workflows install this package:
 npm i @llamaindex/workflow
 ```
 
-This package is a stable, production-ready version of our [llama-flow](https://github.com/run-llama/llama-flow) project. 
+This package is a stable, production-ready version of our [llama-flow](/docs/llamaflow) project. 
 
 While you can still reference the llama-flow documentation for detailed information about the underlying concepts, we recommend using the `@llamaindex/workflow` package for all new projects to ensure stability and long-term availability.
 

--- a/apps/next/src/content/docs/llamaindex/modules/agents/workflows.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/agents/workflows.mdx
@@ -12,7 +12,7 @@ To use workflows install this package:
 npm i @llamaindex/workflow
 ```
 
-This package is a stable, production-ready version of our [llama-flow](../../../llamaflow) project. 
+This package is a stable, production-ready version of our [llama-flow](https://github.com/run-llama/llama-flow) project. 
 
 While you can still reference the llama-flow documentation for detailed information about the underlying concepts, we recommend using the `@llamaindex/workflow` package for all new projects to ensure stability and long-term availability.
 

--- a/apps/next/src/content/docs/llamaindex/modules/data/readers/discord.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/data/readers/discord.mdx
@@ -18,7 +18,7 @@ In your Discord Application, go to the `OAuth2` tab and generate an invite URL b
 This will invite the bot with the necessary permissions to read messages.
 Copy the URL in your browser and select the server you want your bot to join.
 
-<include cwd>../../examples/discord/reader.ts</include>
+<include cwd>../../examples/readers/discord/reader.ts</include>
 
 ### Params
 

--- a/apps/next/src/content/docs/llamaindex/modules/models/llms/groq.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/models/llms/groq.mdx
@@ -55,7 +55,7 @@ const results = await queryEngine.query({
 
 ## Full Example
 
-<include cwd>../../examples/groq.ts</include>
+<include cwd>../../examples/models/groq.ts</include>
 
 ## API Reference
 

--- a/apps/next/src/content/docs/llamaindex/modules/ui/llamaindex-server.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/ui/llamaindex-server.mdx
@@ -163,3 +163,7 @@ The server always provides a chat interface at the root path (`/`) with:
 ## Getting Started with a New Project
 
 Want to start a new project with LlamaIndexServer? Check out our [create-llama](https://github.com/run-llama/create-llama) tool to quickly generate a new project with LlamaIndexServer.
+
+## API Reference
+
+- [LlamaIndexServer](https://github.com/run-llama/create-llama/blob/main/packages/server)

--- a/apps/next/src/content/docs/llamaindex/modules/ui/llamaindex-server.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/ui/llamaindex-server.mdx
@@ -163,7 +163,3 @@ The server always provides a chat interface at the root path (`/`) with:
 ## Getting Started with a New Project
 
 Want to start a new project with LlamaIndexServer? Check out our [create-llama](https://github.com/run-llama/create-llama) tool to quickly generate a new project with LlamaIndexServer.
-
-## API Reference
-
-- [LlamaIndexServer](/docs/api/classes/LlamaIndexServer)

--- a/apps/next/src/content/docs/llamaindex/tutorials/rag/index.mdx
+++ b/apps/next/src/content/docs/llamaindex/tutorials/rag/index.mdx
@@ -27,7 +27,7 @@ Create the file `example.ts`. This code will
 - index it (which creates embeddings using OpenAI)
 - create a query engine to answer questions about the data
 
-<include cwd>../../examples/vectorIndex.ts</include>
+<include cwd>../../examples/index/vectorIndex.ts</include>
 
 Create a `tsconfig.json` file in the same folder:
 

--- a/apps/next/src/content/docs/llamaindex/tutorials/structured_data_extraction.mdx
+++ b/apps/next/src/content/docs/llamaindex/tutorials/structured_data_extraction.mdx
@@ -24,7 +24,7 @@ Create the file `example.ts`. This code will:
 - Give an example of the data structure we wish to generate
 - Prompt the LLM with instructions and the example, plus a sample transcript
 
-<include cwd>../../examples/jsonExtract.ts</include>
+<include cwd>../../examples/misc/jsonExtract.ts</include>
 
 To run the code:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,16 @@
       "path": "./packages/providers/anthropic/tsconfig.json"
     },
     {
+      "path": "./packages/providers/assemblyai/tsconfig.json"
+    },
+    {
       "path": "./packages/providers/deepinfra/tsconfig.json"
+    },
+    {
+      "path": "./packages/providers/discord/tsconfig.json"
+    },
+    {
+      "path": "./packages/providers/notion/tsconfig.json"
     },
     {
       "path": "./packages/providers/portkey-ai/tsconfig.json"
@@ -55,6 +64,9 @@
     },
     {
       "path": "./packages/providers/vercel/tsconfig.json"
+    },
+    {
+      "path": "./packages/providers/xai/tsconfig.json"
     },
     {
       "path": "./packages/cloud/tsconfig.json"


### PR DESCRIPTION
After noting a broken link in #1952 , I noticed the `validate-links` script wasn't actually grabbing the list of files to validate due to changes in #1876 . To get the validate and build working, I:
 - Added references in the root `tsconfig.json` to modules moved to `providers` in #1877 so they are captured by Tsdoc
 - Changed glob regexes in `validate-links` so they find all markdown files
 - Fixed some broken link
 - Fixed some broken includes

There should probably be an additional check in `validate-links` for the example code includes. I've fixed the ones that were broken, but don't have time to add the feature right now. Added issue #1953 for this.