### PR TITLE
fix(qdrant): prevent invalid filter nesting when using preFilters

### DIFF
--- a/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
+++ b/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
@@ -317,17 +317,30 @@ export class QdrantVectorStore extends BaseVectorStore {
 function buildQueryFilter(query: VectorStoreQuery): QdrantFilter | undefined {
   if (!query.docIds && !query.queryStr && !query.filters) return undefined;
 
-  const mustConditions: QdrantMustConditions = [];
-  if (query.docIds) {
-    mustConditions.push({
-      key: "doc_id",
-      match: { any: query.docIds },
-    });
+  const metadataFilters = toQdrantMetadataFilters(query.filters);
+
+  // When there are no docIds, return the metadata filter directly to avoid
+  // creating an invalid extra nesting layer ({must: [{must: [...]}]}).
+  if (!query.docIds) {
+    return metadataFilters;
   }
 
-  const metadataFilters = toQdrantMetadataFilters(query.filters);
+  const mustConditions: QdrantMustConditions = [
+    {
+      key: "doc_id",
+      match: { any: query.docIds },
+    },
+  ];
+
   if (metadataFilters) {
-    mustConditions.push(metadataFilters);
+    if (metadataFilters.should) {
+      // OR-condition metadata filters must be kept as a nested filter so that
+      // the OR semantics are preserved inside the outer AND (must) context.
+      mustConditions.push(metadataFilters);
+    } else {
+      // AND-condition metadata filters can be spread flat into mustConditions.
+      mustConditions.push(...(metadataFilters.must ?? []));
+    }
   }
 
   return { must: mustConditions };

--- a/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
+++ b/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
@@ -3,7 +3,11 @@ import { TextNode } from "@llamaindex/core/schema";
 import type { Mocked } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { VectorStoreQueryMode } from "@llamaindex/core/vector-store";
+import {
+  FilterCondition,
+  FilterOperator,
+  VectorStoreQueryMode,
+} from "@llamaindex/core/vector-store";
 import { QdrantClient } from "@qdrant/js-client-rest";
 import { TestableQdrantVectorStore } from "../mocks/TestableQdrantVectorStore.js";
 
@@ -201,6 +205,89 @@ describe("QdrantVectorStore", () => {
         expect(mockQdrantClient.query).toHaveBeenCalled();
         expect(searchResult.ids).toEqual(["1"]);
         expect(searchResult.similarities).toEqual([0.1]);
+      });
+    });
+
+    describe("[QdrantVectorStore] search with preFilters (AND)", () => {
+      it("should pass a flat must filter without extra nesting when only filters are provided", async () => {
+        mockQdrantClient.query.mockResolvedValue({ points: [] });
+
+        await store.query({
+          queryEmbedding: [0.1, 0.2],
+          similarityTopK: 1,
+          mode: VectorStoreQueryMode.DEFAULT,
+          filters: {
+            filters: [
+              { key: "projectId", value: "proj-1", operator: FilterOperator.EQ },
+            ],
+          },
+        });
+
+        const callArgs = mockQdrantClient.query.mock.calls[0]!;
+        const queryOptions = callArgs[1] as { filter?: unknown };
+        const filter = queryOptions.filter as {
+          must?: unknown[];
+          should?: unknown[];
+        };
+
+        // The filter must be a flat {must: [{key, match}]} — NOT {must: [{must: [...]}]}
+        expect(filter).toBeDefined();
+        expect(Array.isArray(filter.must)).toBe(true);
+        const firstCondition = (filter.must as Array<{ key?: string }>)[0]!;
+        expect(firstCondition.key).toBe("projectId");
+      });
+
+      it("should combine docId filter and metadata filter as flat must conditions", async () => {
+        mockQdrantClient.query.mockResolvedValue({ points: [] });
+
+        await store.query({
+          queryEmbedding: [0.1, 0.2],
+          similarityTopK: 1,
+          mode: VectorStoreQueryMode.DEFAULT,
+          docIds: ["doc-1"],
+          filters: {
+            filters: [
+              { key: "category", value: "news", operator: FilterOperator.EQ },
+            ],
+          },
+        });
+
+        const callArgs = mockQdrantClient.query.mock.calls[0]!;
+        const queryOptions = callArgs[1] as { filter?: unknown };
+        const filter = queryOptions.filter as { must?: unknown[] };
+
+        expect(filter).toBeDefined();
+        expect(Array.isArray(filter.must)).toBe(true);
+        // Both doc_id and category conditions should appear at the same level
+        const conditions = filter.must as Array<{ key?: string }>;
+        const keys = conditions.map((c) => c.key);
+        expect(keys).toContain("doc_id");
+        expect(keys).toContain("category");
+      });
+
+      it("should preserve OR semantics for metadata filters with OR condition", async () => {
+        mockQdrantClient.query.mockResolvedValue({ points: [] });
+
+        await store.query({
+          queryEmbedding: [0.1, 0.2],
+          similarityTopK: 1,
+          mode: VectorStoreQueryMode.DEFAULT,
+          filters: {
+            condition: FilterCondition.OR,
+            filters: [
+              { key: "tag", value: "a", operator: FilterOperator.EQ },
+              { key: "tag", value: "b", operator: FilterOperator.EQ },
+            ],
+          },
+        });
+
+        const callArgs = mockQdrantClient.query.mock.calls[0]!;
+        const queryOptions = callArgs[1] as { filter?: unknown };
+        const filter = queryOptions.filter as { should?: unknown[] };
+
+        expect(filter).toBeDefined();
+        expect(Array.isArray(filter.should)).toBe(true);
+        expect((filter.should as unknown[]).length).toBe(2);
       });
     });
   });


### PR DESCRIPTION
## Problem

Closes #2035

When using `preFilters` with `QdrantVectorStore`, all queries returned a **400 Bad Request** from Qdrant. The root cause was in `buildQueryFilter`:

```ts
// Before — broken
const metadataFilters = toQdrantMetadataFilters(query.filters);
if (metadataFilters) {
  mustConditions.push(metadataFilters); // ← pushes {must:[...]} into must array
}
return { must: mustConditions };
// Produces: { must: [{ must: [...conditions] }] } — invalid Qdrant filter
```

`toQdrantMetadataFilters()` already returns a full `QdrantFilter` object (`{must: [...]}` or `{should: [...]}`). Pushing that into another `must` array creates one extra layer of nesting that the Qdrant REST API rejects.

## What changed

**`packages/providers/storage/qdrant/src/QdrantVectorStore.ts`**
- When no `docIds` are present, return `metadataFilters` directly instead of wrapping it
- When both `docIds` and metadata filters exist, spread AND-condition filter conditions flat into `mustConditions`; keep OR-condition (should) filters as a nested filter object to preserve their semantics

**`packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts`**
- Added test: filters-only AND — verifies filter is flat, no extra nesting
- Added test: docId + metadata filters — verifies both conditions appear at the same `must` level
- Added test: filters-only OR — verifies `should` array is produced at the top level

## How to test

```ts
const queryEngine = index.asQueryEngine({
  preFilters: {
    filters: [{ key: 'projectId', value: 'my-id', operator: '==' }],
  },
});
const result = await queryEngine.query({ query: 'what is this?' });
// Should no longer throw 400 Bad Request
```

Or run the unit tests:
```bash
cd packages/providers/storage/qdrant && pnpm test
```