### PR TITLE
fix: correct SimpleDirectoryReader import path

### DIFF
--- a/.changeset/crazy-heads-invite.md
+++ b/.changeset/crazy-heads-invite.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/doc": patch
+---
+
+fix: correct SimpleDirectoryReader import path in documentation example

--- a/apps/next/src/app/(home)/page.tsx
+++ b/apps/next/src/app/(home)/page.tsx
@@ -113,7 +113,8 @@ export default function HomePage() {
           description="Truly powerful retrieval-augmented generation applications use agentic techniques, and LlamaIndex.TS makes it easy to build them."
         >
           <CodeBlock
-            code={`import { SimpleDirectoryReader, VectorStoreIndex } from "llamaindex";
+            code={`import { VectorStoreIndex } from "llamaindex";
+import { SimpleDirectoryReader } from "@llamaindex/readers/directory";
 import { openai } from "@llamaindex/openai";
 import { agent } from "@llamaindex/workflow";
 


### PR DESCRIPTION
## Documentation Update for SimpleDirectoryReader Import Path

**Description**

This PR corrects the import path for SimpleDirectoryReader on the main documentation landing page. The previous import statement was incorrect and appeared prominently in the official documentation, which could easily confuse users who are using the library for the first time. By updating this, we ensure that newcomers have a clear and accurate starting point.

**Changes Made**

- Updated the import statement in `apps/next/src/app/(home)/page.tsx`.
- Changed from:
  ```typescript
  import { SimpleDirectoryReader, VectorStoreIndex } from "llamaindex";
  ```
- To:
  ```typescript
  import { VectorStoreIndex } from "llamaindex";
  import { SimpleDirectoryReader } from "@llamaindex/readers/directory";
  ```

**Why**

`SimpleDirectoryReader` is defined in `packages/readers/src/directory/index.ts`, and according to the monorepo structure described in CONTRIBUTING.md, it should be imported directly from its package. The incorrect import path was displayed on the main documentation page, potentially leading to confusion for new users trying to follow the example.

**Testing**

- Verified the import path matches the package structure.
- Confirmed alignment with the actual implementation location of `SimpleDirectoryReader`.
- Ensured the documentation example remains clear and accurate.

**Related**

- Follows the package structure described in CONTRIBUTING.md.
- References the actual implementation in `packages/readers/src/directory/index.ts`.

**Checklist**

- [x] Documentation update only
- [x] Follows contribution guidelines
- [x] Maintains code example clarity
- [x] Proper import path verified