### PR TITLE
 fix: ignore empty parts for gemini which confuses agent

### DIFF
--- a/.changeset/green-worlds-rule.md
+++ b/.changeset/green-worlds-rule.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/google": patch
+---
+
+fix: ignore empty parts for gemini which confuses agent


### PR DESCRIPTION
Gemini was returning empty parts consecutively before a tool call, most likely because it was accumulating itself and yielding empty parts

That caused tool calls failing in agent, this fixes the issue