### PR TITLE
fix memory factory

### DIFF
--- a/.changeset/sixty-wasps-flow.md
+++ b/.changeset/sixty-wasps-flow.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/core": patch
+---
+
+Fix createMemory factory when parsing options

--- a/packages/core/src/memory/factories.ts
+++ b/packages/core/src/memory/factories.ts
@@ -79,7 +79,18 @@ export function createMemory<TMessageOptions extends object = object>(
       }
     }
   }
-  return new Memory<Record<string, never>, TMessageOptions>(messages, options);
+
+  // Determine the correct options to pass to Memory
+  const resolvedOptions: MemoryOptions<TMessageOptions> = Array.isArray(
+    messagesOrOptions,
+  )
+    ? options
+    : (messagesOrOptions as MemoryOptions<TMessageOptions>);
+
+  return new Memory<Record<string, never>, TMessageOptions>(
+    messages,
+    resolvedOptions,
+  );
 }
 
 /**


### PR DESCRIPTION
The `createMemory` factory function was not correctly passing options to the underlying `Memory` object

This meant that the docs example doesn't actually work
https://ts.llamaindex.ai/docs/llamaindex/modules/data/memory