### PR TITLE
Update SupabaseVectorStore.ts to fix score calculating error

### DIFF
--- a/packages/providers/storage/supabase/src/SupabaseVectorStore.ts
+++ b/packages/providers/storage/supabase/src/SupabaseVectorStore.ts
@@ -168,8 +168,7 @@ export class SupabaseVectorStore extends BaseVectorStore {
 
     const similarities = searchedEmbeddingResponses.map(
       (item: SearchEmbeddingsResponse) => {
-        const distance = item.similarity || 0;
-        return 1 - distance;
+        return item.similarity;
       },
     );
 


### PR DESCRIPTION
The match_documents() function already returns cosine similarity score if embeddings and query_embedding are normalized https://ts.llamaindex.ai/docs/llamaindex/modules/data/stores/vector_stores/supabase

While the current code returns 1 - item.similarity || 0 which is wrong