### PR TITLE
Add more Acronyms on SentenceSplitter

### DIFF
--- a/.changeset/stupid-boats-leave.md
+++ b/.changeset/stupid-boats-leave.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/core": patch
+---
+
+Add more Acronyms on SentenceSplitter

--- a/packages/core/src/node-parser/utils.ts
+++ b/packages/core/src/node-parser/utils.ts
@@ -39,11 +39,46 @@ let sentenceTokenizer: SentenceTokenizer | null = null;
 export const splitBySentenceTokenizer = (): TextSplitterFn => {
   if (!sentenceTokenizer) {
     sentenceTokenizer = new SentenceTokenizer([
+      // TODO: This should be improved. Take a look at: https://github.com/run-llama/LlamaIndexTS/issues/2019
+      // English
       "i.e.",
       "etc.",
       "vs.",
       "Inc.",
       "A.S.A.P.",
+      "Mr.",
+      "Mrs.",
+      "Ms.",
+      "Dr.",
+      "Prof.",
+      "Sr.",
+      "Jr.",
+      // Spanish
+      "Sr.",
+      "Sres."
+      "Srs."
+      "Sra.",
+      "Sras.",
+      "Srta.",
+      "Srtas.",
+      "Dr.",
+      "Drs.",
+      "Dra.",
+      "Dras.",
+      "Prof.",
+      "Profs.",
+      "Profa.",
+      "Profas.",
+      "Ing.",
+      "Lic.",
+      "Arq.",
+      "Ab."
+      "Abs."
+      "Tel.",
+      "a.m.",
+      "p.m.",
+      "etc.",
+      "Art."
     ]);
   }
   const tokenizer = sentenceTokenizer;

--- a/packages/core/src/node-parser/utils.ts
+++ b/packages/core/src/node-parser/utils.ts
@@ -55,8 +55,8 @@ export const splitBySentenceTokenizer = (): TextSplitterFn => {
       "Jr.",
       // Spanish
       "Sr.",
-      "Sres."
-      "Srs."
+      "Sres.",
+      "Srs.",
       "Sra.",
       "Sras.",
       "Srta.",
@@ -72,8 +72,8 @@ export const splitBySentenceTokenizer = (): TextSplitterFn => {
       "Ing.",
       "Lic.",
       "Arq.",
-      "Ab."
-      "Abs."
+      "Ab.",
+      "Abs.",
       "Tel.",
       "a.m.",
       "p.m.",

--- a/packages/core/src/node-parser/utils.ts
+++ b/packages/core/src/node-parser/utils.ts
@@ -77,8 +77,7 @@ export const splitBySentenceTokenizer = (): TextSplitterFn => {
       "Tel.",
       "a.m.",
       "p.m.",
-      "etc.",
-      "Art."
+      "Art.",
     ]);
   }
   const tokenizer = sentenceTokenizer;


### PR DESCRIPTION
This PR tries to reduce the issues related to https://github.com/run-llama/LlamaIndexTS/issues/2019

It won't fix all the issues, but it should improve a bit the default performance