### PR TITLE
feat: Add vector index compression for  AzureCosmosDBMongoDBVectorStore

### DIFF
--- a/.changeset/lazy-books-stand.md
+++ b/.changeset/lazy-books-stand.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/azure": patch
+---
+
+Add vector index compression


### PR DESCRIPTION
Add Vector Index Compression support for Azure Cosmos DB Mongo vector store: 
- Product Quantization: https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/product-quantization
- Half-Precision: https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/vcore/half-precision