### PR TITLE
store documentId as external id

### DIFF
--- a/packages/providers/storage/postgres/src/PGVectorStore.ts
+++ b/packages/providers/storage/postgres/src/PGVectorStore.ts
@@ -17,7 +17,11 @@ import type { Sql } from "postgres";
 import type { BaseEmbedding } from "@llamaindex/core/embeddings";
 import { DEFAULT_COLLECTION } from "@llamaindex/core/global";
 import type { BaseNode, Metadata } from "@llamaindex/core/schema";
-import { Document, MetadataMode } from "@llamaindex/core/schema";
+import {
+  Document,
+  MetadataMode,
+  NodeRelationship,
+} from "@llamaindex/core/schema";
 
 // todo: create adapter for postgres client
 function fromVercelPool(client: VercelPool): IsomorphicDB {
@@ -309,11 +313,12 @@ export class PGVectorStore extends BaseVectorStore {
       if (!meta.create_date) {
         meta.create_date = new Date();
       }
+      const documentId = node.relationships[NodeRelationship.SOURCE].nodeId;
 
       return [
         // fixme: why id is null?
         id!,
-        "",
+        documentId,
         this.collection,
         node.getContent(MetadataMode.NONE),
         meta,


### PR DESCRIPTION
Previously, an empty string was persisted in the `external_id` column.

Going forward, the document ID will be persisted. This ID will be taken from the relationships belonging to the BaseNode.

[related Issue](https://github.com/run-llama/LlamaIndexTS/issues/2225)