### PR TITLE
feat: multi-turn image generation support

### DIFF
--- a/.changeset/thirty-terms-rush.md
+++ b/.changeset/thirty-terms-rush.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/openai": patch
+---
+
+feat: multi-turn image generation support

--- a/examples/models/openai/responses/image-gen.ts
+++ b/examples/models/openai/responses/image-gen.ts
@@ -30,6 +30,12 @@ async function main() {
   );
   // and print out the text part
   console.log(textPart?.text);
+
+  const imageId = response.message.options?.image_id;
+  if (imageId) {
+    console.log("Image ID for multi-turn generation:", imageId);
+    console.log("Use this image_id in subsequent requests to modify the image");
+  }
 }
 
 main().catch(console.error);

--- a/examples/models/openai/responses/multi-turn-image-gen.ts
+++ b/examples/models/openai/responses/multi-turn-image-gen.ts
@@ -1,0 +1,89 @@
+import { openaiResponses } from "@llamaindex/openai";
+import fs from "fs";
+import { MessageContentDetail } from "llamaindex";
+
+async function main() {
+  const llm = openaiResponses({
+    model: "gpt-4.1-mini",
+    builtInTools: [{ type: "image_generation" }],
+  });
+
+  // First turn: Generate initial image
+  console.log("=== First Turn: Generate initial image ===");
+  const firstResponse = await llm.chat({
+    messages: [
+      {
+        role: "user",
+        content:
+          "Generate an image of a cute tiny llama wearing a hat playing with a cat on a meadow",
+      },
+    ],
+  });
+
+  const firstContent = firstResponse.message.content as MessageContentDetail[];
+  const firstImagePart = firstContent.find((part) => part.type === "image");
+  const firstTextPart = firstContent.find((part) => part.type === "text");
+
+  // Save the first image
+  if (firstImagePart?.data) {
+    fs.writeFileSync(
+      "llama-initial.png",
+      Buffer.from(firstImagePart.data as string, "base64"),
+    );
+    console.log("First image saved as 'llama-initial.png'");
+  }
+
+  if (firstTextPart?.text) {
+    console.log("First response:", firstTextPart.text);
+  }
+
+  // Get the image_id from the response options for multi-turn
+  const imageId = firstResponse.message.options?.image_id;
+  console.log("Image ID for multi-turn:", imageId);
+
+  if (imageId) {
+    // Second turn: Modify the image using the image_id
+    console.log("\n=== Second Turn: Modify the image ===");
+    const secondResponse = await llm.chat({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Generate an image of a cute tiny llama wearing a hat playing with a cat on a meadow",
+        },
+        {
+          role: "assistant",
+          content: firstContent,
+          options: { image_id: imageId },
+        },
+        {
+          role: "user",
+          content:
+            "Now add a rainbow in the background and make the llama's hat blue",
+        },
+      ],
+    });
+
+    const secondContent = secondResponse.message
+      .content as MessageContentDetail[];
+    const secondImagePart = secondContent.find((part) => part.type === "image");
+    const secondTextPart = secondContent.find((part) => part.type === "text");
+
+    // Save the modified image
+    if (secondImagePart?.data) {
+      fs.writeFileSync(
+        "llama-modified.png",
+        Buffer.from(secondImagePart.data as string, "base64"),
+      );
+      console.log("Modified image saved as 'llama-modified.png'");
+    }
+
+    if (secondTextPart?.text) {
+      console.log("Second response:", secondTextPart.text);
+    }
+  } else {
+    console.log("No image_id received, cannot perform multi-turn generation");
+  }
+}
+
+main().catch(console.error);

--- a/packages/providers/openai/src/utils.ts
+++ b/packages/providers/openai/src/utils.ts
@@ -216,6 +216,7 @@ export type ResponsesAdditionalOptions = {
   refusal?: string;
   reasoning?: OpenAILLM.Responses.ResponseReasoningItem;
   usage?: OpenAILLM.Responses.ResponseUsage;
+  image_id?: string;
 };
 
 export type StreamState = {


### PR DESCRIPTION
#1974

## Description

- Added `image_id` parameter to image generation tools for multi-turn support
- Enhanced response parsing to extract and store `image_id` from OpenAI responses  
- Updated message options with `OpenAIResponsesMessageOptions` type including `image_id` field
- Implemented tool configuration to pass `image_id` in subsequent requests for image modifications
- Created example demonstrating multi-turn image generation workflow with initial and modified images
