### PR TITLE
chore: add logger as param to AgentWorkflow constructor

### DIFF
--- a/.changeset/brave-snakes-grin.md
+++ b/.changeset/brave-snakes-grin.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/workflow": patch
+---
+
+chore: add logger as param to AgentWorkflow constructor

--- a/packages/workflow/src/agent/agent-workflow.ts
+++ b/packages/workflow/src/agent/agent-workflow.ts
@@ -103,6 +103,10 @@ export type SingleAgentParams = FunctionAgentParams & {
    * Timeout for the workflow in seconds
    */
   timeout?: number;
+  /**
+   * Attach optional custom logger
+   */
+  logger?: Logger;
 };
 
 export type AgentWorkflowParams = {
@@ -123,11 +127,18 @@ export type AgentWorkflowParams = {
    * If not provided, a new empty memory will be created.
    */
   memory?: Memory | undefined;
+  /**
+   * Whether to log verbose output
+   */
   verbose?: boolean;
   /**
    * Timeout for the workflow in seconds.
    */
   timeout?: number;
+  /**
+   * Attach optional custom logger
+   */
+  logger?: Logger | undefined;
 };
 
 /**
@@ -166,7 +177,13 @@ export class AgentWorkflow implements Workflow {
   private initialMemory?: Memory;
   private logger: Logger;
 
-  constructor({ agents, rootAgent, memory, verbose }: AgentWorkflowParams) {
+  constructor({
+    agents,
+    rootAgent,
+    memory,
+    verbose,
+    logger,
+  }: AgentWorkflowParams) {
     this.verbose = verbose ?? false;
     if (memory) {
       this.initialMemory = memory;
@@ -214,12 +231,8 @@ export class AgentWorkflow implements Workflow {
     this.addAgents(processedAgents);
     this.setupWorkflowSteps();
 
-    this.logger =
-      verbose === false
-        ? emptyLogger
-        : verbose || this.verbose
-          ? consoleLogger
-          : emptyLogger;
+    // Use the provided logger if exists, else default to consoleLogger if verbose, else emptyLogger
+    this.logger = logger ?? (this.verbose ? consoleLogger : emptyLogger);
   }
 
   handle<
@@ -319,6 +332,7 @@ export class AgentWorkflow implements Workflow {
       verbose: params.verbose ?? false,
       timeout: params.timeout ?? 60,
       memory: params.memory,
+      logger: params.logger,
     };
 
     const workflow = new AgentWorkflow(workflowParams);

--- a/packages/workflow/test/agent-workflow.test.ts
+++ b/packages/workflow/test/agent-workflow.test.ts
@@ -1,6 +1,7 @@
 import { Settings } from "@llamaindex/core/global";
 import { MockLLM } from "@llamaindex/core/llms/mock";
 import { FunctionTool } from "@llamaindex/core/tools";
+import { Logger } from "@llamaindex/env";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
 import {
@@ -187,11 +188,19 @@ describe("AgentWorkflow", () => {
 
     vi.spyOn(addTool, "call");
 
+    const testLogger: Logger = Object.freeze({
+      log: console.log.bind(console),
+      error: console.error.bind(console),
+      warn: console.warn.bind(console),
+    });
+
     // Create workflow with single agent
+    // Additionally test verbose logging
     const workflow = AgentWorkflow.fromTools({
       tools: [addTool],
       llm: mockLLM,
-      verbose: false,
+      verbose: true,
+      logger: testLogger,
     });
 
     // Run the workflow


### PR DESCRIPTION
Changes as suggested in #2071 

Additionally, simplified the intialization of the logger object. The logic should be equivalent since `this.verbose` is set in a line above.


```ts
//from
this.logger =
      verbose === false
        ? emptyLogger
        : verbose || this.verbose
          ? consoleLogger
          : emptyLogger;

//to
this.logger = logger ?? (this.verbose ? consoleLogger : emptyLogger);
```