### PR TITLE
fix(prompts): preserve literal braces not in templateVars

### DIFF
--- a/.changeset/fix-prompt-template-literal-braces.md
+++ b/.changeset/fix-prompt-template-literal-braces.md
@@ -1,0 +1,10 @@
+---
+"@llamaindex/core": patch
+---
+
+fix(prompts): preserve literal braces that are not template vars in PromptTemplate
+
+When `templateVars` is explicitly defined, `PromptTemplate.format()` now leaves
+any `{...}` patterns that are not in the template var set unchanged instead of
+throwing `Replacement index out of range`. This allows templates containing
+code snippets or JSON-like content alongside substitution variables.

--- a/packages/core/src/prompts/base.ts
+++ b/packages/core/src/prompts/base.ts
@@ -204,7 +204,26 @@ export class PromptTemplate<
 
     const mappedAllOptions = this.mapAllVars(allOptions);
 
-    const prompt = format(this.template, mappedAllOptions);
+    // When templateVars are explicitly defined, escape any braces that are not
+    // template variables so they are preserved literally in the output rather
+    // than being treated as substitution targets by the format function.
+    // Unicode private-use area characters (U+E000/U+E001) are used as
+    // placeholders because they are extremely unlikely to appear in real text.
+    const BRACE_OPEN = "\uE000";
+    const BRACE_CLOSE = "\uE001";
+    let template: string = this.template;
+    if (this.templateVars.size > 0) {
+      template = template.replace(/\{([^}]*)\}/g, (match, inner) => {
+        const trimmed = inner.trim();
+        if (this.templateVars.has(trimmed)) return match;
+        return `${BRACE_OPEN}${inner}${BRACE_CLOSE}`;
+      });
+    }
+
+    const formatted = format(template, mappedAllOptions);
+    const prompt = formatted
+      .replaceAll(BRACE_OPEN, "{")
+      .replaceAll(BRACE_CLOSE, "}");
 
     if (this.outputParser) {
       return this.outputParser.format(prompt);

--- a/packages/core/tests/prompts.test.ts
+++ b/packages/core/tests/prompts.test.ts
@@ -169,4 +169,27 @@ describe("PromptTemplate", () => {
     expect(vars).toContain("name");
     expect(vars).toContain("age");
   });
+
+  test("should preserve literal braces that are not template vars", () => {
+    const prompt = new PromptTemplate({
+      template:
+        "A code block: import { React } from react;\nA context: {context}",
+      templateVars: ["context"],
+    });
+
+    const result = prompt.format({ context: "hello world" });
+    expect(result).toBe(
+      "A code block: import { React } from react;\nA context: hello world",
+    );
+  });
+
+  test("should preserve multiple literal brace pairs alongside template vars", () => {
+    const prompt = new PromptTemplate({
+      template: "JSON: { key: value } and template: {output}",
+      templateVars: ["output"],
+    });
+
+    const result = prompt.format({ output: "done" });
+    expect(result).toBe("JSON: { key: value } and template: done");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1920

`PromptTemplate.format()` throws `Replacement index 0 out of range for positional args tuple` when the template string contains literal curly braces that are not declared template variables — for example, code snippets like `import { React } from react` or inline JSON objects.

**Root cause:** The underlying `format()` function matches every `{...}` pattern in the template string and throws when no corresponding value is found in the options object.

**Fix:** When `templateVars` is explicitly provided, `PromptTemplate.format()` now escapes any `{...}` patterns whose key is not in the `templateVars` set before delegating to `format()`. Unicode private-use area characters (U+E000/U+E001) are used as placeholders and restored afterward. This is contained to `PromptTemplate` — the generic `format()` function is unchanged.

## Before

```ts
const prompt = new PromptTemplate({
  template: `A code block: import { React } from react;\nA context: {context}`,
  templateVars: ["context"],
});

prompt.format({ context: "hello" });
// ✗ Error: Replacement index 0 out of range for positional args tuple
```

## After

```ts
prompt.format({ context: "hello" });
// ✓ "A code block: import { React } from react;\nA context: hello"
```

## Changes

- `packages/core/src/prompts/base.ts` — escape non-templateVar braces in `PromptTemplate.format()`
- `packages/core/tests/prompts.test.ts` — two new tests covering the bug scenarios
- `.changeset/fix-prompt-template-literal-braces.md` — patch changeset for `@llamaindex/core`