### PR TITLE
docs(models): document per-request LLM and embedModel scoping

### DIFF
--- a/docs/src/content/docs/framework/modules/models/embeddings/index.mdx
+++ b/docs/src/content/docs/framework/modules/models/embeddings/index.mdx
@@ -21,6 +21,58 @@ Settings.embedModel = new OpenAIEmbedding({
 });
 ```
 
+## Per-request embedModel (avoiding global state)
+
+Setting `Settings.embedModel` is a global mutation. In multi-tenant servers where concurrent requests each need their own API key or model, this creates race conditions. Use `Settings.withEmbedModel` instead — it scopes the embedding model to the current async context using `AsyncLocalStorage` and never touches global state.
+
+```typescript
+import { OpenAIEmbedding } from "@llamaindex/openai";
+import { Settings, VectorStoreIndex, Document } from "llamaindex";
+
+// Express / Fastify / any async handler
+app.post("/index", async (req, res) => {
+  const { apiKey, text } = req.body;
+
+  const embedModel = new OpenAIEmbedding({ apiKey });
+
+  const index = await Settings.withEmbedModel(embedModel, () =>
+    VectorStoreIndex.fromDocuments([new Document({ text })]),
+  );
+
+  res.json({ indexId: index.indexStruct.indexId });
+});
+```
+
+The embed model passed to `withEmbedModel` is active only for the duration of that async call. Concurrent requests each get their own isolated embed model without interfering with each other.
+
+You can compose `withEmbedModel` and `withLLM` for full per-request isolation:
+
+```typescript
+import { OpenAI, OpenAIEmbedding } from "@llamaindex/openai";
+import { Settings, VectorStoreIndex, Document } from "llamaindex";
+
+app.post("/query", async (req, res) => {
+  const { apiKey, query, text } = req.body;
+
+  const llm = new OpenAI({ apiKey });
+  const embedModel = new OpenAIEmbedding({ apiKey });
+
+  const answer = await Settings.withEmbedModel(embedModel, () =>
+    Settings.withLLM(llm, async () => {
+      const index = await VectorStoreIndex.fromDocuments([
+        new Document({ text }),
+      ]);
+      const { message } = await index.asQueryEngine().query({ query });
+      return message.content;
+    }),
+  );
+
+  res.json({ answer });
+});
+```
+
+See the [local-settings example](https://github.com/run-llama/LlamaIndexTS/tree/main/examples/local-settings) for a full working Express server.
+
 ## Local Embedding
 
 For local embeddings, you can use the [HuggingFace](/typescript/framework/modules/models/embeddings/huggingface) embedding model.

--- a/docs/src/content/docs/framework/modules/models/llms/index.mdx
+++ b/docs/src/content/docs/framework/modules/models/llms/index.mdx
@@ -19,6 +19,37 @@ import { Settings } from "llamaindex";
 Settings.llm = new OpenAI({ model: "gpt-3.5-turbo", temperature: 0 });
 ```
 
+## Per-request LLM (avoiding global state)
+
+Setting `Settings.llm` is a global mutation. In multi-tenant servers where concurrent requests each need their own API key or model, this creates race conditions. Use `Settings.withLLM` instead — it scopes the LLM to the current async context using `AsyncLocalStorage` and never touches global state.
+
+```typescript
+import { OpenAI } from "@llamaindex/openai";
+import { Settings, VectorStoreIndex, Document } from "llamaindex";
+
+// Express / Fastify / any async handler
+app.post("/query", async (req, res) => {
+  const { apiKey, query, text } = req.body;
+
+  const llm = new OpenAI({ apiKey, model: "gpt-4o" });
+
+  const answer = await Settings.withLLM(llm, async () => {
+    const index = await VectorStoreIndex.fromDocuments([
+      new Document({ text }),
+    ]);
+    const engine = index.asQueryEngine();
+    const { message } = await engine.query({ query });
+    return message.content;
+  });
+
+  res.json({ answer });
+});
+```
+
+The LLM passed to `withLLM` is active only for the duration of that async call. Concurrent requests each get their own isolated LLM without interfering with each other.
+
+See the [local-settings example](https://github.com/run-llama/LlamaIndexTS/tree/main/examples/local-settings) for a full working Express server using both `withLLM` and `withEmbedModel`.
+
 ## Azure OpenAI
 
 To use Azure OpenAI, you only need to set a few environment variables.


### PR DESCRIPTION
## Summary

Fixes #2016

`Settings.llm` and `Settings.embedModel` are global singletons. In multi-tenant API servers — for example an Express app where each request carries its own API key — mutating global state causes race conditions between concurrent requests.

LlamaIndex.TS already ships `Settings.withLLM` and `Settings.withEmbedModel` which use `AsyncLocalStorage` to scope the LLM/embedModel to a single async call tree without touching global state. These APIs exist and work correctly, but are not documented anywhere.

This PR adds sections to the LLM and Embedding index docs explaining the pattern and linking to the existing `examples/local-settings` example.

## Changes

- `docs/src/content/docs/framework/modules/models/llms/index.mdx` — add "Per-request LLM" section with `Settings.withLLM` usage
- `docs/src/content/docs/framework/modules/models/embeddings/index.mdx` — add "Per-request embedModel" section with `Settings.withEmbedModel` usage and composed example

## Before / After

**Before:** Docs only show `Settings.llm = ...` and `Settings.embedModel = ...` (global mutation). Developers hitting the race condition have no documented path forward.

**After:** Docs explain `withLLM` / `withEmbedModel` with a realistic multi-tenant server example and a link to the runnable `local-settings` example.