### PR TITLE
Reuse the context from the previous run

### DIFF
--- a/examples/agents/agent/with-ollama.ts
+++ b/examples/agents/agent/with-ollama.ts
@@ -16,7 +16,9 @@ async function main() {
   console.log(`${JSON.stringify(sfResult, null, 2)}`);
 
   // Reuse the context from the previous run
-  const caResult = await myAgent.run("Compare it with California?");
+  const caResult = await myAgent.run("Compare it with California?", {
+    state: sfResult.data.state,
+  });
 
   // Both San Francisco and California are currently experiencing sunny weather.
   console.log(`${JSON.stringify(caResult, null, 2)}`);


### PR DESCRIPTION
Added `state` to re-use content from previous run, exactly like it was mentioned [here](https://github.com/run-llama/LlamaIndexTS/blob/acd9b66de4ec1305d8f7e87832cc68093116bb16/examples/agents/agent/single-agent.ts#L24)