### PR TITLE
chore: add minimal reasoning effort for gpt5

### DIFF
--- a/.changeset/silent-vans-melt.md
+++ b/.changeset/silent-vans-melt.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/openai": patch
+---
+
+chore: add minimal reasoning effort for gpt5

--- a/packages/providers/openai/src/llm.ts
+++ b/packages/providers/openai/src/llm.ts
@@ -40,6 +40,7 @@ import { OpenAILive } from "./live.js";
 import {
   ALL_AVAILABLE_OPENAI_MODELS,
   isFunctionCallingModel,
+  isReasoningEffortSupported,
   isReasoningModel,
   isTemperatureSupported,
   type LLMInstance,
@@ -54,7 +55,7 @@ export class OpenAI extends ToolCallLLM<OpenAIAdditionalChatOptions> {
     // string & {} is a hack to allow any string, but still give autocomplete
     | (string & {});
   temperature: number;
-  reasoningEffort?: "low" | "medium" | "high" | undefined;
+  reasoningEffort?: "low" | "medium" | "high" | "minimal" | undefined;
   topP: number;
   maxTokens?: number | undefined;
   additionalChatOptions?: OpenAIAdditionalChatOptions | undefined;
@@ -90,9 +91,11 @@ export class OpenAI extends ToolCallLLM<OpenAIAdditionalChatOptions> {
 
     this.model = init?.model ?? "gpt-4o";
     this.temperature = init?.temperature ?? 0.1;
-    this.reasoningEffort = isReasoningModel(this.model)
-      ? init?.reasoningEffort
-      : undefined;
+    this.reasoningEffort =
+      isReasoningModel(this.model) &&
+      isReasoningEffortSupported(this.model, init?.reasoningEffort)
+        ? init?.reasoningEffort
+        : undefined;
     this.topP = init?.topP ?? 1;
     this.maxTokens = init?.maxTokens ?? undefined;
 

--- a/packages/providers/openai/src/utils.ts
+++ b/packages/providers/openai/src/utils.ts
@@ -187,6 +187,16 @@ export function isReasoningModel(model: ChatModel | string): boolean {
   return isO1 || isO3 || isO4 || isGPT5;
 }
 
+export function isReasoningEffortSupported(
+  model: ChatModel | string,
+  effort: string | undefined,
+): boolean {
+  const supportedReasoningEffort = ["low", "medium", "high", undefined];
+  return model.startsWith("gpt-5")
+    ? [...supportedReasoningEffort, "minimal"].includes(effort)
+    : supportedReasoningEffort.includes(effort);
+}
+
 export function isTemperatureSupported(model: ChatModel | string): boolean {
   return !model.startsWith("o3") && !model.startsWith("o4");
 }


### PR DESCRIPTION
This adds the `minimal` reasoningEffort supported by gpt-5 family.

Fixes #2176 