### PR TITLE
feat: add @llamaindex/openrouter LLM provider package

### DIFF
--- a/.changeset/feat-openrouter-provider.md
+++ b/.changeset/feat-openrouter-provider.md
@@ -1,0 +1,8 @@
+---
+"@llamaindex/openrouter": minor
+---
+
+feat: add @llamaindex/openrouter LLM provider package
+
+First-class OpenRouter integration with support for provider routing,
+attribution headers, and 300+ models via OpenAI-compatible API.

--- a/packages/providers/openrouter/package.json
+++ b/packages/providers/openrouter/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@llamaindex/openrouter",
+  "description": "OpenRouter Adapter for LlamaIndex",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/run-llama/LlamaIndexTS.git",
+    "directory": "packages/providers/openrouter"
+  },
+  "scripts": {
+    "build": "bunchee",
+    "dev": "bunchee --watch"
+  },
+  "dependencies": {
+    "@llamaindex/env": "workspace:*",
+    "@llamaindex/openai": "workspace:*"
+  }
+}

--- a/packages/providers/openrouter/src/index.ts
+++ b/packages/providers/openrouter/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./llm";

--- a/packages/providers/openrouter/src/llm.ts
+++ b/packages/providers/openrouter/src/llm.ts
@@ -1,0 +1,96 @@
+import { getEnv } from "@llamaindex/env";
+import { OpenAI } from "@llamaindex/openai";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_MODEL = "openai/gpt-4o";
+
+export type OpenRouterProviderRouting = {
+  /** Ordered list of provider slugs to try (e.g., ["anthropic", "openai"]) */
+  order?: string[];
+  /** Whether to allow fallback to other providers (default: true) */
+  allow_fallbacks?: boolean;
+  /** Only use providers that support all request parameters */
+  require_parameters?: boolean;
+  /** Control whether to use providers that may store data */
+  data_collection?: "allow" | "deny";
+  /** List of provider slugs to allow for this request */
+  only?: string[];
+  /** List of provider slugs to skip for this request */
+  ignore?: string[];
+  /** List of quantization levels to filter by (e.g., ["int4", "int8"]) */
+  quantizations?: string[];
+};
+
+export type OpenRouterAdditionalOptions = {
+  /** Your site URL for OpenRouter leaderboard attribution */
+  siteUrl?: string;
+  /** Your app name for OpenRouter attribution */
+  appName?: string;
+  /** Provider routing preferences */
+  provider?: OpenRouterProviderRouting;
+};
+
+export class OpenRouterLLM extends OpenAI {
+  constructor(
+    init?: Omit<Partial<OpenAI>, "session"> & OpenRouterAdditionalOptions,
+  ) {
+    const {
+      apiKey = getEnv("OPENROUTER_API_KEY"),
+      additionalSessionOptions = {},
+      model = DEFAULT_MODEL,
+      siteUrl,
+      appName,
+      provider,
+      ...rest
+    } = init ?? {};
+
+    if (!apiKey) {
+      throw new Error(
+        "Set OpenRouter API Key in OPENROUTER_API_KEY env variable",
+      );
+    }
+
+    additionalSessionOptions.baseURL =
+      additionalSessionOptions.baseURL ?? OPENROUTER_BASE_URL;
+
+    // Set OpenRouter-specific attribution headers
+    const defaultHeaders: Record<string, string> = {
+      ...((additionalSessionOptions.defaultHeaders as Record<string, string>) ??
+        {}),
+    };
+    if (siteUrl) defaultHeaders["HTTP-Referer"] = siteUrl;
+    if (appName) defaultHeaders["X-OpenRouter-Title"] = appName;
+
+    if (Object.keys(defaultHeaders).length > 0) {
+      additionalSessionOptions.defaultHeaders = defaultHeaders;
+    }
+
+    super({
+      apiKey,
+      additionalSessionOptions,
+      model,
+      ...rest,
+    });
+
+    // Inject provider routing into chat options via extra_body
+    if (provider) {
+      this.additionalChatOptions = {
+        ...this.additionalChatOptions,
+        provider,
+      } as typeof this.additionalChatOptions;
+    }
+  }
+
+  get supportToolCall() {
+    return true;
+  }
+}
+
+/**
+ * Convenience function to create a new OpenRouterLLM instance.
+ * @param init - Optional initialization parameters for the OpenRouterLLM instance.
+ * @returns A new OpenRouterLLM instance.
+ */
+export const openrouter = (
+  init?: ConstructorParameters<typeof OpenRouterLLM>[0],
+) => new OpenRouterLLM(init);

--- a/packages/providers/openrouter/tsconfig.json
+++ b/packages/providers/openrouter/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./lib",
+    "tsBuildInfoFile": "./lib/.tsbuildinfo"
+  },
+  "include": ["./src"],
+  "references": [
+    {
+      "path": "../openai/tsconfig.json"
+    },
+    {
+      "path": "../../env/tsconfig.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -210,6 +210,9 @@
       "path": "./packages/providers/perplexity/tsconfig.json"
     },
     {
+      "path": "./packages/providers/openrouter/tsconfig.json"
+    },
+    {
       "path": "./packages/tools/tsconfig.json"
     },
     {


### PR DESCRIPTION
## Summary

Closes #2262

Adds first-class [OpenRouter](https://openrouter.ai) support as `@llamaindex/openrouter`. OpenRouter is an OpenAI-compatible gateway to 300+ models from providers like OpenAI, Anthropic, Google, Meta, and more.

### Why a dedicated package?

While users can work around this with `@llamaindex/openai` + `baseURL: "https://openrouter.ai/api/v1"`, a dedicated package provides:
- **Provider routing** — control which providers serve your request (`order`, `allow_fallbacks`, `only`, `ignore`, `quantizations`, `data_collection`)
- **Attribution headers** — `HTTP-Referer` and `X-OpenRouter-Title` for leaderboard attribution
- **Proper environment variable** — `OPENROUTER_API_KEY` instead of `OPENAI_API_KEY`
- **Sensible defaults** — `openai/gpt-4o` as default model, correct base URL

### Pattern

Follows the exact same pattern as DeepSeek, xAI, Fireworks, Together, and other OpenAI-compatible providers — extends the `OpenAI` class with provider-specific constructor configuration.

### Usage

```typescript
import { OpenRouterLLM, openrouter } from "@llamaindex/openrouter";

// Using class constructor
const llm = new OpenRouterLLM({
  model: "anthropic/claude-sonnet-4",
  apiKey: "your-key", // or set OPENROUTER_API_KEY env var
  siteUrl: "https://your-app.com",
  appName: "My App",
  provider: {
    order: ["anthropic", "openai"],
    allow_fallbacks: true,
  },
});

// Using convenience function
const llm = openrouter({ model: "meta-llama/llama-3.1-70b-instruct" });
```

### Changes

- **New package:** `packages/providers/openrouter/` (4 files)
  - `src/llm.ts` — `OpenRouterLLM` class + types + `openrouter()` convenience function
  - `src/index.ts` — re-exports
  - `package.json` — standard provider package config
  - `tsconfig.json` — standard provider tsconfig
- **`tsconfig.json`** (root) — added project reference
- **`.changeset/feat-openrouter-provider.md`** — minor changeset

### OpenRouter-Specific Features

| Feature | Implementation |
|---------|---------------|
| Base URL | `https://openrouter.ai/api/v1` |
| Auth | Standard Bearer token via `OPENROUTER_API_KEY` |
| Model names | `provider/model-name` format (e.g., `"anthropic/claude-sonnet-4"`) |
| Attribution | `HTTP-Referer` + `X-OpenRouter-Title` headers |
| Provider routing | `provider` object in `additionalChatOptions` |
| Tool calls | Supported (inherited from OpenAI class) |

### Not included in v1 (follow-up PRs)

- Embedding support (OpenRouter is primarily a chat gateway)
- Dynamic model metadata from `/api/v1/models` endpoint
- Cost tracking from `x-openrouter-cost` response header

## Test Plan

- [x] Package structure matches existing providers (DeepSeek, xAI, etc.)
- [x] Lint and format pass (lint-staged)
- [x] Changeset included
- [x] Root tsconfig reference added