### PR TITLE
docs: updated bedrock import and supported models

### DIFF
--- a/apps/next/src/content/docs/llamaindex/modules/models/llms/bedrock.mdx
+++ b/apps/next/src/content/docs/llamaindex/modules/models/llms/bedrock.mdx
@@ -5,13 +5,13 @@ title: Bedrock
 ## Installation
 
 ```package-install
-npm i llamaindex @llamaindex/community
+npm i llamaindex @llamaindex/aws
 ```
 
 ## Usage
 
 ```ts
-import { BEDROCK_MODELS, Bedrock } from "@llamaindex/community";
+import { BEDROCK_MODELS, Bedrock } from "@llamaindex/aws";
 
 Settings.llm = new Bedrock({
   model: BEDROCK_MODELS.ANTHROPIC_CLAUDE_3_HAIKU,
@@ -23,9 +23,19 @@ Settings.llm = new Bedrock({
 });
 ```
 
-Currently only supports Anthropic and Meta models:
+Supported models are listed below (accessible by BEDROCK_MODELS).
 
 ```ts
+AMAZON_TITAN_TG1_LARGE = "amazon.titan-tg1-large";
+AMAZON_TITAN_TEXT_EXPRESS_V1 = "amazon.titan-text-express-v1";
+AI21_J2_GRANDE_INSTRUCT = "ai21.j2-grande-instruct";
+AI21_J2_JUMBO_INSTRUCT = "ai21.j2-jumbo-instruct";
+AI21_J2_MID = "ai21.j2-mid";
+AI21_J2_MID_V1 = "ai21.j2-mid-v1";
+AI21_J2_ULTRA = "ai21.j2-ultra";
+AI21_J2_ULTRA_V1 = "ai21.j2-ultra-v1";
+COHERE_COMMAND_TEXT_V14 = "cohere.command-text-v14";
+
 ANTHROPIC_CLAUDE_INSTANT_1 = "anthropic.claude-instant-v1";
 ANTHROPIC_CLAUDE_2 = "anthropic.claude-v2";
 ANTHROPIC_CLAUDE_2_1 = "anthropic.claude-v2:1";
@@ -33,7 +43,12 @@ ANTHROPIC_CLAUDE_3_SONNET = "anthropic.claude-3-sonnet-20240229-v1:0";
 ANTHROPIC_CLAUDE_3_HAIKU = "anthropic.claude-3-haiku-20240307-v1:0";
 ANTHROPIC_CLAUDE_3_OPUS = "anthropic.claude-3-opus-20240229-v1:0"; // available on us-west-2
 ANTHROPIC_CLAUDE_3_5_SONNET = "anthropic.claude-3-5-sonnet-20240620-v1:0";
+ANTHROPIC_CLAUDE_3_5_SONNET_V2 = "anthropic.claude-3-5-sonnet-20241022-v2:0";
 ANTHROPIC_CLAUDE_3_5_HAIKU = "anthropic.claude-3-5-haiku-20241022-v1:0";
+ANTHROPIC_CLAUDE_3_7_SONNET = "anthropic.claude-3-7-sonnet-20250219-v1:0";
+ANTHROPIC_CLAUDE_4_SONNET = "anthropic.claude-sonnet-4-20250514-v1:0";
+ANTHROPIC_CLAUDE_4_OPUS = "anthropic.claude-opus-4-20250514-v1:0";
+
 META_LLAMA2_13B_CHAT = "meta.llama2-13b-chat-v1";
 META_LLAMA2_70B_CHAT = "meta.llama2-70b-chat-v1";
 META_LLAMA3_8B_INSTRUCT = "meta.llama3-8b-instruct-v1:0";
@@ -45,41 +60,66 @@ META_LLAMA3_2_1B_INSTRUCT = "meta.llama3-2-1b-instruct-v1:0"; // only available 
 META_LLAMA3_2_3B_INSTRUCT = "meta.llama3-2-3b-instruct-v1:0"; // only available via inference endpoints (see below)
 META_LLAMA3_2_11B_INSTRUCT = "meta.llama3-2-11b-instruct-v1:0"; // only available via inference endpoints (see below), multimodal and function call supported
 META_LLAMA3_2_90B_INSTRUCT = "meta.llama3-2-90b-instruct-v1:0"; // only available via inference endpoints (see below), multimodal and function call supported
+META_LLAMA3_3_70B_INSTRUCT = "meta.llama3-3-70b-instruct-v1:0";
+
+MISTRAL_7B_INSTRUCT = "mistral.mistral-7b-instruct-v0:2";
+MISTRAL_MIXTRAL_7B_INSTRUCT = "mistral.mixtral-8x7b-instruct-v0:1";
+MISTRAL_MIXTRAL_LARGE_2402 = "mistral.mistral-large-2402-v1:0";
+
 AMAZON_NOVA_PREMIER_1 = "amazon.nova-premier-v1:0";
 AMAZON_NOVA_PRO_1 = "amazon.nova-pro-v1:0";
 AMAZON_NOVA_LITE_1 = "amazon.nova-lite-v1:0";
 AMAZON_NOVA_MICRO_1 = "amazon.nova-micro-v1:0";
 ```
 
-You can also use Bedrock's Inference endpoints by using the model names:
+You can also use Bedrock's Inference endpoints by using the model names (accessible by INFERENCE_BEDROCK_MODELS).
+Note that the region must be set correctly.
 
 ```ts
-// US
+//US
 US_ANTHROPIC_CLAUDE_3_HAIKU = "us.anthropic.claude-3-haiku-20240307-v1:0";
+US_ANTHROPIC_CLAUDE_3_5_HAIKU = "us.anthropic.claude-3-5-haiku-20241022-v1:0";
 US_ANTHROPIC_CLAUDE_3_OPUS = "us.anthropic.claude-3-opus-20240229-v1:0";
 US_ANTHROPIC_CLAUDE_3_SONNET = "us.anthropic.claude-3-sonnet-20240229-v1:0";
 US_ANTHROPIC_CLAUDE_3_5_SONNET = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
-US_ANTHROPIC_CLAUDE_3_5_SONNET_V2 =
-  "us.anthropic.claude-3-5-sonnet-20241022-v2:0";
+US_ANTHROPIC_CLAUDE_3_5_SONNET_V2 = "us.anthropic.claude-3-5-sonnet-20241022-v2:0";
+US_ANTHROPIC_CLAUDE_3_7_SONNET = "us.anthropic.claude-3-7-sonnet-20250219-v1:0";
+US_ANTHROPIC_CLAUDE_4_SONNET = "us.anthropic.claude-sonnet-4-20250514-v1:0";
+US_ANTHROPIC_CLAUDE_4_OPUS = "us.anthropic.claude-opus-4-20250514-v1:0";
 US_META_LLAMA_3_2_1B_INSTRUCT = "us.meta.llama3-2-1b-instruct-v1:0";
 US_META_LLAMA_3_2_3B_INSTRUCT = "us.meta.llama3-2-3b-instruct-v1:0";
 US_META_LLAMA_3_2_11B_INSTRUCT = "us.meta.llama3-2-11b-instruct-v1:0";
 US_META_LLAMA_3_2_90B_INSTRUCT = "us.meta.llama3-2-90b-instruct-v1:0";
-US_AMAZON_NOVA_PRO_1 = "us.amazon.nova-premier-v1:0";
+US_META_LLAMA_3_3_70B_INSTRUCT = "us.meta.llama3-3-70b-instruct-v1:0";
+US_AMAZON_NOVA_PREMIER_1 = "us.amazon.nova-premier-v1:0";
 US_AMAZON_NOVA_PRO_1 = "us.amazon.nova-pro-v1:0";
 US_AMAZON_NOVA_LITE_1 = "us.amazon.nova-lite-v1:0";
 US_AMAZON_NOVA_MICRO_1 = "us.amazon.nova-micro-v1:0";
 
-// EU
+//EU
 EU_ANTHROPIC_CLAUDE_3_HAIKU = "eu.anthropic.claude-3-haiku-20240307-v1:0";
+EU_ANTHROPIC_CLAUDE_3_5_HAIKU = "eu.anthropic.claude-3-5-haiku-20240307-v1:0";
 EU_ANTHROPIC_CLAUDE_3_SONNET = "eu.anthropic.claude-3-sonnet-20240229-v1:0";
 EU_ANTHROPIC_CLAUDE_3_5_SONNET = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0";
+EU_ANTHROPIC_CLAUDE_3_7_SONNET = "eu.anthropic.claude-3-7-sonnet-20250219-v1:0";
+EU_ANTHROPIC_CLAUDE_4_SONNET = "eu.anthropic.claude-sonnet-4-20250514-v1:0";
+EU_ANTHROPIC_CLAUDE_4_OPUS = "eu.anthropic.claude-opus-4-20250514-v1:0";
 EU_META_LLAMA_3_2_1B_INSTRUCT = "eu.meta.llama3-2-1b-instruct-v1:0";
 EU_META_LLAMA_3_2_3B_INSTRUCT = "eu.meta.llama3-2-3b-instruct-v1:0";
-EU_AMAZON_NOVA_PRO_1 = "eu.amazon.nova-premier-v1:0";
+EU_AMAZON_NOVA_PREMIER_1 = "eu.amazon.nova-premier-v1:0";
 EU_AMAZON_NOVA_PRO_1 = "eu.amazon.nova-pro-v1:0";
 EU_AMAZON_NOVA_LITE_1 = "eu.amazon.nova-lite-v1:0";
 EU_AMAZON_NOVA_MICRO_1 = "eu.amazon.nova-micro-v1:0";
+
+//APAC
+APAC_ANTHROPIC_CLAUDE_3_5_SONNET = "apac.anthropic.claude-3-5-sonnet-20240620-v1:0";
+APAC_ANTHROPIC_CLAUDE_3_5_SONNET_V2 = "apac.anthropic.claude-3-5-sonnet-20241022-v2:0";
+APAC_ANTHROPIC_CLAUDE_3_7_SONNET = "apac.anthropic.claude-3-7-sonnet-20250219-v1:0";
+APAC_ANTHROPIC_CLAUDE_3_HAIKU = "apac.anthropic.claude-3-haiku-20240307-v1:0";
+APAC_ANTHROPIC_CLAUDE_3_SONNET = "apac.anthropic.claude-3-sonnet-20240229-v1:0";
+APAC_AMAZON_NOVA_PRO_1 = "apac.amazon.nova-pro-v1:0";
+APAC_AMAZON_NOVA_LITE_1 = "apac.amazon.nova-lite-v1:0";
+APAC_AMAZON_NOVA_MICRO_1 = "apac.amazon.nova-micro-v1:0";
 ```
 
 Sonnet, Haiku and Opus are multimodal, image_url only supports base64 data url format, e.g. `data:image/jpeg;base64,SGVsbG8sIFdvcmxkIQ==`
@@ -87,10 +127,11 @@ Sonnet, Haiku and Opus are multimodal, image_url only supports base64 data url f
 ## Full Example
 
 ```ts
-import { BEDROCK_MODELS, Bedrock } from "llamaindex";
+import { INFERENCE_BEDROCK_MODELS, Bedrock } from "@llamaindex/aws";
 
 Settings.llm = new Bedrock({
-  model: BEDROCK_MODELS.ANTHROPIC_CLAUDE_3_HAIKU,
+  model: INFERENCE_BEDROCK_MODELS.US_ANTHROPIC_CLAUDE_3_SONNET,
+  region: "us-east-1",
 });
 
 async function main() {
@@ -119,7 +160,7 @@ async function main() {
 ## Agent Example
 
 ```ts
-import { BEDROCK_MODELS, Bedrock } from "@llamaindex/community";
+import { BEDROCK_MODELS, Bedrock } from "@llamaindex/aws";
 import { tool } from "llamaindex";
 import { agent } from "@llamaindex/workflow";
 import { z } from "zod";


### PR DESCRIPTION
Changed @llamaindex/community to @llamaindex/aws, and updated model and inference models list. For #2124

**Question**: are the comments for the meta models and claude 3 opus still valid? Not sure what "only available via inference endpoints (see below)" means.