### PR TITLE
fix(deepseek): add 'as const' assertion to DEEPSEEK_MODELS for correct TypeScript inference

### DIFF
--- a/.changeset/two-pigs-deliver.md
+++ b/.changeset/two-pigs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/deepseek": patch
+---
+
+fix: contextwindow metadata

--- a/packages/providers/deepseek/src/llm.ts
+++ b/packages/providers/deepseek/src/llm.ts
@@ -4,7 +4,7 @@ import { OpenAI } from "@llamaindex/openai";
 export const DEEPSEEK_MODELS = {
   "deepseek-coder": { contextWindow: 128000 },
   "deepseek-chat": { contextWindow: 128000 },
-};
+} as const;
 
 type DeepSeekModelName = keyof typeof DEEPSEEK_MODELS;
 const DEFAULT_MODEL: DeepSeekModelName = "deepseek-coder";


### PR DESCRIPTION
Fixes issue #2147 by adding 'as const' to deepseek models to ensure proper TypeScript compilation. Previously would lead to failing to build context window sizes.

To test, build the deepseek provider and ensure that the `.ts` dist files build with the correct context window sizes.

> Closes #2147 