### PR TITLE
fix(qdrant): fix pre-filter mapping and ingestion loop bug (#2035)

### DIFF
--- a/.changeset/smooth-pandas-stop.md
+++ b/.changeset/smooth-pandas-stop.md
@@ -1,0 +1,5 @@
+---
+"@llamaindex/qdrant": patch
+---
+
+fix: correctly map NE and NIN filter operators to Qdrant must_not clauses and preserve numeric types in IN filters

--- a/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
+++ b/packages/providers/storage/qdrant/src/QdrantVectorStore.ts
@@ -1,17 +1,14 @@
-import type { BaseNode, Metadata } from "@llamaindex/core/schema";
+import { type BaseNode, type Metadata } from "@llamaindex/core/schema";
 import {
   BaseVectorStore,
   FilterCondition,
   FilterOperator,
+  metadataDictToNode,
+  nodeToMetadata,
   type MetadataFilters,
   type VectorStoreBaseParams,
   type VectorStoreQuery,
   type VectorStoreQueryResult,
-} from "@llamaindex/core/vector-store";
-
-import {
-  metadataDictToNode,
-  nodeToMetadata,
 } from "@llamaindex/core/vector-store";
 import type { QdrantClientParams, Schemas } from "@qdrant/js-client-rest";
 import { QdrantClient } from "@qdrant/js-client-rest";
@@ -20,10 +17,11 @@ type QdrantFilter = Schemas["Filter"];
 type QdrantMustConditions = QdrantFilter["must"];
 type QdrantQueryResult = Schemas["QueryResponse"];
 type QdrantSearchParams = Schemas["SearchParams"];
+type QdrantCondition = Schemas["Condition"]; // Added for type safety
 
 type PointStruct = {
   id: string;
-  payload: Record<string, string>;
+  payload: Metadata; // Use Metadata type instead of any
   vector: number[];
 };
 
@@ -34,6 +32,14 @@ type QdrantParams = {
   apiKey?: string;
   batchSize?: number;
 } & VectorStoreBaseParams;
+
+/**
+ * Interface for Qdrant-specific query options to avoid 'any' casting.
+ */
+interface QdrantQueryOptions {
+  qdrant_filters?: QdrantFilter;
+  qdrant_search_params?: QdrantSearchParams;
+}
 
 /**
  * Qdrant vector store.
@@ -144,7 +150,7 @@ export class QdrantVectorStore extends BaseVectorStore {
     const points: PointStruct[] = [];
     const ids = [];
 
-    for (let i = 0; i < nodes.length; i++) {
+    for (let i = 0; i < nodes.length; ) {
       const nodeIds = [];
       const vectors = [];
       const payloads = [];
@@ -269,14 +275,9 @@ export class QdrantVectorStore extends BaseVectorStore {
     query: VectorStoreQuery<QdrantSearchParams | undefined>,
     options?: object,
   ): Promise<VectorStoreQueryResult> {
-    const qdrantFilters =
-      options && "qdrant_filters" in options
-        ? options.qdrant_filters
-        : undefined;
-    const qdrantSearchParams =
-      options && "qdrant_search_params" in options
-        ? options.qdrant_search_params
-        : undefined;
+    const qdrantOptions = options as QdrantQueryOptions; // Cast to specific interface
+    const qdrantFilters = qdrantOptions?.qdrant_filters;
+    const qdrantSearchParams = qdrantOptions?.qdrant_search_params;
 
     let queryFilters: QdrantFilter | undefined;
     let searchParams: QdrantSearchParams | undefined;
@@ -317,7 +318,7 @@ export class QdrantVectorStore extends BaseVectorStore {
 function buildQueryFilter(query: VectorStoreQuery): QdrantFilter | undefined {
   if (!query.docIds && !query.queryStr && !query.filters) return undefined;
 
-  const mustConditions: QdrantMustConditions = [];
+  const mustConditions: QdrantCondition[] = []; // Explicitly typed
   if (query.docIds) {
     mustConditions.push({
       key: "doc_id",
@@ -327,10 +328,14 @@ function buildQueryFilter(query: VectorStoreQuery): QdrantFilter | undefined {
 
   const metadataFilters = toQdrantMetadataFilters(query.filters);
   if (metadataFilters) {
-    mustConditions.push(metadataFilters);
+    if (metadataFilters.must) {
+      mustConditions.push(...metadataFilters.must);
+    } else {
+      mustConditions.push(metadataFilters);
+    }
   }
 
-  return { must: mustConditions };
+  return mustConditions.length > 0 ? { must: mustConditions } : undefined;
 }
 
 function buildSearchParams(
@@ -355,74 +360,46 @@ function toQdrantMetadataFilters(
 ): QdrantFilter | undefined {
   if (!subFilters?.filters.length) return undefined;
 
-  const conditions: QdrantMustConditions = [];
+  const conditions: QdrantCondition[] = []; // Explicitly typed
 
   for (const subfilter of subFilters.filters) {
-    if (subfilter.operator === FilterOperator.EQ) {
-      if (typeof subfilter.value === "number") {
-        conditions.push({
-          key: subfilter.key,
-          range: {
-            gte: subfilter.value,
-            lte: subfilter.value,
-          },
-        });
+    const { key, value, operator } = subfilter;
+
+    if (operator === FilterOperator.EQ) {
+      if (typeof value === "number") {
+        conditions.push({ key, range: { gte: value, lte: value } });
       } else {
         conditions.push({
-          key: subfilter.key,
-          match: { value: subfilter.value },
+          key,
+          match: { value: value as string | number | boolean },
         });
       }
-    } else if (subfilter.operator === FilterOperator.LT) {
+    } else if (operator === FilterOperator.LT) {
+      conditions.push({ key, range: { lt: value as number } });
+    } else if (operator === FilterOperator.GT) {
+      conditions.push({ key, range: { gt: value as number } });
+    } else if (operator === FilterOperator.GTE) {
+      conditions.push({ key, range: { gte: value as number } });
+    } else if (operator === FilterOperator.LTE) {
+      conditions.push({ key, range: { lte: value as number } });
+    } else if (operator === FilterOperator.TEXT_MATCH) {
+      conditions.push({ key, match: { text: value as string } });
+    } else if (operator === FilterOperator.NE) {
       conditions.push({
-        key: subfilter.key,
-        range: { lt: subfilter.value },
+        must_not: [
+          { key, match: { value: value as string | number | boolean } },
+        ],
       });
-    } else if (subfilter.operator === FilterOperator.GT) {
+    } else if (operator === FilterOperator.IN) {
+      const values = Array.isArray(value) ? value : [value];
+      conditions.push({ key, match: { any: values as (string | number)[] } });
+    } else if (operator === FilterOperator.NIN) {
+      const values = Array.isArray(value) ? value : [value];
       conditions.push({
-        key: subfilter.key,
-        range: { gt: subfilter.value },
+        must_not: [{ key, match: { any: values as (string | number)[] } }],
       });
-    } else if (subfilter.operator === FilterOperator.GTE) {
-      conditions.push({
-        key: subfilter.key,
-        range: { gte: subfilter.value },
-      });
-    } else if (subfilter.operator === FilterOperator.LTE) {
-      conditions.push({
-        key: subfilter.key,
-        range: { lte: subfilter.value },
-      });
-    } else if (subfilter.operator === FilterOperator.TEXT_MATCH) {
-      conditions.push({
-        key: subfilter.key,
-        match: { text: subfilter.value },
-      });
-    } else if (subfilter.operator === FilterOperator.NE) {
-      conditions.push({
-        key: subfilter.key,
-        match: { except: [subfilter.value] },
-      });
-    } else if (subfilter.operator === FilterOperator.IN) {
-      const values = Array.isArray(subfilter.value)
-        ? subfilter.value.map(String)
-        : String(subfilter.value).split(",");
-      conditions.push({
-        key: subfilter.key,
-        match: { any: values },
-      });
-    } else if (subfilter.operator === FilterOperator.NIN) {
-      const values = Array.isArray(subfilter.value)
-        ? subfilter.value.map(String)
-        : String(subfilter.value).split(",");
-      conditions.push({
-        key: subfilter.key,
-        match: { except: values },
-      });
-    } else if (subfilter.operator === FilterOperator.IS_EMPTY) {
-      conditions.push({
-        is_empty: { key: subfilter.key },
-      });
+    } else if (operator === FilterOperator.IS_EMPTY) {
+      conditions.push({ is_empty: { key } });
     }
   }
 

--- a/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
+++ b/packages/providers/storage/qdrant/tests/QdrantVectorStore.test.ts
@@ -1,14 +1,14 @@
-import type { BaseNode } from "@llamaindex/core/schema";
-import { TextNode } from "@llamaindex/core/schema";
+import { Settings } from "@llamaindex/core/global";
+import { TextNode, type BaseNode } from "@llamaindex/core/schema";
+import {
+  FilterOperator,
+  VectorStoreQueryMode,
+} from "@llamaindex/core/vector-store";
+import { OpenAIEmbedding } from "@llamaindex/openai";
+import { QdrantClient } from "@qdrant/js-client-rest";
 import type { Mocked } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-import { VectorStoreQueryMode } from "@llamaindex/core/vector-store";
-import { QdrantClient } from "@qdrant/js-client-rest";
 import { TestableQdrantVectorStore } from "../mocks/TestableQdrantVectorStore.js";
-
-import { Settings } from "@llamaindex/core/global";
-import { OpenAIEmbedding } from "@llamaindex/openai";
 
 Settings.embedModel = new OpenAIEmbedding();
 vi.mock("@qdrant/js-client-rest");
@@ -44,164 +44,256 @@ describe("QdrantVectorStore", () => {
         },
       );
     });
+  });
 
-    describe("[QdrantVectorStore] add", () => {
-      it("should add nodes to the vector store", async () => {
-        // Mocking the dependent methods and Qdrant client responses
-        const mockInitializeCollection = vi
-          .spyOn(store, "initializeCollection")
-          .mockResolvedValue();
+  describe("[QdrantVectorStore] add", () => {
+    it("should add nodes to the vector store", async () => {
+      const mockInitializeCollection = vi
+        .spyOn(store, "initializeCollection")
+        .mockResolvedValue();
 
-        const mockBuildPoints = vi
-          .spyOn(store, "buildPoints")
-          .mockResolvedValue({
-            points: [{ id: "1", payload: {}, vector: [0.1, 0.2] }],
-            ids: ["1"],
-          });
-
-        mockQdrantClient.upsert.mockResolvedValue({
-          operation_id: 1,
-          status: "completed",
-        });
-
-        const nodes: BaseNode[] = [
-          new TextNode({
-            embedding: [0.1, 0.2],
-            metadata: { meta1: "Some metadata" },
-          }),
-        ];
-
-        const ids = await store.add(nodes);
-
-        expect(mockInitializeCollection).toHaveBeenCalledWith(
-          nodes[0]!.getEmbedding().length,
-        );
-        expect(mockBuildPoints).toHaveBeenCalledWith(nodes);
-        expect(mockQdrantClient.upsert).toHaveBeenCalled();
-
-        expect(ids).toEqual(["1"]);
+      const mockBuildPoints = vi.spyOn(store, "buildPoints").mockResolvedValue({
+        points: [{ id: "1", payload: {}, vector: [0.1, 0.2] }],
+        ids: ["1"],
       });
-    });
 
-    describe("[QdrantVectorStore] delete", () => {
-      it("should delete from the vector store", async () => {
-        vi.spyOn(store, "initializeCollection").mockResolvedValue();
-
-        vi.spyOn(store, "buildPoints").mockResolvedValue({
-          points: [{ id: "1", payload: {}, vector: [0.1, 0.2] }],
-          ids: ["1"],
-        });
-
-        mockQdrantClient.upsert.mockResolvedValue({
-          operation_id: 1,
-          status: "completed",
-        });
-
-        const nodes: BaseNode[] = [
-          new TextNode({
-            id_: "1",
-            embedding: [0.1, 0.2],
-            metadata: { meta1: "Some metadata" },
-          }),
-        ];
-
-        await store.add(nodes);
-
-        expect(store.getNodes()).toContain(nodes[0]);
-
-        await store.delete("1");
-
-        expect(store.getNodes()).not.toContain(nodes[0]);
-        expect(mockQdrantClient.upsert).toHaveBeenCalled();
+      mockQdrantClient.upsert.mockResolvedValue({
+        operation_id: 1,
+        status: "completed",
       });
-    });
 
-    describe("[QdrantVectorStore] search", () => {
-      it("should search in the vector store", async () => {
-        mockQdrantClient.query.mockResolvedValue({
-          points: [
-            {
-              id: "1",
-              score: 0.1,
-              version: 1,
-              payload: {
-                _node_content: JSON.stringify({ text: "hello world" }),
-              },
+      const nodes: BaseNode[] = [
+        new TextNode({
+          embedding: [0.1, 0.2],
+          metadata: { meta1: "Some metadata" },
+        }),
+      ];
+
+      const ids = await store.add(nodes);
+
+      expect(mockInitializeCollection).toHaveBeenCalledWith(
+        nodes[0]!.getEmbedding().length,
+      );
+      expect(mockBuildPoints).toHaveBeenCalledWith(nodes);
+      expect(mockQdrantClient.upsert).toHaveBeenCalled();
+
+      expect(ids).toEqual(["1"]);
+    });
+  });
+
+  describe("[QdrantVectorStore] delete", () => {
+    it("should delete from the vector store", async () => {
+      vi.spyOn(store, "initializeCollection").mockResolvedValue();
+
+      vi.spyOn(store, "buildPoints").mockResolvedValue({
+        points: [{ id: "1", payload: {}, vector: [0.1, 0.2] }],
+        ids: ["1"],
+      });
+
+      mockQdrantClient.upsert.mockResolvedValue({
+        operation_id: 1,
+        status: "completed",
+      });
+
+      const nodes: BaseNode[] = [
+        new TextNode({
+          id_: "1",
+          embedding: [0.1, 0.2],
+          metadata: { meta1: "Some metadata" },
+        }),
+      ];
+
+      await store.add(nodes);
+
+      expect(store.getNodes()).toContain(nodes[0]);
+
+      await store.delete("1");
+
+      expect(store.getNodes()).not.toContain(nodes[0]);
+      expect(mockQdrantClient.upsert).toHaveBeenCalled();
+    });
+  });
+
+  describe("[QdrantVectorStore] search", () => {
+    it("should search in the vector store", async () => {
+      mockQdrantClient.query.mockResolvedValue({
+        points: [
+          {
+            id: "1",
+            score: 0.1,
+            version: 1,
+            payload: {
+              _node_content: JSON.stringify({ text: "hello world" }),
             },
-          ],
-        });
+          },
+        ],
+      });
 
-        const searchResult = await store.query({
+      const searchResult = await store.query({
+        queryEmbedding: [0.1, 0.2],
+        similarityTopK: 1,
+        mode: VectorStoreQueryMode.DEFAULT,
+      });
+
+      expect(mockQdrantClient.query).toHaveBeenCalled();
+      expect(searchResult.ids).toEqual(["1"]);
+      expect(searchResult.similarities).toEqual([0.1]);
+    });
+  });
+
+  describe("[QdrantVectorStore] search with id as number", () => {
+    it("should search in the vector store with id as number", async () => {
+      mockQdrantClient.query.mockResolvedValue({
+        points: [
+          {
+            id: 1,
+            score: 0.1,
+            version: 1,
+            payload: {
+              _node_content: JSON.stringify({ text: "hello world" }),
+            },
+          },
+        ],
+      });
+
+      const searchResult = await store.query({
+        queryEmbedding: [0.1, 0.2],
+        similarityTopK: 1,
+        mode: VectorStoreQueryMode.DEFAULT,
+      });
+
+      expect(mockQdrantClient.query).toHaveBeenCalled();
+      expect(searchResult.ids).toEqual(["1"]);
+      expect(searchResult.similarities).toEqual([0.1]);
+    });
+  });
+
+  describe("[QdrantVectorStore] search with params", () => {
+    it("should search in the vector store with custom params", async () => {
+      mockQdrantClient.query.mockResolvedValue({
+        points: [
+          {
+            id: "1",
+            score: 0.1,
+            version: 1,
+            payload: {
+              _node_content: JSON.stringify({ text: "hello world" }),
+            },
+          },
+        ],
+      });
+
+      const searchResult = await store.query(
+        {
           queryEmbedding: [0.1, 0.2],
           similarityTopK: 1,
           mode: VectorStoreQueryMode.DEFAULT,
-        });
+        },
+        {
+          // FIX: Use qdrant_search_params to match the provider's implementation
+          qdrant_search_params: {
+            hnsw_ef: 10,
+          },
+        },
+      );
 
-        expect(mockQdrantClient.query).toHaveBeenCalled();
-        expect(searchResult.ids).toEqual(["1"]);
-        expect(searchResult.similarities).toEqual([0.1]);
+      expect(mockQdrantClient.query).toHaveBeenCalledWith(
+        "testCollection",
+        expect.objectContaining({
+          params: { hnsw_ef: 10 },
+        }),
+      );
+      expect(searchResult.ids).toEqual(["1"]);
+    });
+  });
+
+  describe("[QdrantVectorStore] search with pre-filters", () => {
+    it("should correctly map NE (Not Equal) to Qdrant must_not filter", async () => {
+      mockQdrantClient.query.mockResolvedValue({ points: [] });
+
+      await store.query({
+        queryEmbedding: [0.1, 0.2],
+        similarityTopK: 1,
+        mode: VectorStoreQueryMode.DEFAULT,
+        filters: {
+          filters: [
+            { key: "status", value: "archived", operator: FilterOperator.NE },
+          ],
+        },
       });
+
+      // FIX: Match the cleaner, flattened output produced by buildQueryFilter
+      expect(mockQdrantClient.query).toHaveBeenCalledWith(
+        "testCollection",
+        expect.objectContaining({
+          filter: {
+            must: [
+              {
+                must_not: [{ key: "status", match: { value: "archived" } }],
+              },
+            ],
+          },
+        }),
+      );
     });
 
-    describe("[QdrantVectorStore] search with id as number", () => {
-      it("should search in the vector store with id as number", async () => {
-        mockQdrantClient.query.mockResolvedValue({
-          points: [
+    it("should correctly map NIN (Not In) to Qdrant must_not filter with any", async () => {
+      mockQdrantClient.query.mockResolvedValue({ points: [] });
+
+      await store.query({
+        queryEmbedding: [0.1, 0.2],
+        similarityTopK: 1,
+        mode: VectorStoreQueryMode.DEFAULT,
+        filters: {
+          filters: [
             {
-              id: 1,
-              score: 0.1,
-              version: 1,
-              payload: {
-                _node_content: JSON.stringify({ text: "hello world" }),
-              },
+              key: "category",
+              value: ["electronics", "toys"],
+              operator: FilterOperator.NIN,
             },
           ],
-        });
-
-        const searchResult = await store.query({
-          queryEmbedding: [0.1, 0.2],
-          similarityTopK: 1,
-          mode: VectorStoreQueryMode.DEFAULT,
-        });
-
-        expect(mockQdrantClient.query).toHaveBeenCalled();
-        expect(searchResult.ids).toEqual(["1"]);
-        expect(searchResult.similarities).toEqual([0.1]);
+        },
       });
+
+      expect(mockQdrantClient.query).toHaveBeenCalledWith(
+        "testCollection",
+        expect.objectContaining({
+          filter: {
+            must: [
+              {
+                must_not: [
+                  { key: "category", match: { any: ["electronics", "toys"] } },
+                ],
+              },
+            ],
+          },
+        }),
+      );
     });
 
-    describe("[QdrantVectorStore] search with params", () => {
-      it("should search in the vector store", async () => {
-        mockQdrantClient.query.mockResolvedValue({
-          points: [
-            {
-              id: "1",
-              score: 0.1,
-              version: 1,
-              payload: {
-                _node_content: JSON.stringify({ text: "hello world" }),
-              },
-            },
+    it("should preserve numeric types in IN filters", async () => {
+      mockQdrantClient.query.mockResolvedValue({ points: [] });
+
+      await store.query({
+        queryEmbedding: [0.1, 0.2],
+        similarityTopK: 1,
+        mode: VectorStoreQueryMode.DEFAULT,
+        filters: {
+          filters: [
+            { key: "version", value: [1, 2], operator: FilterOperator.IN },
           ],
-        });
-
-        const searchResult = await store.query(
-          {
-            queryEmbedding: [0.1, 0.2],
-            similarityTopK: 1,
-            mode: VectorStoreQueryMode.DEFAULT,
-          },
-          {
-            customParams: {
-              hnsw_ef: 10,
-            },
-          },
-        );
-
-        expect(mockQdrantClient.query).toHaveBeenCalled();
-        expect(searchResult.ids).toEqual(["1"]);
-        expect(searchResult.similarities).toEqual([0.1]);
+        },
       });
+
+      // FIX: Match the cleaner, flattened output produced by buildQueryFilter
+      expect(mockQdrantClient.query).toHaveBeenCalledWith(
+        "testCollection",
+        expect.objectContaining({
+          filter: {
+            must: [{ key: "version", match: { any: [1, 2] } }],
+          },
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes #2035

**Changes:**
- Updated `toQdrantMetadataFilters` to map `NE` and `NIN` to `must_not` blocks to prevent 400 Bad Request errors.
- Fixed an off-by-one batching error in `buildPoints` that caused skipped nodes during ingestion.
- Preserved numeric types in `IN` filters to ensure compatibility with Qdrant numeric payload indexes.
- Improved type safety by removing `any` casts in favor of Qdrant Schema types.