### PR TITLE
chore: Use base64 for encoding files

### DIFF
--- a/.changeset/gold-dolls-cough.md
+++ b/.changeset/gold-dolls-cough.md
@@ -1,0 +1,7 @@
+---
+"@llamaindex/anthropic": patch
+"@llamaindex/openai": patch
+"@llamaindex/core": patch
+---
+
+Use base64 for encoding files

--- a/examples/models/anthropic/chat-with-file.ts
+++ b/examples/models/anthropic/chat-with-file.ts
@@ -25,7 +25,7 @@ async function main() {
           },
           {
             type: "file",
-            data: Uint8Array.from(fs.readFileSync("./data/manga.pdf")),
+            data: fs.readFileSync("./data/manga.pdf").toString("base64"),
             mimeType: "application/pdf",
           },
         ],

--- a/examples/models/gemini/chat.ts
+++ b/examples/models/gemini/chat.ts
@@ -32,7 +32,7 @@ import fs from "fs";
           },
           {
             type: "file",
-            data: Uint8Array.from(fs.readFileSync("./data/manga.pdf")),
+            data: fs.readFileSync("./data/manga.pdf").toString("base64"),
             mimeType: "application/pdf",
           },
         ],

--- a/examples/models/openai/openai.ts
+++ b/examples/models/openai/openai.ts
@@ -26,7 +26,7 @@ import fs from "fs";
           },
           {
             type: "file",
-            data: new Uint8Array(fs.readFileSync("./data/manga.pdf")),
+            data: fs.readFileSync("./data/manga.pdf").toString("base64"),
             mimeType: "application/pdf",
           },
         ],

--- a/examples/models/openai/responses/chat-with-file.ts
+++ b/examples/models/openai/responses/chat-with-file.ts
@@ -21,7 +21,7 @@ async function main() {
           },
           {
             type: "file",
-            data: Uint8Array.from(fs.readFileSync("./data/manga.pdf")),
+            data: fs.readFileSync("./data/manga.pdf").toString("base64"),
             mimeType: "application/pdf",
           },
         ],

--- a/packages/core/src/llms/type.ts
+++ b/packages/core/src/llms/type.ts
@@ -166,28 +166,29 @@ export type MessageContentImageDetail = {
 
 export type MessageContentAudioDetail = {
   type: "audio";
-  //audio could be a base64 string as well
-  data: string | Uint8Array;
+  // this is a base64 encoded string
+  data: string;
   mimeType: string;
 };
 
 export type MessageContentVideoDetail = {
   type: "video";
-  //video could be a base64 string as well
-  data: string | Uint8Array;
+  // this is a base64 encoded string
+  data: string;
   mimeType: string;
 };
 
 export type MessageContentImageDataDetail = {
   type: "image";
-  //image could be a base64 string as well
-  data: string | Uint8Array;
+  // this is a base64 encoded string
+  data: string;
   mimeType: string;
 };
 
 export type MessageContentFileDetail = {
   type: "file";
-  data: Uint8Array;
+  // this is a base64 encoded string
+  data: string;
   mimeType: string;
 };
 

--- a/packages/providers/anthropic/src/llm.ts
+++ b/packages/providers/anthropic/src/llm.ts
@@ -28,7 +28,7 @@ import type {
 } from "@llamaindex/core/llms";
 import { ToolCallLLM } from "@llamaindex/core/llms";
 import { extractText } from "@llamaindex/core/utils";
-import { getEnv, uint8ArrayToBase64 } from "@llamaindex/env";
+import { getEnv } from "@llamaindex/env";
 import { isDeepEqual } from "remeda";
 
 export class AnthropicSession {
@@ -332,7 +332,7 @@ export class Anthropic extends ToolCallLLM<
               source: {
                 type: "base64" as const,
                 media_type: content.mimeType,
-                data: uint8ArrayToBase64(content.data),
+                data: content.data,
               },
             };
           }

--- a/packages/providers/anthropic/tests/index.test.ts
+++ b/packages/providers/anthropic/tests/index.test.ts
@@ -178,7 +178,7 @@ describe("Message Formatting", () => {
             {
               type: "file",
               mimeType: "application/pdf",
-              data: pdfBuffer,
+              data: pdfBuffer.toString("base64"),
             },
           ],
           role: "user",

--- a/packages/providers/openai/src/llm.ts
+++ b/packages/providers/openai/src/llm.ts
@@ -13,7 +13,7 @@ import {
   type ToolCallLLMMessageOptions,
 } from "@llamaindex/core/llms";
 import { extractText } from "@llamaindex/core/utils";
-import { getEnv, uint8ArrayToBase64 } from "@llamaindex/env";
+import { getEnv } from "@llamaindex/env";
 import { Tokenizers } from "@llamaindex/env/tokenizers";
 import type {
   ClientOptions as OpenAIClientOptions,
@@ -206,7 +206,7 @@ export class OpenAI extends ToolCallLLM<OpenAIAdditionalChatOptions> {
               if (item.mimeType !== "application/pdf") {
                 throw new Error("Only PDF files are supported");
               }
-              const base64Data = uint8ArrayToBase64(item.data);
+              const base64Data = item.data;
               return {
                 type: "file",
                 file: {

--- a/packages/providers/openai/src/responses.ts
+++ b/packages/providers/openai/src/responses.ts
@@ -18,7 +18,7 @@ import {
 } from "@llamaindex/core/llms";
 import type { StoredValue } from "@llamaindex/core/schema";
 import { extractText } from "@llamaindex/core/utils";
-import { getEnv, uint8ArrayToBase64 } from "@llamaindex/env";
+import { getEnv } from "@llamaindex/env";
 
 import { wrapEventCaller } from "@llamaindex/core/decorator";
 import { Tokenizers } from "@llamaindex/env/tokenizers";
@@ -694,7 +694,7 @@ export class OpenAIResponses extends ToolCallLLM<OpenAIResponsesChatOptions> {
           );
         }
 
-        const base64Data = uint8ArrayToBase64(item.data);
+        const base64Data = item.data;
         return {
           type: "input_file",
           filename: `part-${index}.pdf`,

--- a/packages/providers/openai/tests/responses.test.ts
+++ b/packages/providers/openai/tests/responses.test.ts
@@ -205,7 +205,7 @@ describe("OpenAIResponses Unit Tests", () => {
         {
           type: "file",
           mimeType: "image/jpeg",
-          data: Uint8Array.from(Buffer.from("test image content")),
+          data: Buffer.from("test image content").toString("base64"),
         },
       ];
       // @ts-expect-error accessing private method


### PR DESCRIPTION
Use base64 for encoding files that we send to an LLM (audio, video, pdf, etc.) and also for data that we receive from an LLM.

Why?
1. Anthropic, Google and OpenAI are also only using base64 for both directions
2. `Buffer` only works with NodeJS
3. `Uint8Array` is an alternative but would require conversion back and forth (see 1.)

We could argue to use `Uint8Array | string` for data that we are sending, but this would
1. Complicate the implementation of each of our LLM providers (does it handle the `Uint8Array` case properly?)
2. LLM providers don't do it
3. user can call `uint8ArrayToBase64` if needed (in our env package) 