### PR TITLE
fix(notion): resolve @notionhq/client dependency conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "vitest": "^3.1.1"
   },
   "packageManager": "pnpm@10.8.1",
+  "pnpm": {
+    "overrides": {
+      "@notionhq/client": "4.0.0"
+    }
+  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",

--- a/packages/providers/notion/package.json
+++ b/packages/providers/notion/package.json
@@ -26,12 +26,12 @@
   },
   "devDependencies": {
     "@llamaindex/core": "workspace:*",
-    "@llamaindex/env": "workspace:*",
-    "@notionhq/client": "^4.0.0"
+    "@llamaindex/env": "workspace:*"
   },
   "peerDependencies": {
     "@llamaindex/core": "workspace:*",
-    "@llamaindex/env": "workspace:*"
+    "@llamaindex/env": "workspace:*",
+    "@notionhq/client": "^4.0.0"
   },
   "dependencies": {
     "notion-md-crawler": "^1.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@notionhq/client': 4.0.0
+
 importers:
 
   .:
@@ -750,7 +753,7 @@ importers:
         specifier: ^0.0.11
         version: link:../packages/providers/xai
       '@notionhq/client':
-        specifier: ^4.0.0
+        specifier: 4.0.0
         version: 4.0.0
       '@pinecone-database/pinecone':
         specifier: ^4.0.0
@@ -854,7 +857,7 @@ importers:
         specifier: workspace:* || ^1.0.25
         version: link:../../packages/readers
       '@notionhq/client':
-        specifier: ^4.0.0
+        specifier: 4.0.0
         version: 4.0.0
       llamaindex:
         specifier: workspace:* || ^0.8.37
@@ -1365,6 +1368,9 @@ importers:
 
   packages/providers/notion:
     dependencies:
+      '@notionhq/client':
+        specifier: 4.0.0
+        version: 4.0.0
       notion-md-crawler:
         specifier: ^1.0.2
         version: 1.0.2
@@ -1375,9 +1381,6 @@ importers:
       '@llamaindex/env':
         specifier: workspace:*
         version: link:../../env
-      '@notionhq/client':
-        specifier: ^4.0.0
-        version: 4.0.0
 
   packages/providers/ollama:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the TypeScript compilation error in `typecheck-examples` CI job that was failing due to conflicting `@notionhq/client` dependencies.

- Move `@notionhq/client` from `devDependencies` to `peerDependencies` in `@llamaindex/notion` package
- Add pnpm override to ensure consistent version (4.0.0) across the entire workspace
- This prevents multiple instances of `@notionhq/client` from being installed in different locations

## Root Cause Analysis

The issue was caused by:
1. `@notionhq/client` being declared as `devDependencies` in `@llamaindex/notion` package (incorrect)
2. `notion-md-crawler` dependency also requiring `@notionhq/client` as its own dependency
3. This led to two separate installations of the same package, which TypeScript treated as incompatible types

The error message was:
```
Property '#private' in type 'Client' refers to a different member that cannot be accessed from within type 'Client'.
```

## Solution

The correct approach is to treat `@notionhq/client` as a peer dependency since:
- It's a runtime dependency that users must provide
- It should be controlled by the consuming application
- This follows library design best practices

## Test Plan

- [x] Modified dependency declarations
- [x] Added pnpm overrides for version consistency
- [x] Updated lockfile to reflect changes
- [ ] Verify CI passes (typecheck-examples should now succeed)
- [ ] Verify Vercel deployment succeeds (likely same root cause)

🤖 Generated with [Claude Code](https://claude.ai/code)