### PR TITLE
fix(openai): move image detail into image_url object for Chat Completions API

### DIFF
--- a/.changeset/fix-openai-image-detail.md
+++ b/.changeset/fix-openai-image-detail.md
@@ -1,0 +1,12 @@
+---
+"@llamaindex/openai": patch
+---
+
+fix(openai): move image `detail` into `image_url` object for Chat Completions API
+
+The `detail` parameter (`"high"`, `"low"`, `"auto"`) on `image_url` content blocks
+was being passed as a sibling of `image_url` to OpenAI's Chat Completions API,
+causing a `400 Invalid chat format` error. OpenAI expects `detail` inside the
+`image_url` object. This adds a transform in `toOpenAIMessage()` to correctly
+nest the `detail` parameter. The core `MessageContentImageDetail` type is
+unchanged — this is a provider-layer transform only.

--- a/packages/providers/openai/src/llm.ts
+++ b/packages/providers/openai/src/llm.ts
@@ -245,7 +245,19 @@ export class OpenAI extends ToolCallLLM<OpenAIAdditionalChatOptions> {
               } satisfies ChatCompletionContentPart.File;
             }
 
-            // Keep other types as is (text, image_url, etc.)
+            // Transform image_url: move detail inside image_url object
+            // where OpenAI Chat Completions API expects it
+            if (item.type === "image_url") {
+              return {
+                type: "image_url" as const,
+                image_url: {
+                  url: item.image_url.url,
+                  ...(item.detail && { detail: item.detail }),
+                },
+              };
+            }
+
+            // Keep other types as is (text, etc.)
             return item;
           }) as ChatCompletionContentPart[],
         } satisfies ChatCompletionUserMessageParam;

--- a/packages/providers/openai/tests/llm.test.ts
+++ b/packages/providers/openai/tests/llm.test.ts
@@ -38,6 +38,132 @@ describe("Message Formatting", () => {
     });
   });
 
+  describe("Image Detail Formatting", () => {
+    test("moves detail inside image_url for Chat Completions API", () => {
+      const inputMessages: ChatMessage[] = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "data:image/jpeg;base64,aGVsbG8=" },
+              detail: "high",
+            },
+          ],
+        },
+      ];
+      const result = OpenAI.toOpenAIMessage(inputMessages);
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: {
+                url: "data:image/jpeg;base64,aGVsbG8=",
+                detail: "high",
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    test("handles image_url without detail (no spurious detail key)", () => {
+      const inputMessages: ChatMessage[] = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/img.jpg" },
+            },
+          ],
+        },
+      ];
+      const result = OpenAI.toOpenAIMessage(inputMessages);
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/img.jpg" },
+            },
+          ],
+        },
+      ]);
+    });
+
+    test("handles detail values: low and auto", () => {
+      const inputMessages: ChatMessage[] = [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/a.jpg" },
+              detail: "low",
+            },
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/b.jpg" },
+              detail: "auto",
+            },
+          ],
+        },
+      ];
+      const result = OpenAI.toOpenAIMessage(inputMessages);
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/a.jpg", detail: "low" },
+            },
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/b.jpg", detail: "auto" },
+            },
+          ],
+        },
+      ]);
+    });
+
+    test("handles mixed text and image_url content with detail", () => {
+      const inputMessages: ChatMessage[] = [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "image_url",
+              image_url: { url: "https://example.com/photo.jpg" },
+              detail: "high",
+            },
+          ],
+        },
+      ];
+      const result = OpenAI.toOpenAIMessage(inputMessages);
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "image_url",
+              image_url: {
+                url: "https://example.com/photo.jpg",
+                detail: "high",
+              },
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
   describe("Tool Message Formatting", () => {
     const toolCallMessages: ChatMessage[] = [
       {


### PR DESCRIPTION
## Summary

Fixes #2221

The `detail` parameter (`"high"`, `"low"`, `"auto"`) on `image_url` content blocks was being passed as a sibling of `image_url` to OpenAI's Chat Completions API, causing a **400 Invalid chat format** error. OpenAI expects `detail` **inside** the `image_url` object:

```json
{
  "type": "image_url",
  "image_url": {
    "url": "https://example.com/img.jpg",
    "detail": "high"
  }
}
```

The core `MessageContentImageDetail` type is **unchanged** — this is a provider-layer transform only, following the guidance from the issue discussion.

### Root Cause

In `toOpenAIMessage()`, `image_url` content parts were passed through to the API without transformation. The LlamaIndex internal representation has `detail` as a sibling of `image_url`, but OpenAI's Chat Completions API expects it nested inside. The Responses API path (`responses.ts`) already handled this correctly.

### Changes

- **`packages/providers/openai/src/llm.ts`**: Added transform in `toOpenAIMessage()` content mapping to move `detail` inside the `image_url` object when present
- **`packages/providers/openai/tests/llm.test.ts`**: Added 4 test cases:
  - Image with `detail: "high"` produces correct nested format
  - Image without `detail` produces clean output (no spurious key)
  - Multiple images with `detail: "low"` and `detail: "auto"`
  - Mixed text + image content with detail

### Before / After

**Before:** `{ type: "image_url", image_url: { url: "..." }, detail: "high" }` → 400 error from OpenAI

**After:** `{ type: "image_url", image_url: { url: "...", detail: "high" } }` → works correctly

## Test Plan

- [x] Image with detail="high" produces correct OpenAI format
- [x] Image without detail produces clean output
- [x] All detail values (low, auto, high) handled
- [x] Mixed text + image content works
- [x] Responses API path unaffected (already correct)
- [x] Lint and format pass (lint-staged)