### PR TITLE
fix: message delta visibility for anthropic fixed

### DIFF
--- a/packages/providers/anthropic/src/llm.ts
+++ b/packages/providers/anthropic/src/llm.ts
@@ -604,6 +604,15 @@ export class Anthropic extends ToolCallLLM<
           ? part.delta.signature
           : undefined;
 
+      if (part.type === "message_delta") {
+        yield {
+          raw: part,
+          delta: "",
+          options: {},
+        };
+        continue;
+      }
+
       if (
         part.type === "content_block_start" &&
         part.content_block.type === "tool_use"

--- a/packages/workflow/src/agent/function-agent.ts
+++ b/packages/workflow/src/agent/function-agent.ts
@@ -197,6 +197,7 @@ export class FunctionAgent implements BaseWorkflowAgent {
     let lastChunk: ChatResponseChunk | undefined;
     const toolCalls: Map<string, AgentToolCall> = new Map();
     for await (const chunk of responseStream) {
+      lastChunk = chunk;
       response += chunk.delta;
       ctx.sendEvent(
         agentStreamEvent.with({


### PR DESCRIPTION
This PR aims to fix the message_delta not taken into consideration for Anthropic's LLMs

It solves the following issues 
- Anthropic's `message_delta` is emiting now, so the usage meta data isn't dropped and is actually reaching the user
- The final streamed chunk was always `undefined`, this is fixed as the lastChunk is being assigned the value of the chunk that is read last in the loop, even though it might have empty content, their is usage data which can be passed on.
- Included `raw` as one of the fields in AgentWorkflow, so callers of `agent.run` recieve the usage when it is sent by the `takeStep` function

The following tests were ran and they were passing for the same
- `pnpm --filter @llamaindex/workflow test`
- `pnpm --filter @llamaindex/anthropic test`